### PR TITLE
change func name to attach error to gin context

### DIFF
--- a/pkg/artifact/artifactfakes/fake_credentials_controller.go
+++ b/pkg/artifact/artifactfakes/fake_credentials_controller.go
@@ -11,6 +11,28 @@ import (
 )
 
 type FakeCredentialsController struct {
+	ListArtifactCredentialsNamesAndTypesStub        func() []artifact.Credentials
+	listArtifactCredentialsNamesAndTypesMutex       sync.RWMutex
+	listArtifactCredentialsNamesAndTypesArgsForCall []struct{}
+	listArtifactCredentialsNamesAndTypesReturns     struct {
+		result1 []artifact.Credentials
+	}
+	listArtifactCredentialsNamesAndTypesReturnsOnCall map[int]struct {
+		result1 []artifact.Credentials
+	}
+	HelmClientForAccountNameStub        func(string) (helm.Client, error)
+	helmClientForAccountNameMutex       sync.RWMutex
+	helmClientForAccountNameArgsForCall []struct {
+		arg1 string
+	}
+	helmClientForAccountNameReturns struct {
+		result1 helm.Client
+		result2 error
+	}
+	helmClientForAccountNameReturnsOnCall map[int]struct {
+		result1 helm.Client
+		result2 error
+	}
 	GitClientForAccountNameStub        func(string) (*github.Client, error)
 	gitClientForAccountNameMutex       sync.RWMutex
 	gitClientForAccountNameArgsForCall []struct {
@@ -22,19 +44,6 @@ type FakeCredentialsController struct {
 	}
 	gitClientForAccountNameReturnsOnCall map[int]struct {
 		result1 *github.Client
-		result2 error
-	}
-	GitRepoClientForAccountNameStub        func(string) (*http.Client, error)
-	gitRepoClientForAccountNameMutex       sync.RWMutex
-	gitRepoClientForAccountNameArgsForCall []struct {
-		arg1 string
-	}
-	gitRepoClientForAccountNameReturns struct {
-		result1 *http.Client
-		result2 error
-	}
-	gitRepoClientForAccountNameReturnsOnCall map[int]struct {
-		result1 *http.Client
 		result2 error
 	}
 	HTTPClientForAccountNameStub        func(string) (*http.Client, error)
@@ -50,31 +59,112 @@ type FakeCredentialsController struct {
 		result1 *http.Client
 		result2 error
 	}
-	HelmClientForAccountNameStub        func(string) (helm.Client, error)
-	helmClientForAccountNameMutex       sync.RWMutex
-	helmClientForAccountNameArgsForCall []struct {
+	GitRepoClientForAccountNameStub        func(string) (*http.Client, error)
+	gitRepoClientForAccountNameMutex       sync.RWMutex
+	gitRepoClientForAccountNameArgsForCall []struct {
 		arg1 string
 	}
-	helmClientForAccountNameReturns struct {
-		result1 helm.Client
+	gitRepoClientForAccountNameReturns struct {
+		result1 *http.Client
 		result2 error
 	}
-	helmClientForAccountNameReturnsOnCall map[int]struct {
-		result1 helm.Client
+	gitRepoClientForAccountNameReturnsOnCall map[int]struct {
+		result1 *http.Client
 		result2 error
-	}
-	ListArtifactCredentialsNamesAndTypesStub        func() []artifact.Credentials
-	listArtifactCredentialsNamesAndTypesMutex       sync.RWMutex
-	listArtifactCredentialsNamesAndTypesArgsForCall []struct {
-	}
-	listArtifactCredentialsNamesAndTypesReturns struct {
-		result1 []artifact.Credentials
-	}
-	listArtifactCredentialsNamesAndTypesReturnsOnCall map[int]struct {
-		result1 []artifact.Credentials
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypes() []artifact.Credentials {
+	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
+	ret, specificReturn := fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)]
+	fake.listArtifactCredentialsNamesAndTypesArgsForCall = append(fake.listArtifactCredentialsNamesAndTypesArgsForCall, struct{}{})
+	fake.recordInvocation("ListArtifactCredentialsNamesAndTypes", []interface{}{})
+	fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
+	if fake.ListArtifactCredentialsNamesAndTypesStub != nil {
+		return fake.ListArtifactCredentialsNamesAndTypesStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.listArtifactCredentialsNamesAndTypesReturns.result1
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCallCount() int {
+	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
+	return len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturns(result1 []artifact.Credentials) {
+	fake.ListArtifactCredentialsNamesAndTypesStub = nil
+	fake.listArtifactCredentialsNamesAndTypesReturns = struct {
+		result1 []artifact.Credentials
+	}{result1}
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturnsOnCall(i int, result1 []artifact.Credentials) {
+	fake.ListArtifactCredentialsNamesAndTypesStub = nil
+	if fake.listArtifactCredentialsNamesAndTypesReturnsOnCall == nil {
+		fake.listArtifactCredentialsNamesAndTypesReturnsOnCall = make(map[int]struct {
+			result1 []artifact.Credentials
+		})
+	}
+	fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[i] = struct {
+		result1 []artifact.Credentials
+	}{result1}
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountName(arg1 string) (helm.Client, error) {
+	fake.helmClientForAccountNameMutex.Lock()
+	ret, specificReturn := fake.helmClientForAccountNameReturnsOnCall[len(fake.helmClientForAccountNameArgsForCall)]
+	fake.helmClientForAccountNameArgsForCall = append(fake.helmClientForAccountNameArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("HelmClientForAccountName", []interface{}{arg1})
+	fake.helmClientForAccountNameMutex.Unlock()
+	if fake.HelmClientForAccountNameStub != nil {
+		return fake.HelmClientForAccountNameStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.helmClientForAccountNameReturns.result1, fake.helmClientForAccountNameReturns.result2
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameCallCount() int {
+	fake.helmClientForAccountNameMutex.RLock()
+	defer fake.helmClientForAccountNameMutex.RUnlock()
+	return len(fake.helmClientForAccountNameArgsForCall)
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameArgsForCall(i int) string {
+	fake.helmClientForAccountNameMutex.RLock()
+	defer fake.helmClientForAccountNameMutex.RUnlock()
+	return fake.helmClientForAccountNameArgsForCall[i].arg1
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameReturns(result1 helm.Client, result2 error) {
+	fake.HelmClientForAccountNameStub = nil
+	fake.helmClientForAccountNameReturns = struct {
+		result1 helm.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameReturnsOnCall(i int, result1 helm.Client, result2 error) {
+	fake.HelmClientForAccountNameStub = nil
+	if fake.helmClientForAccountNameReturnsOnCall == nil {
+		fake.helmClientForAccountNameReturnsOnCall = make(map[int]struct {
+			result1 helm.Client
+			result2 error
+		})
+	}
+	fake.helmClientForAccountNameReturnsOnCall[i] = struct {
+		result1 helm.Client
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountName(arg1 string) (*github.Client, error) {
@@ -91,8 +181,7 @@ func (fake *FakeCredentialsController) GitClientForAccountName(arg1 string) (*gi
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.gitClientForAccountNameReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.gitClientForAccountNameReturns.result1, fake.gitClientForAccountNameReturns.result2
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountNameCallCount() int {
@@ -101,22 +190,13 @@ func (fake *FakeCredentialsController) GitClientForAccountNameCallCount() int {
 	return len(fake.gitClientForAccountNameArgsForCall)
 }
 
-func (fake *FakeCredentialsController) GitClientForAccountNameCalls(stub func(string) (*github.Client, error)) {
-	fake.gitClientForAccountNameMutex.Lock()
-	defer fake.gitClientForAccountNameMutex.Unlock()
-	fake.GitClientForAccountNameStub = stub
-}
-
 func (fake *FakeCredentialsController) GitClientForAccountNameArgsForCall(i int) string {
 	fake.gitClientForAccountNameMutex.RLock()
 	defer fake.gitClientForAccountNameMutex.RUnlock()
-	argsForCall := fake.gitClientForAccountNameArgsForCall[i]
-	return argsForCall.arg1
+	return fake.gitClientForAccountNameArgsForCall[i].arg1
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountNameReturns(result1 *github.Client, result2 error) {
-	fake.gitClientForAccountNameMutex.Lock()
-	defer fake.gitClientForAccountNameMutex.Unlock()
 	fake.GitClientForAccountNameStub = nil
 	fake.gitClientForAccountNameReturns = struct {
 		result1 *github.Client
@@ -125,8 +205,6 @@ func (fake *FakeCredentialsController) GitClientForAccountNameReturns(result1 *g
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountNameReturnsOnCall(i int, result1 *github.Client, result2 error) {
-	fake.gitClientForAccountNameMutex.Lock()
-	defer fake.gitClientForAccountNameMutex.Unlock()
 	fake.GitClientForAccountNameStub = nil
 	if fake.gitClientForAccountNameReturnsOnCall == nil {
 		fake.gitClientForAccountNameReturnsOnCall = make(map[int]struct {
@@ -136,69 +214,6 @@ func (fake *FakeCredentialsController) GitClientForAccountNameReturnsOnCall(i in
 	}
 	fake.gitClientForAccountNameReturnsOnCall[i] = struct {
 		result1 *github.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountName(arg1 string) (*http.Client, error) {
-	fake.gitRepoClientForAccountNameMutex.Lock()
-	ret, specificReturn := fake.gitRepoClientForAccountNameReturnsOnCall[len(fake.gitRepoClientForAccountNameArgsForCall)]
-	fake.gitRepoClientForAccountNameArgsForCall = append(fake.gitRepoClientForAccountNameArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("GitRepoClientForAccountName", []interface{}{arg1})
-	fake.gitRepoClientForAccountNameMutex.Unlock()
-	if fake.GitRepoClientForAccountNameStub != nil {
-		return fake.GitRepoClientForAccountNameStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	fakeReturns := fake.gitRepoClientForAccountNameReturns
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountNameCallCount() int {
-	fake.gitRepoClientForAccountNameMutex.RLock()
-	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
-	return len(fake.gitRepoClientForAccountNameArgsForCall)
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountNameCalls(stub func(string) (*http.Client, error)) {
-	fake.gitRepoClientForAccountNameMutex.Lock()
-	defer fake.gitRepoClientForAccountNameMutex.Unlock()
-	fake.GitRepoClientForAccountNameStub = stub
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountNameArgsForCall(i int) string {
-	fake.gitRepoClientForAccountNameMutex.RLock()
-	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
-	argsForCall := fake.gitRepoClientForAccountNameArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturns(result1 *http.Client, result2 error) {
-	fake.gitRepoClientForAccountNameMutex.Lock()
-	defer fake.gitRepoClientForAccountNameMutex.Unlock()
-	fake.GitRepoClientForAccountNameStub = nil
-	fake.gitRepoClientForAccountNameReturns = struct {
-		result1 *http.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
-	fake.gitRepoClientForAccountNameMutex.Lock()
-	defer fake.gitRepoClientForAccountNameMutex.Unlock()
-	fake.GitRepoClientForAccountNameStub = nil
-	if fake.gitRepoClientForAccountNameReturnsOnCall == nil {
-		fake.gitRepoClientForAccountNameReturnsOnCall = make(map[int]struct {
-			result1 *http.Client
-			result2 error
-		})
-	}
-	fake.gitRepoClientForAccountNameReturnsOnCall[i] = struct {
-		result1 *http.Client
 		result2 error
 	}{result1, result2}
 }
@@ -217,8 +232,7 @@ func (fake *FakeCredentialsController) HTTPClientForAccountName(arg1 string) (*h
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.hTTPClientForAccountNameReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.hTTPClientForAccountNameReturns.result1, fake.hTTPClientForAccountNameReturns.result2
 }
 
 func (fake *FakeCredentialsController) HTTPClientForAccountNameCallCount() int {
@@ -227,22 +241,13 @@ func (fake *FakeCredentialsController) HTTPClientForAccountNameCallCount() int {
 	return len(fake.hTTPClientForAccountNameArgsForCall)
 }
 
-func (fake *FakeCredentialsController) HTTPClientForAccountNameCalls(stub func(string) (*http.Client, error)) {
-	fake.hTTPClientForAccountNameMutex.Lock()
-	defer fake.hTTPClientForAccountNameMutex.Unlock()
-	fake.HTTPClientForAccountNameStub = stub
-}
-
 func (fake *FakeCredentialsController) HTTPClientForAccountNameArgsForCall(i int) string {
 	fake.hTTPClientForAccountNameMutex.RLock()
 	defer fake.hTTPClientForAccountNameMutex.RUnlock()
-	argsForCall := fake.hTTPClientForAccountNameArgsForCall[i]
-	return argsForCall.arg1
+	return fake.hTTPClientForAccountNameArgsForCall[i].arg1
 }
 
 func (fake *FakeCredentialsController) HTTPClientForAccountNameReturns(result1 *http.Client, result2 error) {
-	fake.hTTPClientForAccountNameMutex.Lock()
-	defer fake.hTTPClientForAccountNameMutex.Unlock()
 	fake.HTTPClientForAccountNameStub = nil
 	fake.hTTPClientForAccountNameReturns = struct {
 		result1 *http.Client
@@ -251,8 +256,6 @@ func (fake *FakeCredentialsController) HTTPClientForAccountNameReturns(result1 *
 }
 
 func (fake *FakeCredentialsController) HTTPClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
-	fake.hTTPClientForAccountNameMutex.Lock()
-	defer fake.hTTPClientForAccountNameMutex.Unlock()
 	fake.HTTPClientForAccountNameStub = nil
 	if fake.hTTPClientForAccountNameReturnsOnCall == nil {
 		fake.hTTPClientForAccountNameReturnsOnCall = make(map[int]struct {
@@ -266,134 +269,70 @@ func (fake *FakeCredentialsController) HTTPClientForAccountNameReturnsOnCall(i i
 	}{result1, result2}
 }
 
-func (fake *FakeCredentialsController) HelmClientForAccountName(arg1 string) (helm.Client, error) {
-	fake.helmClientForAccountNameMutex.Lock()
-	ret, specificReturn := fake.helmClientForAccountNameReturnsOnCall[len(fake.helmClientForAccountNameArgsForCall)]
-	fake.helmClientForAccountNameArgsForCall = append(fake.helmClientForAccountNameArgsForCall, struct {
+func (fake *FakeCredentialsController) GitRepoClientForAccountName(arg1 string) (*http.Client, error) {
+	fake.gitRepoClientForAccountNameMutex.Lock()
+	ret, specificReturn := fake.gitRepoClientForAccountNameReturnsOnCall[len(fake.gitRepoClientForAccountNameArgsForCall)]
+	fake.gitRepoClientForAccountNameArgsForCall = append(fake.gitRepoClientForAccountNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	fake.recordInvocation("HelmClientForAccountName", []interface{}{arg1})
-	fake.helmClientForAccountNameMutex.Unlock()
-	if fake.HelmClientForAccountNameStub != nil {
-		return fake.HelmClientForAccountNameStub(arg1)
+	fake.recordInvocation("GitRepoClientForAccountName", []interface{}{arg1})
+	fake.gitRepoClientForAccountNameMutex.Unlock()
+	if fake.GitRepoClientForAccountNameStub != nil {
+		return fake.GitRepoClientForAccountNameStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.helmClientForAccountNameReturns
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.gitRepoClientForAccountNameReturns.result1, fake.gitRepoClientForAccountNameReturns.result2
 }
 
-func (fake *FakeCredentialsController) HelmClientForAccountNameCallCount() int {
-	fake.helmClientForAccountNameMutex.RLock()
-	defer fake.helmClientForAccountNameMutex.RUnlock()
-	return len(fake.helmClientForAccountNameArgsForCall)
+func (fake *FakeCredentialsController) GitRepoClientForAccountNameCallCount() int {
+	fake.gitRepoClientForAccountNameMutex.RLock()
+	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
+	return len(fake.gitRepoClientForAccountNameArgsForCall)
 }
 
-func (fake *FakeCredentialsController) HelmClientForAccountNameCalls(stub func(string) (helm.Client, error)) {
-	fake.helmClientForAccountNameMutex.Lock()
-	defer fake.helmClientForAccountNameMutex.Unlock()
-	fake.HelmClientForAccountNameStub = stub
+func (fake *FakeCredentialsController) GitRepoClientForAccountNameArgsForCall(i int) string {
+	fake.gitRepoClientForAccountNameMutex.RLock()
+	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
+	return fake.gitRepoClientForAccountNameArgsForCall[i].arg1
 }
 
-func (fake *FakeCredentialsController) HelmClientForAccountNameArgsForCall(i int) string {
-	fake.helmClientForAccountNameMutex.RLock()
-	defer fake.helmClientForAccountNameMutex.RUnlock()
-	argsForCall := fake.helmClientForAccountNameArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountNameReturns(result1 helm.Client, result2 error) {
-	fake.helmClientForAccountNameMutex.Lock()
-	defer fake.helmClientForAccountNameMutex.Unlock()
-	fake.HelmClientForAccountNameStub = nil
-	fake.helmClientForAccountNameReturns = struct {
-		result1 helm.Client
+func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturns(result1 *http.Client, result2 error) {
+	fake.GitRepoClientForAccountNameStub = nil
+	fake.gitRepoClientForAccountNameReturns = struct {
+		result1 *http.Client
 		result2 error
 	}{result1, result2}
 }
 
-func (fake *FakeCredentialsController) HelmClientForAccountNameReturnsOnCall(i int, result1 helm.Client, result2 error) {
-	fake.helmClientForAccountNameMutex.Lock()
-	defer fake.helmClientForAccountNameMutex.Unlock()
-	fake.HelmClientForAccountNameStub = nil
-	if fake.helmClientForAccountNameReturnsOnCall == nil {
-		fake.helmClientForAccountNameReturnsOnCall = make(map[int]struct {
-			result1 helm.Client
+func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
+	fake.GitRepoClientForAccountNameStub = nil
+	if fake.gitRepoClientForAccountNameReturnsOnCall == nil {
+		fake.gitRepoClientForAccountNameReturnsOnCall = make(map[int]struct {
+			result1 *http.Client
 			result2 error
 		})
 	}
-	fake.helmClientForAccountNameReturnsOnCall[i] = struct {
-		result1 helm.Client
+	fake.gitRepoClientForAccountNameReturnsOnCall[i] = struct {
+		result1 *http.Client
 		result2 error
 	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypes() []artifact.Credentials {
-	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
-	ret, specificReturn := fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)]
-	fake.listArtifactCredentialsNamesAndTypesArgsForCall = append(fake.listArtifactCredentialsNamesAndTypesArgsForCall, struct {
-	}{})
-	fake.recordInvocation("ListArtifactCredentialsNamesAndTypes", []interface{}{})
-	fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
-	if fake.ListArtifactCredentialsNamesAndTypesStub != nil {
-		return fake.ListArtifactCredentialsNamesAndTypesStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.listArtifactCredentialsNamesAndTypesReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCallCount() int {
-	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
-	return len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCalls(stub func() []artifact.Credentials) {
-	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
-	fake.ListArtifactCredentialsNamesAndTypesStub = stub
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturns(result1 []artifact.Credentials) {
-	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
-	fake.ListArtifactCredentialsNamesAndTypesStub = nil
-	fake.listArtifactCredentialsNamesAndTypesReturns = struct {
-		result1 []artifact.Credentials
-	}{result1}
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturnsOnCall(i int, result1 []artifact.Credentials) {
-	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
-	fake.ListArtifactCredentialsNamesAndTypesStub = nil
-	if fake.listArtifactCredentialsNamesAndTypesReturnsOnCall == nil {
-		fake.listArtifactCredentialsNamesAndTypesReturnsOnCall = make(map[int]struct {
-			result1 []artifact.Credentials
-		})
-	}
-	fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[i] = struct {
-		result1 []artifact.Credentials
-	}{result1}
 }
 
 func (fake *FakeCredentialsController) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.gitClientForAccountNameMutex.RLock()
-	defer fake.gitClientForAccountNameMutex.RUnlock()
-	fake.gitRepoClientForAccountNameMutex.RLock()
-	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
-	fake.hTTPClientForAccountNameMutex.RLock()
-	defer fake.hTTPClientForAccountNameMutex.RUnlock()
-	fake.helmClientForAccountNameMutex.RLock()
-	defer fake.helmClientForAccountNameMutex.RUnlock()
 	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
 	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
+	fake.helmClientForAccountNameMutex.RLock()
+	defer fake.helmClientForAccountNameMutex.RUnlock()
+	fake.gitClientForAccountNameMutex.RLock()
+	defer fake.gitClientForAccountNameMutex.RUnlock()
+	fake.hTTPClientForAccountNameMutex.RLock()
+	defer fake.hTTPClientForAccountNameMutex.RUnlock()
+	fake.gitRepoClientForAccountNameMutex.RLock()
+	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -6,7 +6,8 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type Error struct {
+// This represents a clouddriver error.
+type ErrorResponse struct {
 	Error     string `json:"error"`
 	Message   string `json:"message"`
 	Status    int    `json:"status"`
@@ -20,16 +21,17 @@ type Error struct {
 //   "status":403,
 //   "timestamp":1597608027851
 // }
-func NewError(e, m string, s int) Error {
-	return Error{
-		Error:     e,
-		Message:   m,
-		Status:    s,
+func NewError(err, message string, status int) ErrorResponse {
+	return ErrorResponse{
+		Error:     err,
+		Message:   message,
+		Status:    status,
 		Timestamp: time.Now().UnixNano() / 1000000,
 	}
 }
 
-func WriteError(c *gin.Context, status int, err error) {
+// Error attaches a given Go error to a gin context and sets its type to public.
+func Error(c *gin.Context, status int, err error) {
 	c.Status(status)
 	c.Error(err).SetType(gin.ErrorTypePublic)
 }

--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -45,7 +45,7 @@ func ListApplications(c *gin.Context) {
 
 	rs, err := sc.ListKubernetesResourcesByFields("account_name", "kind", "name", "spinnaker_app")
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -166,7 +166,7 @@ func ListServerGroupManagers(c *gin.Context) {
 
 	accounts, err := sc.ListKubernetesAccountsBySpinnakerApp(application)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -371,7 +371,7 @@ func ListLoadBalancers(c *gin.Context) {
 
 	accounts, err := sc.ListKubernetesAccountsBySpinnakerApp(application)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -509,7 +509,7 @@ func ListClusters(c *gin.Context) {
 
 	rs, err := sc.ListKubernetesClustersByApplication(application)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -633,7 +633,7 @@ func ListServerGroups(c *gin.Context) {
 
 	accounts, err := sc.ListKubernetesAccountsBySpinnakerApp(application)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -937,19 +937,19 @@ func GetServerGroup(c *gin.Context) {
 
 	provider, err := sc.GetKubernetesProvider(account)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	token, err := ac.Token()
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -963,7 +963,7 @@ func GetServerGroup(c *gin.Context) {
 
 	client, err := kc.NewClient(config)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -974,14 +974,14 @@ func GetServerGroup(c *gin.Context) {
 
 	result, err := client.Get(kind, name, location)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	// "Instances" in kubernetes are pods.
 	pods, err := client.ListResource("pods", lo)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1144,19 +1144,19 @@ func GetJob(c *gin.Context) {
 
 	provider, err := sc.GetKubernetesProvider(account)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	token, err := ac.Token()
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -1170,13 +1170,13 @@ func GetJob(c *gin.Context) {
 
 	client, err := kc.NewClient(config)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	result, err := client.Get(kind, name, location)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/pkg/http/core/core_test.go
+++ b/pkg/http/core/core_test.go
@@ -217,8 +217,8 @@ func validateGZipResponse(expected []byte) {
 	Expect(actual).To(Equal(expected), "correct body")
 }
 
-func getClouddriverError() clouddriver.Error {
-	ce := clouddriver.Error{}
+func getClouddriverError() clouddriver.ErrorResponse {
+	ce := clouddriver.ErrorResponse{}
 	b, _ := ioutil.ReadAll(res.Body)
 	json.Unmarshal(b, &ce)
 	return ce

--- a/pkg/http/core/credentials.go
+++ b/pkg/http/core/credentials.go
@@ -68,7 +68,7 @@ func ListCredentials(c *gin.Context) {
 
 	providers, err := sc.ListKubernetesProvidersAndPermissions()
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -197,19 +197,19 @@ func GetAccountCredentials(c *gin.Context) {
 
 	provider, err := sc.GetKubernetesProvider(account)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	readGroups, err := sc.ListReadGroupsByAccountName(provider.Name)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	writeGroups, err := sc.ListWriteGroupsByAccountName(provider.Name)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 

--- a/pkg/http/core/manifest.go
+++ b/pkg/http/core/manifest.go
@@ -45,19 +45,19 @@ func GetManifest(c *gin.Context) {
 
 	provider, err := sc.GetKubernetesProvider(account)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	token, err := ac.Token()
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -71,13 +71,13 @@ func GetManifest(c *gin.Context) {
 
 	client, err := kc.NewClient(config)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	result, err := client.Get(kind, name, namespace)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -128,19 +128,19 @@ func GetManifestByTarget(c *gin.Context) {
 
 	provider, err := sc.GetKubernetesProvider(account)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	token, err := ac.Token()
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -154,13 +154,13 @@ func GetManifestByTarget(c *gin.Context) {
 
 	client, err := kc.NewClient(config)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	gvr, err := client.GVRForKind(kind)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -177,14 +177,14 @@ func GetManifestByTarget(c *gin.Context) {
 
 	list, err := client.ListByGVR(gvr, lo)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	// Filter out all unassociated objects based on the moniker.spinnaker.io/cluster annotation.
 	items := filterOnCluster(list.Items, cluster)
 	if len(items) == 0 {
-		clouddriver.WriteError(c, http.StatusNotFound, errors.New("no resources found for cluster "+cluster))
+		clouddriver.Error(c, http.StatusNotFound, errors.New("no resources found for cluster "+cluster))
 		return
 	}
 
@@ -202,18 +202,18 @@ func GetManifestByTarget(c *gin.Context) {
 		result = items[0]
 	case "second_newest":
 		if len(items) < 2 {
-			clouddriver.WriteError(c, http.StatusBadRequest, errors.New("requested target \"Second Newest\" for cluster "+cluster+", but only one resource was found"))
+			clouddriver.Error(c, http.StatusBadRequest, errors.New("requested target \"Second Newest\" for cluster "+cluster+", but only one resource was found"))
 			return
 		}
 		result = items[1]
 	case "oldest":
 		if len(items) < 2 {
-			clouddriver.WriteError(c, http.StatusBadRequest, errors.New("requested target \"Oldest\" for cluster "+cluster+", but only one resource was found"))
+			clouddriver.Error(c, http.StatusBadRequest, errors.New("requested target \"Oldest\" for cluster "+cluster+", but only one resource was found"))
 			return
 		}
 		result = items[len(items)-1]
 	default:
-		clouddriver.WriteError(c, http.StatusNotImplemented, errors.New("requested target \""+target+"\" for cluster "+cluster+" is not supported"))
+		clouddriver.Error(c, http.StatusNotImplemented, errors.New("requested target \""+target+"\" for cluster "+cluster+" is not supported"))
 		return
 	}
 

--- a/pkg/http/core/ops.go
+++ b/pkg/http/core/ops.go
@@ -33,7 +33,7 @@ func CreateKubernetesOperation(c *gin.Context) {
 
 	err := c.ShouldBindJSON(&ko)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusBadRequest, err)
+		clouddriver.Error(c, http.StatusBadRequest, err)
 		return
 	}
 
@@ -62,7 +62,7 @@ func CreateKubernetesOperation(c *gin.Context) {
 		if req.DeployManifest != nil {
 			err = ah.NewDeployManifestAction(config).Run()
 			if err != nil {
-				clouddriver.WriteError(c, http.StatusInternalServerError, err)
+				clouddriver.Error(c, http.StatusInternalServerError, err)
 				return
 			}
 		}
@@ -70,7 +70,7 @@ func CreateKubernetesOperation(c *gin.Context) {
 		if req.DeleteManifest != nil {
 			err = ah.NewDeleteManifestAction(config).Run()
 			if err != nil {
-				clouddriver.WriteError(c, http.StatusInternalServerError, err)
+				clouddriver.Error(c, http.StatusInternalServerError, err)
 				return
 			}
 		}
@@ -78,7 +78,7 @@ func CreateKubernetesOperation(c *gin.Context) {
 		if req.ScaleManifest != nil {
 			err = ah.NewScaleManifestAction(config).Run()
 			if err != nil {
-				clouddriver.WriteError(c, http.StatusInternalServerError, err)
+				clouddriver.Error(c, http.StatusInternalServerError, err)
 				return
 			}
 		}
@@ -86,7 +86,7 @@ func CreateKubernetesOperation(c *gin.Context) {
 		if req.CleanupArtifacts != nil {
 			err = ah.NewCleanupArtifactsAction(config).Run()
 			if err != nil {
-				clouddriver.WriteError(c, http.StatusInternalServerError, err)
+				clouddriver.Error(c, http.StatusInternalServerError, err)
 				return
 			}
 		}
@@ -94,7 +94,7 @@ func CreateKubernetesOperation(c *gin.Context) {
 		if req.RollingRestartManifest != nil {
 			err = ah.NewRollingRestartAction(config).Run()
 			if err != nil {
-				clouddriver.WriteError(c, http.StatusInternalServerError, err)
+				clouddriver.Error(c, http.StatusInternalServerError, err)
 				return
 			}
 		}
@@ -102,7 +102,7 @@ func CreateKubernetesOperation(c *gin.Context) {
 		if req.RunJob != nil {
 			err = ah.NewRunJobAction(config).Run()
 			if err != nil {
-				clouddriver.WriteError(c, http.StatusInternalServerError, err)
+				clouddriver.Error(c, http.StatusInternalServerError, err)
 				return
 			}
 		}
@@ -110,7 +110,7 @@ func CreateKubernetesOperation(c *gin.Context) {
 		if req.UndoRolloutManifest != nil {
 			err = ah.NewRollbackAction(config).Run()
 			if err != nil {
-				clouddriver.WriteError(c, http.StatusInternalServerError, err)
+				clouddriver.Error(c, http.StatusInternalServerError, err)
 				return
 			}
 		}
@@ -118,7 +118,7 @@ func CreateKubernetesOperation(c *gin.Context) {
 		if req.PatchManifest != nil {
 			err = ah.NewPatchManifestAction(config).Run()
 			if err != nil {
-				clouddriver.WriteError(c, http.StatusInternalServerError, err)
+				clouddriver.Error(c, http.StatusInternalServerError, err)
 				return
 			}
 		}

--- a/pkg/http/core/search.go
+++ b/pkg/http/core/search.go
@@ -49,7 +49,7 @@ func Search(c *gin.Context) {
 	accounts := strings.Split(c.GetHeader("X-Spinnaker-Accounts"), ",")
 
 	if kind == "" || namespace == "" {
-		clouddriver.WriteError(c, http.StatusBadRequest,
+		clouddriver.Error(c, http.StatusBadRequest,
 			errors.New("must provide query params 'q' to specify the namespace and 'type' to specify the kind"))
 		return
 	}

--- a/pkg/http/core/task.go
+++ b/pkg/http/core/task.go
@@ -25,7 +25,7 @@ func GetTask(c *gin.Context) {
 
 	resources, err := sc.ListKubernetesResourcesByTaskID(id)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusBadRequest, err)
+		clouddriver.Error(c, http.StatusBadRequest, err)
 		return
 	}
 
@@ -40,19 +40,19 @@ func GetTask(c *gin.Context) {
 
 	provider, err := sc.GetKubernetesProvider(accountName)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
 	token, err := ac.Token()
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -66,7 +66,7 @@ func GetTask(c *gin.Context) {
 
 	client, err := kc.NewClient(config)
 	if err != nil {
-		clouddriver.WriteError(c, http.StatusInternalServerError, err)
+		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
 
@@ -79,7 +79,7 @@ func GetTask(c *gin.Context) {
 
 		result, err := client.Get(r.Resource, r.Name, r.Namespace)
 		if err != nil {
-			clouddriver.WriteError(c, http.StatusInternalServerError, err)
+			clouddriver.Error(c, http.StatusInternalServerError, err)
 			return
 		}
 

--- a/pkg/middleware/auth.go
+++ b/pkg/middleware/auth.go
@@ -31,7 +31,7 @@ func AuthApplication(permissions ...string) gin.HandlerFunc {
 		fiatClient := fiat.Instance(c)
 		authResp, err := fiatClient.Authorize(user)
 		if err != nil {
-			clouddriver.WriteError(c, http.StatusUnauthorized, err)
+			clouddriver.Error(c, http.StatusUnauthorized, err)
 			return
 		}
 
@@ -41,7 +41,7 @@ func AuthApplication(permissions ...string) gin.HandlerFunc {
 				for _, p := range permissions {
 					found := find(auth.Authorizations, p)
 					if !found {
-						clouddriver.WriteError(c, http.StatusForbidden, fmt.Errorf("Access denied to application %s - required authorization: %s", app, p))
+						clouddriver.Error(c, http.StatusForbidden, fmt.Errorf("Access denied to application %s - required authorization: %s", app, p))
 						return
 					}
 				}
@@ -64,7 +64,7 @@ func AuthAccount(permissions ...string) gin.HandlerFunc {
 
 		authResp, err := fiatClient.Authorize(user)
 		if err != nil {
-			clouddriver.WriteError(c, http.StatusUnauthorized, err)
+			clouddriver.Error(c, http.StatusUnauthorized, err)
 			return
 		}
 
@@ -75,7 +75,7 @@ func AuthAccount(permissions ...string) gin.HandlerFunc {
 				for _, p := range permissions {
 					found := find(auth.Authorizations, p)
 					if !found {
-						clouddriver.WriteError(c, http.StatusForbidden, fmt.Errorf("Access denied to account %s - required authorization: %s", account, p))
+						clouddriver.Error(c, http.StatusForbidden, fmt.Errorf("Access denied to account %s - required authorization: %s", account, p))
 						return
 					}
 				}
@@ -105,7 +105,7 @@ func PostFilterAuthorizedApplications(permissions ...string) gin.HandlerFunc {
 		fiatClient := fiat.Instance(c)
 		authResp, err := fiatClient.Authorize(user)
 		if err != nil {
-			clouddriver.WriteError(c, http.StatusUnauthorized, err)
+			clouddriver.Error(c, http.StatusUnauthorized, err)
 			return
 		}
 		authorizedApps := authResp.Applications


### PR DESCRIPTION
- changes the func name from `WriteError` to `Error` since we aren't really writing anything, but instead attaching an error to the gin context