### PR TITLE
fix timeout when listing resources

### DIFF
--- a/pkg/arcade/arcadefakes/fake_client.go
+++ b/pkg/arcade/arcadefakes/fake_client.go
@@ -10,9 +10,8 @@ import (
 type FakeClient struct {
 	TokenStub        func() (string, error)
 	tokenMutex       sync.RWMutex
-	tokenArgsForCall []struct {
-	}
-	tokenReturns struct {
+	tokenArgsForCall []struct{}
+	tokenReturns     struct {
 		result1 string
 		result2 error
 	}
@@ -32,19 +31,16 @@ type FakeClient struct {
 func (fake *FakeClient) Token() (string, error) {
 	fake.tokenMutex.Lock()
 	ret, specificReturn := fake.tokenReturnsOnCall[len(fake.tokenArgsForCall)]
-	fake.tokenArgsForCall = append(fake.tokenArgsForCall, struct {
-	}{})
-	stub := fake.TokenStub
-	fakeReturns := fake.tokenReturns
+	fake.tokenArgsForCall = append(fake.tokenArgsForCall, struct{}{})
 	fake.recordInvocation("Token", []interface{}{})
 	fake.tokenMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.TokenStub != nil {
+		return fake.TokenStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.tokenReturns.result1, fake.tokenReturns.result2
 }
 
 func (fake *FakeClient) TokenCallCount() int {
@@ -53,15 +49,7 @@ func (fake *FakeClient) TokenCallCount() int {
 	return len(fake.tokenArgsForCall)
 }
 
-func (fake *FakeClient) TokenCalls(stub func() (string, error)) {
-	fake.tokenMutex.Lock()
-	defer fake.tokenMutex.Unlock()
-	fake.TokenStub = stub
-}
-
 func (fake *FakeClient) TokenReturns(result1 string, result2 error) {
-	fake.tokenMutex.Lock()
-	defer fake.tokenMutex.Unlock()
 	fake.TokenStub = nil
 	fake.tokenReturns = struct {
 		result1 string
@@ -70,8 +58,6 @@ func (fake *FakeClient) TokenReturns(result1 string, result2 error) {
 }
 
 func (fake *FakeClient) TokenReturnsOnCall(i int, result1 string, result2 error) {
-	fake.tokenMutex.Lock()
-	defer fake.tokenMutex.Unlock()
 	fake.TokenStub = nil
 	if fake.tokenReturnsOnCall == nil {
 		fake.tokenReturnsOnCall = make(map[int]struct {
@@ -90,10 +76,9 @@ func (fake *FakeClient) WithAPIKey(arg1 string) {
 	fake.withAPIKeyArgsForCall = append(fake.withAPIKeyArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.WithAPIKeyStub
 	fake.recordInvocation("WithAPIKey", []interface{}{arg1})
 	fake.withAPIKeyMutex.Unlock()
-	if stub != nil {
+	if fake.WithAPIKeyStub != nil {
 		fake.WithAPIKeyStub(arg1)
 	}
 }
@@ -104,17 +89,10 @@ func (fake *FakeClient) WithAPIKeyCallCount() int {
 	return len(fake.withAPIKeyArgsForCall)
 }
 
-func (fake *FakeClient) WithAPIKeyCalls(stub func(string)) {
-	fake.withAPIKeyMutex.Lock()
-	defer fake.withAPIKeyMutex.Unlock()
-	fake.WithAPIKeyStub = stub
-}
-
 func (fake *FakeClient) WithAPIKeyArgsForCall(i int) string {
 	fake.withAPIKeyMutex.RLock()
 	defer fake.withAPIKeyMutex.RUnlock()
-	argsForCall := fake.withAPIKeyArgsForCall[i]
-	return argsForCall.arg1
+	return fake.withAPIKeyArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) Invocations() map[string][][]interface{} {

--- a/pkg/artifact/artifactfakes/fake_credentials_controller.go
+++ b/pkg/artifact/artifactfakes/fake_credentials_controller.go
@@ -11,6 +11,28 @@ import (
 )
 
 type FakeCredentialsController struct {
+	ListArtifactCredentialsNamesAndTypesStub        func() []artifact.Credentials
+	listArtifactCredentialsNamesAndTypesMutex       sync.RWMutex
+	listArtifactCredentialsNamesAndTypesArgsForCall []struct{}
+	listArtifactCredentialsNamesAndTypesReturns     struct {
+		result1 []artifact.Credentials
+	}
+	listArtifactCredentialsNamesAndTypesReturnsOnCall map[int]struct {
+		result1 []artifact.Credentials
+	}
+	HelmClientForAccountNameStub        func(string) (helm.Client, error)
+	helmClientForAccountNameMutex       sync.RWMutex
+	helmClientForAccountNameArgsForCall []struct {
+		arg1 string
+	}
+	helmClientForAccountNameReturns struct {
+		result1 helm.Client
+		result2 error
+	}
+	helmClientForAccountNameReturnsOnCall map[int]struct {
+		result1 helm.Client
+		result2 error
+	}
 	GitClientForAccountNameStub        func(string) (*github.Client, error)
 	gitClientForAccountNameMutex       sync.RWMutex
 	gitClientForAccountNameArgsForCall []struct {
@@ -22,19 +44,6 @@ type FakeCredentialsController struct {
 	}
 	gitClientForAccountNameReturnsOnCall map[int]struct {
 		result1 *github.Client
-		result2 error
-	}
-	GitRepoClientForAccountNameStub        func(string) (*http.Client, error)
-	gitRepoClientForAccountNameMutex       sync.RWMutex
-	gitRepoClientForAccountNameArgsForCall []struct {
-		arg1 string
-	}
-	gitRepoClientForAccountNameReturns struct {
-		result1 *http.Client
-		result2 error
-	}
-	gitRepoClientForAccountNameReturnsOnCall map[int]struct {
-		result1 *http.Client
 		result2 error
 	}
 	HTTPClientForAccountNameStub        func(string) (*http.Client, error)
@@ -50,223 +59,61 @@ type FakeCredentialsController struct {
 		result1 *http.Client
 		result2 error
 	}
-	HelmClientForAccountNameStub        func(string) (helm.Client, error)
-	helmClientForAccountNameMutex       sync.RWMutex
-	helmClientForAccountNameArgsForCall []struct {
+	GitRepoClientForAccountNameStub        func(string) (*http.Client, error)
+	gitRepoClientForAccountNameMutex       sync.RWMutex
+	gitRepoClientForAccountNameArgsForCall []struct {
 		arg1 string
 	}
-	helmClientForAccountNameReturns struct {
-		result1 helm.Client
+	gitRepoClientForAccountNameReturns struct {
+		result1 *http.Client
 		result2 error
 	}
-	helmClientForAccountNameReturnsOnCall map[int]struct {
-		result1 helm.Client
+	gitRepoClientForAccountNameReturnsOnCall map[int]struct {
+		result1 *http.Client
 		result2 error
-	}
-	ListArtifactCredentialsNamesAndTypesStub        func() []artifact.Credentials
-	listArtifactCredentialsNamesAndTypesMutex       sync.RWMutex
-	listArtifactCredentialsNamesAndTypesArgsForCall []struct {
-	}
-	listArtifactCredentialsNamesAndTypesReturns struct {
-		result1 []artifact.Credentials
-	}
-	listArtifactCredentialsNamesAndTypesReturnsOnCall map[int]struct {
-		result1 []artifact.Credentials
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCredentialsController) GitClientForAccountName(arg1 string) (*github.Client, error) {
-	fake.gitClientForAccountNameMutex.Lock()
-	ret, specificReturn := fake.gitClientForAccountNameReturnsOnCall[len(fake.gitClientForAccountNameArgsForCall)]
-	fake.gitClientForAccountNameArgsForCall = append(fake.gitClientForAccountNameArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	stub := fake.GitClientForAccountNameStub
-	fakeReturns := fake.gitClientForAccountNameReturns
-	fake.recordInvocation("GitClientForAccountName", []interface{}{arg1})
-	fake.gitClientForAccountNameMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypes() []artifact.Credentials {
+	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
+	ret, specificReturn := fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)]
+	fake.listArtifactCredentialsNamesAndTypesArgsForCall = append(fake.listArtifactCredentialsNamesAndTypesArgsForCall, struct{}{})
+	fake.recordInvocation("ListArtifactCredentialsNamesAndTypes", []interface{}{})
+	fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
+	if fake.ListArtifactCredentialsNamesAndTypesStub != nil {
+		return fake.ListArtifactCredentialsNamesAndTypesStub()
 	}
 	if specificReturn {
-		return ret.result1, ret.result2
+		return ret.result1
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listArtifactCredentialsNamesAndTypesReturns.result1
 }
 
-func (fake *FakeCredentialsController) GitClientForAccountNameCallCount() int {
-	fake.gitClientForAccountNameMutex.RLock()
-	defer fake.gitClientForAccountNameMutex.RUnlock()
-	return len(fake.gitClientForAccountNameArgsForCall)
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCallCount() int {
+	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
+	return len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)
 }
 
-func (fake *FakeCredentialsController) GitClientForAccountNameCalls(stub func(string) (*github.Client, error)) {
-	fake.gitClientForAccountNameMutex.Lock()
-	defer fake.gitClientForAccountNameMutex.Unlock()
-	fake.GitClientForAccountNameStub = stub
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturns(result1 []artifact.Credentials) {
+	fake.ListArtifactCredentialsNamesAndTypesStub = nil
+	fake.listArtifactCredentialsNamesAndTypesReturns = struct {
+		result1 []artifact.Credentials
+	}{result1}
 }
 
-func (fake *FakeCredentialsController) GitClientForAccountNameArgsForCall(i int) string {
-	fake.gitClientForAccountNameMutex.RLock()
-	defer fake.gitClientForAccountNameMutex.RUnlock()
-	argsForCall := fake.gitClientForAccountNameArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeCredentialsController) GitClientForAccountNameReturns(result1 *github.Client, result2 error) {
-	fake.gitClientForAccountNameMutex.Lock()
-	defer fake.gitClientForAccountNameMutex.Unlock()
-	fake.GitClientForAccountNameStub = nil
-	fake.gitClientForAccountNameReturns = struct {
-		result1 *github.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) GitClientForAccountNameReturnsOnCall(i int, result1 *github.Client, result2 error) {
-	fake.gitClientForAccountNameMutex.Lock()
-	defer fake.gitClientForAccountNameMutex.Unlock()
-	fake.GitClientForAccountNameStub = nil
-	if fake.gitClientForAccountNameReturnsOnCall == nil {
-		fake.gitClientForAccountNameReturnsOnCall = make(map[int]struct {
-			result1 *github.Client
-			result2 error
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturnsOnCall(i int, result1 []artifact.Credentials) {
+	fake.ListArtifactCredentialsNamesAndTypesStub = nil
+	if fake.listArtifactCredentialsNamesAndTypesReturnsOnCall == nil {
+		fake.listArtifactCredentialsNamesAndTypesReturnsOnCall = make(map[int]struct {
+			result1 []artifact.Credentials
 		})
 	}
-	fake.gitClientForAccountNameReturnsOnCall[i] = struct {
-		result1 *github.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountName(arg1 string) (*http.Client, error) {
-	fake.gitRepoClientForAccountNameMutex.Lock()
-	ret, specificReturn := fake.gitRepoClientForAccountNameReturnsOnCall[len(fake.gitRepoClientForAccountNameArgsForCall)]
-	fake.gitRepoClientForAccountNameArgsForCall = append(fake.gitRepoClientForAccountNameArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	stub := fake.GitRepoClientForAccountNameStub
-	fakeReturns := fake.gitRepoClientForAccountNameReturns
-	fake.recordInvocation("GitRepoClientForAccountName", []interface{}{arg1})
-	fake.gitRepoClientForAccountNameMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountNameCallCount() int {
-	fake.gitRepoClientForAccountNameMutex.RLock()
-	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
-	return len(fake.gitRepoClientForAccountNameArgsForCall)
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountNameCalls(stub func(string) (*http.Client, error)) {
-	fake.gitRepoClientForAccountNameMutex.Lock()
-	defer fake.gitRepoClientForAccountNameMutex.Unlock()
-	fake.GitRepoClientForAccountNameStub = stub
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountNameArgsForCall(i int) string {
-	fake.gitRepoClientForAccountNameMutex.RLock()
-	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
-	argsForCall := fake.gitRepoClientForAccountNameArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturns(result1 *http.Client, result2 error) {
-	fake.gitRepoClientForAccountNameMutex.Lock()
-	defer fake.gitRepoClientForAccountNameMutex.Unlock()
-	fake.GitRepoClientForAccountNameStub = nil
-	fake.gitRepoClientForAccountNameReturns = struct {
-		result1 *http.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
-	fake.gitRepoClientForAccountNameMutex.Lock()
-	defer fake.gitRepoClientForAccountNameMutex.Unlock()
-	fake.GitRepoClientForAccountNameStub = nil
-	if fake.gitRepoClientForAccountNameReturnsOnCall == nil {
-		fake.gitRepoClientForAccountNameReturnsOnCall = make(map[int]struct {
-			result1 *http.Client
-			result2 error
-		})
-	}
-	fake.gitRepoClientForAccountNameReturnsOnCall[i] = struct {
-		result1 *http.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountName(arg1 string) (*http.Client, error) {
-	fake.hTTPClientForAccountNameMutex.Lock()
-	ret, specificReturn := fake.hTTPClientForAccountNameReturnsOnCall[len(fake.hTTPClientForAccountNameArgsForCall)]
-	fake.hTTPClientForAccountNameArgsForCall = append(fake.hTTPClientForAccountNameArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	stub := fake.HTTPClientForAccountNameStub
-	fakeReturns := fake.hTTPClientForAccountNameReturns
-	fake.recordInvocation("HTTPClientForAccountName", []interface{}{arg1})
-	fake.hTTPClientForAccountNameMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountNameCallCount() int {
-	fake.hTTPClientForAccountNameMutex.RLock()
-	defer fake.hTTPClientForAccountNameMutex.RUnlock()
-	return len(fake.hTTPClientForAccountNameArgsForCall)
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountNameCalls(stub func(string) (*http.Client, error)) {
-	fake.hTTPClientForAccountNameMutex.Lock()
-	defer fake.hTTPClientForAccountNameMutex.Unlock()
-	fake.HTTPClientForAccountNameStub = stub
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountNameArgsForCall(i int) string {
-	fake.hTTPClientForAccountNameMutex.RLock()
-	defer fake.hTTPClientForAccountNameMutex.RUnlock()
-	argsForCall := fake.hTTPClientForAccountNameArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountNameReturns(result1 *http.Client, result2 error) {
-	fake.hTTPClientForAccountNameMutex.Lock()
-	defer fake.hTTPClientForAccountNameMutex.Unlock()
-	fake.HTTPClientForAccountNameStub = nil
-	fake.hTTPClientForAccountNameReturns = struct {
-		result1 *http.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
-	fake.hTTPClientForAccountNameMutex.Lock()
-	defer fake.hTTPClientForAccountNameMutex.Unlock()
-	fake.HTTPClientForAccountNameStub = nil
-	if fake.hTTPClientForAccountNameReturnsOnCall == nil {
-		fake.hTTPClientForAccountNameReturnsOnCall = make(map[int]struct {
-			result1 *http.Client
-			result2 error
-		})
-	}
-	fake.hTTPClientForAccountNameReturnsOnCall[i] = struct {
-		result1 *http.Client
-		result2 error
-	}{result1, result2}
+	fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[i] = struct {
+		result1 []artifact.Credentials
+	}{result1}
 }
 
 func (fake *FakeCredentialsController) HelmClientForAccountName(arg1 string) (helm.Client, error) {
@@ -275,17 +122,15 @@ func (fake *FakeCredentialsController) HelmClientForAccountName(arg1 string) (he
 	fake.helmClientForAccountNameArgsForCall = append(fake.helmClientForAccountNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.HelmClientForAccountNameStub
-	fakeReturns := fake.helmClientForAccountNameReturns
 	fake.recordInvocation("HelmClientForAccountName", []interface{}{arg1})
 	fake.helmClientForAccountNameMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.HelmClientForAccountNameStub != nil {
+		return fake.HelmClientForAccountNameStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.helmClientForAccountNameReturns.result1, fake.helmClientForAccountNameReturns.result2
 }
 
 func (fake *FakeCredentialsController) HelmClientForAccountNameCallCount() int {
@@ -294,22 +139,13 @@ func (fake *FakeCredentialsController) HelmClientForAccountNameCallCount() int {
 	return len(fake.helmClientForAccountNameArgsForCall)
 }
 
-func (fake *FakeCredentialsController) HelmClientForAccountNameCalls(stub func(string) (helm.Client, error)) {
-	fake.helmClientForAccountNameMutex.Lock()
-	defer fake.helmClientForAccountNameMutex.Unlock()
-	fake.HelmClientForAccountNameStub = stub
-}
-
 func (fake *FakeCredentialsController) HelmClientForAccountNameArgsForCall(i int) string {
 	fake.helmClientForAccountNameMutex.RLock()
 	defer fake.helmClientForAccountNameMutex.RUnlock()
-	argsForCall := fake.helmClientForAccountNameArgsForCall[i]
-	return argsForCall.arg1
+	return fake.helmClientForAccountNameArgsForCall[i].arg1
 }
 
 func (fake *FakeCredentialsController) HelmClientForAccountNameReturns(result1 helm.Client, result2 error) {
-	fake.helmClientForAccountNameMutex.Lock()
-	defer fake.helmClientForAccountNameMutex.Unlock()
 	fake.HelmClientForAccountNameStub = nil
 	fake.helmClientForAccountNameReturns = struct {
 		result1 helm.Client
@@ -318,8 +154,6 @@ func (fake *FakeCredentialsController) HelmClientForAccountNameReturns(result1 h
 }
 
 func (fake *FakeCredentialsController) HelmClientForAccountNameReturnsOnCall(i int, result1 helm.Client, result2 error) {
-	fake.helmClientForAccountNameMutex.Lock()
-	defer fake.helmClientForAccountNameMutex.Unlock()
 	fake.HelmClientForAccountNameStub = nil
 	if fake.helmClientForAccountNameReturnsOnCall == nil {
 		fake.helmClientForAccountNameReturnsOnCall = make(map[int]struct {
@@ -333,72 +167,172 @@ func (fake *FakeCredentialsController) HelmClientForAccountNameReturnsOnCall(i i
 	}{result1, result2}
 }
 
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypes() []artifact.Credentials {
-	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
-	ret, specificReturn := fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)]
-	fake.listArtifactCredentialsNamesAndTypesArgsForCall = append(fake.listArtifactCredentialsNamesAndTypesArgsForCall, struct {
-	}{})
-	stub := fake.ListArtifactCredentialsNamesAndTypesStub
-	fakeReturns := fake.listArtifactCredentialsNamesAndTypesReturns
-	fake.recordInvocation("ListArtifactCredentialsNamesAndTypes", []interface{}{})
-	fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
-	if stub != nil {
-		return stub()
+func (fake *FakeCredentialsController) GitClientForAccountName(arg1 string) (*github.Client, error) {
+	fake.gitClientForAccountNameMutex.Lock()
+	ret, specificReturn := fake.gitClientForAccountNameReturnsOnCall[len(fake.gitClientForAccountNameArgsForCall)]
+	fake.gitClientForAccountNameArgsForCall = append(fake.gitClientForAccountNameArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GitClientForAccountName", []interface{}{arg1})
+	fake.gitClientForAccountNameMutex.Unlock()
+	if fake.GitClientForAccountNameStub != nil {
+		return fake.GitClientForAccountNameStub(arg1)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1
+	return fake.gitClientForAccountNameReturns.result1, fake.gitClientForAccountNameReturns.result2
 }
 
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCallCount() int {
-	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
-	return len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)
+func (fake *FakeCredentialsController) GitClientForAccountNameCallCount() int {
+	fake.gitClientForAccountNameMutex.RLock()
+	defer fake.gitClientForAccountNameMutex.RUnlock()
+	return len(fake.gitClientForAccountNameArgsForCall)
 }
 
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCalls(stub func() []artifact.Credentials) {
-	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
-	fake.ListArtifactCredentialsNamesAndTypesStub = stub
+func (fake *FakeCredentialsController) GitClientForAccountNameArgsForCall(i int) string {
+	fake.gitClientForAccountNameMutex.RLock()
+	defer fake.gitClientForAccountNameMutex.RUnlock()
+	return fake.gitClientForAccountNameArgsForCall[i].arg1
 }
 
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturns(result1 []artifact.Credentials) {
-	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
-	fake.ListArtifactCredentialsNamesAndTypesStub = nil
-	fake.listArtifactCredentialsNamesAndTypesReturns = struct {
-		result1 []artifact.Credentials
-	}{result1}
+func (fake *FakeCredentialsController) GitClientForAccountNameReturns(result1 *github.Client, result2 error) {
+	fake.GitClientForAccountNameStub = nil
+	fake.gitClientForAccountNameReturns = struct {
+		result1 *github.Client
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturnsOnCall(i int, result1 []artifact.Credentials) {
-	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
-	fake.ListArtifactCredentialsNamesAndTypesStub = nil
-	if fake.listArtifactCredentialsNamesAndTypesReturnsOnCall == nil {
-		fake.listArtifactCredentialsNamesAndTypesReturnsOnCall = make(map[int]struct {
-			result1 []artifact.Credentials
+func (fake *FakeCredentialsController) GitClientForAccountNameReturnsOnCall(i int, result1 *github.Client, result2 error) {
+	fake.GitClientForAccountNameStub = nil
+	if fake.gitClientForAccountNameReturnsOnCall == nil {
+		fake.gitClientForAccountNameReturnsOnCall = make(map[int]struct {
+			result1 *github.Client
+			result2 error
 		})
 	}
-	fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[i] = struct {
-		result1 []artifact.Credentials
-	}{result1}
+	fake.gitClientForAccountNameReturnsOnCall[i] = struct {
+		result1 *github.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) HTTPClientForAccountName(arg1 string) (*http.Client, error) {
+	fake.hTTPClientForAccountNameMutex.Lock()
+	ret, specificReturn := fake.hTTPClientForAccountNameReturnsOnCall[len(fake.hTTPClientForAccountNameArgsForCall)]
+	fake.hTTPClientForAccountNameArgsForCall = append(fake.hTTPClientForAccountNameArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("HTTPClientForAccountName", []interface{}{arg1})
+	fake.hTTPClientForAccountNameMutex.Unlock()
+	if fake.HTTPClientForAccountNameStub != nil {
+		return fake.HTTPClientForAccountNameStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.hTTPClientForAccountNameReturns.result1, fake.hTTPClientForAccountNameReturns.result2
+}
+
+func (fake *FakeCredentialsController) HTTPClientForAccountNameCallCount() int {
+	fake.hTTPClientForAccountNameMutex.RLock()
+	defer fake.hTTPClientForAccountNameMutex.RUnlock()
+	return len(fake.hTTPClientForAccountNameArgsForCall)
+}
+
+func (fake *FakeCredentialsController) HTTPClientForAccountNameArgsForCall(i int) string {
+	fake.hTTPClientForAccountNameMutex.RLock()
+	defer fake.hTTPClientForAccountNameMutex.RUnlock()
+	return fake.hTTPClientForAccountNameArgsForCall[i].arg1
+}
+
+func (fake *FakeCredentialsController) HTTPClientForAccountNameReturns(result1 *http.Client, result2 error) {
+	fake.HTTPClientForAccountNameStub = nil
+	fake.hTTPClientForAccountNameReturns = struct {
+		result1 *http.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) HTTPClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
+	fake.HTTPClientForAccountNameStub = nil
+	if fake.hTTPClientForAccountNameReturnsOnCall == nil {
+		fake.hTTPClientForAccountNameReturnsOnCall = make(map[int]struct {
+			result1 *http.Client
+			result2 error
+		})
+	}
+	fake.hTTPClientForAccountNameReturnsOnCall[i] = struct {
+		result1 *http.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) GitRepoClientForAccountName(arg1 string) (*http.Client, error) {
+	fake.gitRepoClientForAccountNameMutex.Lock()
+	ret, specificReturn := fake.gitRepoClientForAccountNameReturnsOnCall[len(fake.gitRepoClientForAccountNameArgsForCall)]
+	fake.gitRepoClientForAccountNameArgsForCall = append(fake.gitRepoClientForAccountNameArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GitRepoClientForAccountName", []interface{}{arg1})
+	fake.gitRepoClientForAccountNameMutex.Unlock()
+	if fake.GitRepoClientForAccountNameStub != nil {
+		return fake.GitRepoClientForAccountNameStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.gitRepoClientForAccountNameReturns.result1, fake.gitRepoClientForAccountNameReturns.result2
+}
+
+func (fake *FakeCredentialsController) GitRepoClientForAccountNameCallCount() int {
+	fake.gitRepoClientForAccountNameMutex.RLock()
+	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
+	return len(fake.gitRepoClientForAccountNameArgsForCall)
+}
+
+func (fake *FakeCredentialsController) GitRepoClientForAccountNameArgsForCall(i int) string {
+	fake.gitRepoClientForAccountNameMutex.RLock()
+	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
+	return fake.gitRepoClientForAccountNameArgsForCall[i].arg1
+}
+
+func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturns(result1 *http.Client, result2 error) {
+	fake.GitRepoClientForAccountNameStub = nil
+	fake.gitRepoClientForAccountNameReturns = struct {
+		result1 *http.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
+	fake.GitRepoClientForAccountNameStub = nil
+	if fake.gitRepoClientForAccountNameReturnsOnCall == nil {
+		fake.gitRepoClientForAccountNameReturnsOnCall = make(map[int]struct {
+			result1 *http.Client
+			result2 error
+		})
+	}
+	fake.gitRepoClientForAccountNameReturnsOnCall[i] = struct {
+		result1 *http.Client
+		result2 error
+	}{result1, result2}
 }
 
 func (fake *FakeCredentialsController) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.gitClientForAccountNameMutex.RLock()
-	defer fake.gitClientForAccountNameMutex.RUnlock()
-	fake.gitRepoClientForAccountNameMutex.RLock()
-	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
-	fake.hTTPClientForAccountNameMutex.RLock()
-	defer fake.hTTPClientForAccountNameMutex.RUnlock()
-	fake.helmClientForAccountNameMutex.RLock()
-	defer fake.helmClientForAccountNameMutex.RUnlock()
 	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
 	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
+	fake.helmClientForAccountNameMutex.RLock()
+	defer fake.helmClientForAccountNameMutex.RUnlock()
+	fake.gitClientForAccountNameMutex.RLock()
+	defer fake.gitClientForAccountNameMutex.RUnlock()
+	fake.hTTPClientForAccountNameMutex.RLock()
+	defer fake.hTTPClientForAccountNameMutex.RUnlock()
+	fake.gitRepoClientForAccountNameMutex.RLock()
+	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/fiat/fiatfakes/fake_client.go
+++ b/pkg/fiat/fiatfakes/fake_client.go
@@ -8,10 +8,10 @@ import (
 )
 
 type FakeClient struct {
-	AuthorizeStub        func(string) (fiat.Response, error)
+	AuthorizeStub        func(account string) (fiat.Response, error)
 	authorizeMutex       sync.RWMutex
 	authorizeArgsForCall []struct {
-		arg1 string
+		account string
 	}
 	authorizeReturns struct {
 		result1 fiat.Response
@@ -25,23 +25,21 @@ type FakeClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClient) Authorize(arg1 string) (fiat.Response, error) {
+func (fake *FakeClient) Authorize(account string) (fiat.Response, error) {
 	fake.authorizeMutex.Lock()
 	ret, specificReturn := fake.authorizeReturnsOnCall[len(fake.authorizeArgsForCall)]
 	fake.authorizeArgsForCall = append(fake.authorizeArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	stub := fake.AuthorizeStub
-	fakeReturns := fake.authorizeReturns
-	fake.recordInvocation("Authorize", []interface{}{arg1})
+		account string
+	}{account})
+	fake.recordInvocation("Authorize", []interface{}{account})
 	fake.authorizeMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.AuthorizeStub != nil {
+		return fake.AuthorizeStub(account)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.authorizeReturns.result1, fake.authorizeReturns.result2
 }
 
 func (fake *FakeClient) AuthorizeCallCount() int {
@@ -50,22 +48,13 @@ func (fake *FakeClient) AuthorizeCallCount() int {
 	return len(fake.authorizeArgsForCall)
 }
 
-func (fake *FakeClient) AuthorizeCalls(stub func(string) (fiat.Response, error)) {
-	fake.authorizeMutex.Lock()
-	defer fake.authorizeMutex.Unlock()
-	fake.AuthorizeStub = stub
-}
-
 func (fake *FakeClient) AuthorizeArgsForCall(i int) string {
 	fake.authorizeMutex.RLock()
 	defer fake.authorizeMutex.RUnlock()
-	argsForCall := fake.authorizeArgsForCall[i]
-	return argsForCall.arg1
+	return fake.authorizeArgsForCall[i].account
 }
 
 func (fake *FakeClient) AuthorizeReturns(result1 fiat.Response, result2 error) {
-	fake.authorizeMutex.Lock()
-	defer fake.authorizeMutex.Unlock()
 	fake.AuthorizeStub = nil
 	fake.authorizeReturns = struct {
 		result1 fiat.Response
@@ -74,8 +63,6 @@ func (fake *FakeClient) AuthorizeReturns(result1 fiat.Response, result2 error) {
 }
 
 func (fake *FakeClient) AuthorizeReturnsOnCall(i int, result1 fiat.Response, result2 error) {
-	fake.authorizeMutex.Lock()
-	defer fake.authorizeMutex.Unlock()
 	fake.AuthorizeStub = nil
 	if fake.authorizeReturnsOnCall == nil {
 		fake.authorizeReturnsOnCall = make(map[int]struct {

--- a/pkg/helm/helmfakes/fake_client.go
+++ b/pkg/helm/helmfakes/fake_client.go
@@ -8,6 +8,17 @@ import (
 )
 
 type FakeClient struct {
+	GetIndexStub        func() (helm.Index, error)
+	getIndexMutex       sync.RWMutex
+	getIndexArgsForCall []struct{}
+	getIndexReturns     struct {
+		result1 helm.Index
+		result2 error
+	}
+	getIndexReturnsOnCall map[int]struct {
+		result1 helm.Index
+		result2 error
+	}
 	GetChartStub        func(string, string) ([]byte, error)
 	getChartMutex       sync.RWMutex
 	getChartArgsForCall []struct {
@@ -22,103 +33,23 @@ type FakeClient struct {
 		result1 []byte
 		result2 error
 	}
-	GetIndexStub        func() (helm.Index, error)
-	getIndexMutex       sync.RWMutex
-	getIndexArgsForCall []struct {
-	}
-	getIndexReturns struct {
-		result1 helm.Index
-		result2 error
-	}
-	getIndexReturnsOnCall map[int]struct {
-		result1 helm.Index
-		result2 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeClient) GetChart(arg1 string, arg2 string) ([]byte, error) {
-	fake.getChartMutex.Lock()
-	ret, specificReturn := fake.getChartReturnsOnCall[len(fake.getChartArgsForCall)]
-	fake.getChartArgsForCall = append(fake.getChartArgsForCall, struct {
-		arg1 string
-		arg2 string
-	}{arg1, arg2})
-	stub := fake.GetChartStub
-	fakeReturns := fake.getChartReturns
-	fake.recordInvocation("GetChart", []interface{}{arg1, arg2})
-	fake.getChartMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeClient) GetChartCallCount() int {
-	fake.getChartMutex.RLock()
-	defer fake.getChartMutex.RUnlock()
-	return len(fake.getChartArgsForCall)
-}
-
-func (fake *FakeClient) GetChartCalls(stub func(string, string) ([]byte, error)) {
-	fake.getChartMutex.Lock()
-	defer fake.getChartMutex.Unlock()
-	fake.GetChartStub = stub
-}
-
-func (fake *FakeClient) GetChartArgsForCall(i int) (string, string) {
-	fake.getChartMutex.RLock()
-	defer fake.getChartMutex.RUnlock()
-	argsForCall := fake.getChartArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeClient) GetChartReturns(result1 []byte, result2 error) {
-	fake.getChartMutex.Lock()
-	defer fake.getChartMutex.Unlock()
-	fake.GetChartStub = nil
-	fake.getChartReturns = struct {
-		result1 []byte
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) GetChartReturnsOnCall(i int, result1 []byte, result2 error) {
-	fake.getChartMutex.Lock()
-	defer fake.getChartMutex.Unlock()
-	fake.GetChartStub = nil
-	if fake.getChartReturnsOnCall == nil {
-		fake.getChartReturnsOnCall = make(map[int]struct {
-			result1 []byte
-			result2 error
-		})
-	}
-	fake.getChartReturnsOnCall[i] = struct {
-		result1 []byte
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *FakeClient) GetIndex() (helm.Index, error) {
 	fake.getIndexMutex.Lock()
 	ret, specificReturn := fake.getIndexReturnsOnCall[len(fake.getIndexArgsForCall)]
-	fake.getIndexArgsForCall = append(fake.getIndexArgsForCall, struct {
-	}{})
-	stub := fake.GetIndexStub
-	fakeReturns := fake.getIndexReturns
+	fake.getIndexArgsForCall = append(fake.getIndexArgsForCall, struct{}{})
 	fake.recordInvocation("GetIndex", []interface{}{})
 	fake.getIndexMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.GetIndexStub != nil {
+		return fake.GetIndexStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.getIndexReturns.result1, fake.getIndexReturns.result2
 }
 
 func (fake *FakeClient) GetIndexCallCount() int {
@@ -127,15 +58,7 @@ func (fake *FakeClient) GetIndexCallCount() int {
 	return len(fake.getIndexArgsForCall)
 }
 
-func (fake *FakeClient) GetIndexCalls(stub func() (helm.Index, error)) {
-	fake.getIndexMutex.Lock()
-	defer fake.getIndexMutex.Unlock()
-	fake.GetIndexStub = stub
-}
-
 func (fake *FakeClient) GetIndexReturns(result1 helm.Index, result2 error) {
-	fake.getIndexMutex.Lock()
-	defer fake.getIndexMutex.Unlock()
 	fake.GetIndexStub = nil
 	fake.getIndexReturns = struct {
 		result1 helm.Index
@@ -144,8 +67,6 @@ func (fake *FakeClient) GetIndexReturns(result1 helm.Index, result2 error) {
 }
 
 func (fake *FakeClient) GetIndexReturnsOnCall(i int, result1 helm.Index, result2 error) {
-	fake.getIndexMutex.Lock()
-	defer fake.getIndexMutex.Unlock()
 	fake.GetIndexStub = nil
 	if fake.getIndexReturnsOnCall == nil {
 		fake.getIndexReturnsOnCall = make(map[int]struct {
@@ -159,13 +80,65 @@ func (fake *FakeClient) GetIndexReturnsOnCall(i int, result1 helm.Index, result2
 	}{result1, result2}
 }
 
+func (fake *FakeClient) GetChart(arg1 string, arg2 string) ([]byte, error) {
+	fake.getChartMutex.Lock()
+	ret, specificReturn := fake.getChartReturnsOnCall[len(fake.getChartArgsForCall)]
+	fake.getChartArgsForCall = append(fake.getChartArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("GetChart", []interface{}{arg1, arg2})
+	fake.getChartMutex.Unlock()
+	if fake.GetChartStub != nil {
+		return fake.GetChartStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.getChartReturns.result1, fake.getChartReturns.result2
+}
+
+func (fake *FakeClient) GetChartCallCount() int {
+	fake.getChartMutex.RLock()
+	defer fake.getChartMutex.RUnlock()
+	return len(fake.getChartArgsForCall)
+}
+
+func (fake *FakeClient) GetChartArgsForCall(i int) (string, string) {
+	fake.getChartMutex.RLock()
+	defer fake.getChartMutex.RUnlock()
+	return fake.getChartArgsForCall[i].arg1, fake.getChartArgsForCall[i].arg2
+}
+
+func (fake *FakeClient) GetChartReturns(result1 []byte, result2 error) {
+	fake.GetChartStub = nil
+	fake.getChartReturns = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetChartReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.GetChartStub = nil
+	if fake.getChartReturnsOnCall == nil {
+		fake.getChartReturnsOnCall = make(map[int]struct {
+			result1 []byte
+			result2 error
+		})
+	}
+	fake.getChartReturnsOnCall[i] = struct {
+		result1 []byte
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getChartMutex.RLock()
-	defer fake.getChartMutex.RUnlock()
 	fake.getIndexMutex.RLock()
 	defer fake.getIndexMutex.RUnlock()
+	fake.getChartMutex.RLock()
+	defer fake.getChartMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/http/core/core_test.go
+++ b/pkg/http/core/core_test.go
@@ -84,6 +84,28 @@ func setup() {
 			},
 		},
 	}, nil)
+	fakeKubeClient.ListByGVRWithContextReturns(&unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
+						},
+					},
+				},
+			},
+			{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
+						},
+					},
+				},
+			},
+		},
+	}, nil)
 	fakeKubeClient.ListResourceReturns(&unstructured.UnstructuredList{
 		Items: []unstructured.Unstructured{
 			{

--- a/pkg/http/core/credentials_test.go
+++ b/pkg/http/core/credentials_test.go
@@ -118,7 +118,7 @@ var _ = Describe("Credential", func() {
 						},
 					},
 				}, nil)
-				fakeKubeClient.ListByGVRReturns(&unstructured.UnstructuredList{
+				fakeKubeClient.ListByGVRWithContextReturns(&unstructured.UnstructuredList{
 					Items: []unstructured.Unstructured{
 						{
 							Object: map[string]interface{}{
@@ -227,12 +227,12 @@ var _ = Describe("Credential", func() {
 
 			When("listing namespaces returns an error", func() {
 				BeforeEach(func() {
-					fakeKubeClient.ListByGVRReturns(nil, errors.New("error listing"))
+					fakeKubeClient.ListByGVRWithContextReturns(nil, errors.New("error listing"))
 				})
 
 				It("continues", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusOK))
-					Expect(fakeKubeClient.ListByGVRCallCount()).To(Equal(2))
+					Expect(fakeKubeClient.ListByGVRWithContextCallCount()).To(Equal(2))
 					validateResponse(payloadCredentialsExpandTrueNoNamespaces)
 				})
 			})

--- a/pkg/http/core/payload_test.go
+++ b/pkg/http/core/payload_test.go
@@ -731,7 +731,7 @@ const payloadCredentialsExpandTrueNoNamespaces = `[
                 "enabled": false,
                 "environment": "provider1",
                 "name": "provider1",
-                "namespaces": null,
+                "namespaces": [],
                 "permissions": {
                   "READ": [
                     "gg_test"
@@ -789,7 +789,7 @@ const payloadCredentialsExpandTrueNoNamespaces = `[
                 "enabled": false,
                 "environment": "provider2",
                 "name": "provider2",
-                "namespaces": null,
+                "namespaces": [],
                 "permissions": {
                   "READ": [
                     "gg_test2"

--- a/pkg/kubernetes/cached/disk/diskfakes/fake_cache_round_tripper.go
+++ b/pkg/kubernetes/cached/disk/diskfakes/fake_cache_round_tripper.go
@@ -9,15 +9,10 @@ import (
 )
 
 type FakeCacheRoundTripper struct {
-	CancelRequestStub        func(*http.Request)
-	cancelRequestMutex       sync.RWMutex
-	cancelRequestArgsForCall []struct {
-		arg1 *http.Request
-	}
-	RoundTripStub        func(*http.Request) (*http.Response, error)
+	RoundTripStub        func(req *http.Request) (*http.Response, error)
 	roundTripMutex       sync.RWMutex
 	roundTripArgsForCall []struct {
-		arg1 *http.Request
+		req *http.Request
 	}
 	roundTripReturns struct {
 		result1 *http.Response
@@ -27,59 +22,30 @@ type FakeCacheRoundTripper struct {
 		result1 *http.Response
 		result2 error
 	}
+	CancelRequestStub        func(req *http.Request)
+	cancelRequestMutex       sync.RWMutex
+	cancelRequestArgsForCall []struct {
+		req *http.Request
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCacheRoundTripper) CancelRequest(arg1 *http.Request) {
-	fake.cancelRequestMutex.Lock()
-	fake.cancelRequestArgsForCall = append(fake.cancelRequestArgsForCall, struct {
-		arg1 *http.Request
-	}{arg1})
-	stub := fake.CancelRequestStub
-	fake.recordInvocation("CancelRequest", []interface{}{arg1})
-	fake.cancelRequestMutex.Unlock()
-	if stub != nil {
-		fake.CancelRequestStub(arg1)
-	}
-}
-
-func (fake *FakeCacheRoundTripper) CancelRequestCallCount() int {
-	fake.cancelRequestMutex.RLock()
-	defer fake.cancelRequestMutex.RUnlock()
-	return len(fake.cancelRequestArgsForCall)
-}
-
-func (fake *FakeCacheRoundTripper) CancelRequestCalls(stub func(*http.Request)) {
-	fake.cancelRequestMutex.Lock()
-	defer fake.cancelRequestMutex.Unlock()
-	fake.CancelRequestStub = stub
-}
-
-func (fake *FakeCacheRoundTripper) CancelRequestArgsForCall(i int) *http.Request {
-	fake.cancelRequestMutex.RLock()
-	defer fake.cancelRequestMutex.RUnlock()
-	argsForCall := fake.cancelRequestArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeCacheRoundTripper) RoundTrip(arg1 *http.Request) (*http.Response, error) {
+func (fake *FakeCacheRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 	fake.roundTripMutex.Lock()
 	ret, specificReturn := fake.roundTripReturnsOnCall[len(fake.roundTripArgsForCall)]
 	fake.roundTripArgsForCall = append(fake.roundTripArgsForCall, struct {
-		arg1 *http.Request
-	}{arg1})
-	stub := fake.RoundTripStub
-	fakeReturns := fake.roundTripReturns
-	fake.recordInvocation("RoundTrip", []interface{}{arg1})
+		req *http.Request
+	}{req})
+	fake.recordInvocation("RoundTrip", []interface{}{req})
 	fake.roundTripMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.RoundTripStub != nil {
+		return fake.RoundTripStub(req)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.roundTripReturns.result1, fake.roundTripReturns.result2
 }
 
 func (fake *FakeCacheRoundTripper) RoundTripCallCount() int {
@@ -88,22 +54,13 @@ func (fake *FakeCacheRoundTripper) RoundTripCallCount() int {
 	return len(fake.roundTripArgsForCall)
 }
 
-func (fake *FakeCacheRoundTripper) RoundTripCalls(stub func(*http.Request) (*http.Response, error)) {
-	fake.roundTripMutex.Lock()
-	defer fake.roundTripMutex.Unlock()
-	fake.RoundTripStub = stub
-}
-
 func (fake *FakeCacheRoundTripper) RoundTripArgsForCall(i int) *http.Request {
 	fake.roundTripMutex.RLock()
 	defer fake.roundTripMutex.RUnlock()
-	argsForCall := fake.roundTripArgsForCall[i]
-	return argsForCall.arg1
+	return fake.roundTripArgsForCall[i].req
 }
 
 func (fake *FakeCacheRoundTripper) RoundTripReturns(result1 *http.Response, result2 error) {
-	fake.roundTripMutex.Lock()
-	defer fake.roundTripMutex.Unlock()
 	fake.RoundTripStub = nil
 	fake.roundTripReturns = struct {
 		result1 *http.Response
@@ -112,8 +69,6 @@ func (fake *FakeCacheRoundTripper) RoundTripReturns(result1 *http.Response, resu
 }
 
 func (fake *FakeCacheRoundTripper) RoundTripReturnsOnCall(i int, result1 *http.Response, result2 error) {
-	fake.roundTripMutex.Lock()
-	defer fake.roundTripMutex.Unlock()
 	fake.RoundTripStub = nil
 	if fake.roundTripReturnsOnCall == nil {
 		fake.roundTripReturnsOnCall = make(map[int]struct {
@@ -127,13 +82,37 @@ func (fake *FakeCacheRoundTripper) RoundTripReturnsOnCall(i int, result1 *http.R
 	}{result1, result2}
 }
 
+func (fake *FakeCacheRoundTripper) CancelRequest(req *http.Request) {
+	fake.cancelRequestMutex.Lock()
+	fake.cancelRequestArgsForCall = append(fake.cancelRequestArgsForCall, struct {
+		req *http.Request
+	}{req})
+	fake.recordInvocation("CancelRequest", []interface{}{req})
+	fake.cancelRequestMutex.Unlock()
+	if fake.CancelRequestStub != nil {
+		fake.CancelRequestStub(req)
+	}
+}
+
+func (fake *FakeCacheRoundTripper) CancelRequestCallCount() int {
+	fake.cancelRequestMutex.RLock()
+	defer fake.cancelRequestMutex.RUnlock()
+	return len(fake.cancelRequestArgsForCall)
+}
+
+func (fake *FakeCacheRoundTripper) CancelRequestArgsForCall(i int) *http.Request {
+	fake.cancelRequestMutex.RLock()
+	defer fake.cancelRequestMutex.RUnlock()
+	return fake.cancelRequestArgsForCall[i].req
+}
+
 func (fake *FakeCacheRoundTripper) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.cancelRequestMutex.RLock()
-	defer fake.cancelRequestMutex.RUnlock()
 	fake.roundTripMutex.RLock()
 	defer fake.roundTripMutex.RUnlock()
+	fake.cancelRequestMutex.RLock()
+	defer fake.cancelRequestMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -39,6 +39,7 @@ type Client interface {
 	GVRForKind(string) (schema.GroupVersionResource, error)
 	Get(string, string, string) (*unstructured.Unstructured, error)
 	ListByGVR(schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	ListByGVRWithContext(context.Context, schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
 	ListResource(string, metav1.ListOptions) (*unstructured.UnstructuredList, error)
 	Patch(string, string, string, []byte) (Metadata, *unstructured.Unstructured, error)
 	PatchUsingStrategy(string, string, string, []byte, types.PatchType) (Metadata, *unstructured.Unstructured, error)
@@ -230,6 +231,11 @@ func (c *client) GVRForKind(kind string) (schema.GroupVersionResource, error) {
 // List all resources by their GVR and list options.
 func (c *client) ListByGVR(gvr schema.GroupVersionResource, lo metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	return c.c.Resource(gvr).List(context.TODO(), lo)
+}
+
+// List all resources by their GVR and list options with context,
+func (c *client) ListByGVRWithContext(ctx context.Context, gvr schema.GroupVersionResource, lo metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	return c.c.Resource(gvr).List(ctx, lo)
 }
 
 // List all resources by their kind or resource (e.g. "replicaset" or "replicasets")

--- a/pkg/kubernetes/kubernetesfakes/fake_client.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_client.go
@@ -2,10 +2,11 @@
 package kubernetesfakes
 
 import (
+	"context"
 	"sync"
 
 	"github.com/homedepot/go-clouddriver/pkg/kubernetes"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -39,13 +40,13 @@ type FakeClient struct {
 		result1 kubernetes.Metadata
 		result2 error
 	}
-	DeleteResourceByKindAndNameAndNamespaceStub        func(string, string, string, v1.DeleteOptions) error
+	DeleteResourceByKindAndNameAndNamespaceStub        func(string, string, string, metav1.DeleteOptions) error
 	deleteResourceByKindAndNameAndNamespaceMutex       sync.RWMutex
 	deleteResourceByKindAndNameAndNamespaceArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
-		arg4 v1.DeleteOptions
+		arg4 metav1.DeleteOptions
 	}
 	deleteResourceByKindAndNameAndNamespaceReturns struct {
 		result1 error
@@ -81,11 +82,11 @@ type FakeClient struct {
 		result1 *unstructured.Unstructured
 		result2 error
 	}
-	ListByGVRStub        func(schema.GroupVersionResource, v1.ListOptions) (*unstructured.UnstructuredList, error)
+	ListByGVRStub        func(schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
 	listByGVRMutex       sync.RWMutex
 	listByGVRArgsForCall []struct {
 		arg1 schema.GroupVersionResource
-		arg2 v1.ListOptions
+		arg2 metav1.ListOptions
 	}
 	listByGVRReturns struct {
 		result1 *unstructured.UnstructuredList
@@ -95,11 +96,26 @@ type FakeClient struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
 	}
-	ListResourceStub        func(string, v1.ListOptions) (*unstructured.UnstructuredList, error)
+	ListByGVRWithContextStub        func(context.Context, schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	listByGVRWithContextMutex       sync.RWMutex
+	listByGVRWithContextArgsForCall []struct {
+		arg1 context.Context
+		arg2 schema.GroupVersionResource
+		arg3 metav1.ListOptions
+	}
+	listByGVRWithContextReturns struct {
+		result1 *unstructured.UnstructuredList
+		result2 error
+	}
+	listByGVRWithContextReturnsOnCall map[int]struct {
+		result1 *unstructured.UnstructuredList
+		result2 error
+	}
+	ListResourceStub        func(string, metav1.ListOptions) (*unstructured.UnstructuredList, error)
 	listResourceMutex       sync.RWMutex
 	listResourceArgsForCall []struct {
 		arg1 string
-		arg2 v1.ListOptions
+		arg2 metav1.ListOptions
 	}
 	listResourceReturns struct {
 		result1 *unstructured.UnstructuredList
@@ -156,17 +172,15 @@ func (fake *FakeClient) Apply(arg1 *unstructured.Unstructured) (kubernetes.Metad
 	fake.applyArgsForCall = append(fake.applyArgsForCall, struct {
 		arg1 *unstructured.Unstructured
 	}{arg1})
-	stub := fake.ApplyStub
-	fakeReturns := fake.applyReturns
 	fake.recordInvocation("Apply", []interface{}{arg1})
 	fake.applyMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ApplyStub != nil {
+		return fake.ApplyStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.applyReturns.result1, fake.applyReturns.result2
 }
 
 func (fake *FakeClient) ApplyCallCount() int {
@@ -175,22 +189,13 @@ func (fake *FakeClient) ApplyCallCount() int {
 	return len(fake.applyArgsForCall)
 }
 
-func (fake *FakeClient) ApplyCalls(stub func(*unstructured.Unstructured) (kubernetes.Metadata, error)) {
-	fake.applyMutex.Lock()
-	defer fake.applyMutex.Unlock()
-	fake.ApplyStub = stub
-}
-
 func (fake *FakeClient) ApplyArgsForCall(i int) *unstructured.Unstructured {
 	fake.applyMutex.RLock()
 	defer fake.applyMutex.RUnlock()
-	argsForCall := fake.applyArgsForCall[i]
-	return argsForCall.arg1
+	return fake.applyArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) ApplyReturns(result1 kubernetes.Metadata, result2 error) {
-	fake.applyMutex.Lock()
-	defer fake.applyMutex.Unlock()
 	fake.ApplyStub = nil
 	fake.applyReturns = struct {
 		result1 kubernetes.Metadata
@@ -199,8 +204,6 @@ func (fake *FakeClient) ApplyReturns(result1 kubernetes.Metadata, result2 error)
 }
 
 func (fake *FakeClient) ApplyReturnsOnCall(i int, result1 kubernetes.Metadata, result2 error) {
-	fake.applyMutex.Lock()
-	defer fake.applyMutex.Unlock()
 	fake.ApplyStub = nil
 	if fake.applyReturnsOnCall == nil {
 		fake.applyReturnsOnCall = make(map[int]struct {
@@ -221,17 +224,15 @@ func (fake *FakeClient) ApplyWithNamespaceOverride(arg1 *unstructured.Unstructur
 		arg1 *unstructured.Unstructured
 		arg2 string
 	}{arg1, arg2})
-	stub := fake.ApplyWithNamespaceOverrideStub
-	fakeReturns := fake.applyWithNamespaceOverrideReturns
 	fake.recordInvocation("ApplyWithNamespaceOverride", []interface{}{arg1, arg2})
 	fake.applyWithNamespaceOverrideMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
+	if fake.ApplyWithNamespaceOverrideStub != nil {
+		return fake.ApplyWithNamespaceOverrideStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.applyWithNamespaceOverrideReturns.result1, fake.applyWithNamespaceOverrideReturns.result2
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideCallCount() int {
@@ -240,22 +241,13 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideCallCount() int {
 	return len(fake.applyWithNamespaceOverrideArgsForCall)
 }
 
-func (fake *FakeClient) ApplyWithNamespaceOverrideCalls(stub func(*unstructured.Unstructured, string) (kubernetes.Metadata, error)) {
-	fake.applyWithNamespaceOverrideMutex.Lock()
-	defer fake.applyWithNamespaceOverrideMutex.Unlock()
-	fake.ApplyWithNamespaceOverrideStub = stub
-}
-
 func (fake *FakeClient) ApplyWithNamespaceOverrideArgsForCall(i int) (*unstructured.Unstructured, string) {
 	fake.applyWithNamespaceOverrideMutex.RLock()
 	defer fake.applyWithNamespaceOverrideMutex.RUnlock()
-	argsForCall := fake.applyWithNamespaceOverrideArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return fake.applyWithNamespaceOverrideArgsForCall[i].arg1, fake.applyWithNamespaceOverrideArgsForCall[i].arg2
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideReturns(result1 kubernetes.Metadata, result2 error) {
-	fake.applyWithNamespaceOverrideMutex.Lock()
-	defer fake.applyWithNamespaceOverrideMutex.Unlock()
 	fake.ApplyWithNamespaceOverrideStub = nil
 	fake.applyWithNamespaceOverrideReturns = struct {
 		result1 kubernetes.Metadata
@@ -264,8 +256,6 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideReturns(result1 kubernetes.Met
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideReturnsOnCall(i int, result1 kubernetes.Metadata, result2 error) {
-	fake.applyWithNamespaceOverrideMutex.Lock()
-	defer fake.applyWithNamespaceOverrideMutex.Unlock()
 	fake.ApplyWithNamespaceOverrideStub = nil
 	if fake.applyWithNamespaceOverrideReturnsOnCall == nil {
 		fake.applyWithNamespaceOverrideReturnsOnCall = make(map[int]struct {
@@ -279,26 +269,24 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideReturnsOnCall(i int, result1 k
 	}{result1, result2}
 }
 
-func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg2 string, arg3 string, arg4 v1.DeleteOptions) error {
+func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg2 string, arg3 string, arg4 metav1.DeleteOptions) error {
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
 	ret, specificReturn := fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall[len(fake.deleteResourceByKindAndNameAndNamespaceArgsForCall)]
 	fake.deleteResourceByKindAndNameAndNamespaceArgsForCall = append(fake.deleteResourceByKindAndNameAndNamespaceArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-		arg4 v1.DeleteOptions
+		arg4 metav1.DeleteOptions
 	}{arg1, arg2, arg3, arg4})
-	stub := fake.DeleteResourceByKindAndNameAndNamespaceStub
-	fakeReturns := fake.deleteResourceByKindAndNameAndNamespaceReturns
 	fake.recordInvocation("DeleteResourceByKindAndNameAndNamespace", []interface{}{arg1, arg2, arg3, arg4})
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+	if fake.DeleteResourceByKindAndNameAndNamespaceStub != nil {
+		return fake.DeleteResourceByKindAndNameAndNamespaceStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fakeReturns.result1
+	return fake.deleteResourceByKindAndNameAndNamespaceReturns.result1
 }
 
 func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceCallCount() int {
@@ -307,22 +295,13 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceCallCount() int {
 	return len(fake.deleteResourceByKindAndNameAndNamespaceArgsForCall)
 }
 
-func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceCalls(stub func(string, string, string, v1.DeleteOptions) error) {
-	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
-	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
-	fake.DeleteResourceByKindAndNameAndNamespaceStub = stub
-}
-
-func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceArgsForCall(i int) (string, string, string, v1.DeleteOptions) {
+func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceArgsForCall(i int) (string, string, string, metav1.DeleteOptions) {
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.RLock()
 	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.RUnlock()
-	argsForCall := fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg1, fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg2, fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg3, fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg4
 }
 
 func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceReturns(result1 error) {
-	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
-	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
 	fake.DeleteResourceByKindAndNameAndNamespaceStub = nil
 	fake.deleteResourceByKindAndNameAndNamespaceReturns = struct {
 		result1 error
@@ -330,8 +309,6 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceReturns(result1 e
 }
 
 func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceReturnsOnCall(i int, result1 error) {
-	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
-	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
 	fake.DeleteResourceByKindAndNameAndNamespaceStub = nil
 	if fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall == nil {
 		fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall = make(map[int]struct {
@@ -349,17 +326,15 @@ func (fake *FakeClient) GVRForKind(arg1 string) (schema.GroupVersionResource, er
 	fake.gVRForKindArgsForCall = append(fake.gVRForKindArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.GVRForKindStub
-	fakeReturns := fake.gVRForKindReturns
 	fake.recordInvocation("GVRForKind", []interface{}{arg1})
 	fake.gVRForKindMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.GVRForKindStub != nil {
+		return fake.GVRForKindStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.gVRForKindReturns.result1, fake.gVRForKindReturns.result2
 }
 
 func (fake *FakeClient) GVRForKindCallCount() int {
@@ -368,22 +343,13 @@ func (fake *FakeClient) GVRForKindCallCount() int {
 	return len(fake.gVRForKindArgsForCall)
 }
 
-func (fake *FakeClient) GVRForKindCalls(stub func(string) (schema.GroupVersionResource, error)) {
-	fake.gVRForKindMutex.Lock()
-	defer fake.gVRForKindMutex.Unlock()
-	fake.GVRForKindStub = stub
-}
-
 func (fake *FakeClient) GVRForKindArgsForCall(i int) string {
 	fake.gVRForKindMutex.RLock()
 	defer fake.gVRForKindMutex.RUnlock()
-	argsForCall := fake.gVRForKindArgsForCall[i]
-	return argsForCall.arg1
+	return fake.gVRForKindArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) GVRForKindReturns(result1 schema.GroupVersionResource, result2 error) {
-	fake.gVRForKindMutex.Lock()
-	defer fake.gVRForKindMutex.Unlock()
 	fake.GVRForKindStub = nil
 	fake.gVRForKindReturns = struct {
 		result1 schema.GroupVersionResource
@@ -392,8 +358,6 @@ func (fake *FakeClient) GVRForKindReturns(result1 schema.GroupVersionResource, r
 }
 
 func (fake *FakeClient) GVRForKindReturnsOnCall(i int, result1 schema.GroupVersionResource, result2 error) {
-	fake.gVRForKindMutex.Lock()
-	defer fake.gVRForKindMutex.Unlock()
 	fake.GVRForKindStub = nil
 	if fake.gVRForKindReturnsOnCall == nil {
 		fake.gVRForKindReturnsOnCall = make(map[int]struct {
@@ -415,17 +379,15 @@ func (fake *FakeClient) Get(arg1 string, arg2 string, arg3 string) (*unstructure
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
-	stub := fake.GetStub
-	fakeReturns := fake.getReturns
 	fake.recordInvocation("Get", []interface{}{arg1, arg2, arg3})
 	fake.getMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
+	if fake.GetStub != nil {
+		return fake.GetStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.getReturns.result1, fake.getReturns.result2
 }
 
 func (fake *FakeClient) GetCallCount() int {
@@ -434,22 +396,13 @@ func (fake *FakeClient) GetCallCount() int {
 	return len(fake.getArgsForCall)
 }
 
-func (fake *FakeClient) GetCalls(stub func(string, string, string) (*unstructured.Unstructured, error)) {
-	fake.getMutex.Lock()
-	defer fake.getMutex.Unlock()
-	fake.GetStub = stub
-}
-
 func (fake *FakeClient) GetArgsForCall(i int) (string, string, string) {
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
-	argsForCall := fake.getArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+	return fake.getArgsForCall[i].arg1, fake.getArgsForCall[i].arg2, fake.getArgsForCall[i].arg3
 }
 
 func (fake *FakeClient) GetReturns(result1 *unstructured.Unstructured, result2 error) {
-	fake.getMutex.Lock()
-	defer fake.getMutex.Unlock()
 	fake.GetStub = nil
 	fake.getReturns = struct {
 		result1 *unstructured.Unstructured
@@ -458,8 +411,6 @@ func (fake *FakeClient) GetReturns(result1 *unstructured.Unstructured, result2 e
 }
 
 func (fake *FakeClient) GetReturnsOnCall(i int, result1 *unstructured.Unstructured, result2 error) {
-	fake.getMutex.Lock()
-	defer fake.getMutex.Unlock()
 	fake.GetStub = nil
 	if fake.getReturnsOnCall == nil {
 		fake.getReturnsOnCall = make(map[int]struct {
@@ -473,24 +424,22 @@ func (fake *FakeClient) GetReturnsOnCall(i int, result1 *unstructured.Unstructur
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 v1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
 	fake.listByGVRMutex.Lock()
 	ret, specificReturn := fake.listByGVRReturnsOnCall[len(fake.listByGVRArgsForCall)]
 	fake.listByGVRArgsForCall = append(fake.listByGVRArgsForCall, struct {
 		arg1 schema.GroupVersionResource
-		arg2 v1.ListOptions
+		arg2 metav1.ListOptions
 	}{arg1, arg2})
-	stub := fake.ListByGVRStub
-	fakeReturns := fake.listByGVRReturns
 	fake.recordInvocation("ListByGVR", []interface{}{arg1, arg2})
 	fake.listByGVRMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
+	if fake.ListByGVRStub != nil {
+		return fake.ListByGVRStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listByGVRReturns.result1, fake.listByGVRReturns.result2
 }
 
 func (fake *FakeClient) ListByGVRCallCount() int {
@@ -499,22 +448,13 @@ func (fake *FakeClient) ListByGVRCallCount() int {
 	return len(fake.listByGVRArgsForCall)
 }
 
-func (fake *FakeClient) ListByGVRCalls(stub func(schema.GroupVersionResource, v1.ListOptions) (*unstructured.UnstructuredList, error)) {
-	fake.listByGVRMutex.Lock()
-	defer fake.listByGVRMutex.Unlock()
-	fake.ListByGVRStub = stub
-}
-
-func (fake *FakeClient) ListByGVRArgsForCall(i int) (schema.GroupVersionResource, v1.ListOptions) {
+func (fake *FakeClient) ListByGVRArgsForCall(i int) (schema.GroupVersionResource, metav1.ListOptions) {
 	fake.listByGVRMutex.RLock()
 	defer fake.listByGVRMutex.RUnlock()
-	argsForCall := fake.listByGVRArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return fake.listByGVRArgsForCall[i].arg1, fake.listByGVRArgsForCall[i].arg2
 }
 
 func (fake *FakeClient) ListByGVRReturns(result1 *unstructured.UnstructuredList, result2 error) {
-	fake.listByGVRMutex.Lock()
-	defer fake.listByGVRMutex.Unlock()
 	fake.ListByGVRStub = nil
 	fake.listByGVRReturns = struct {
 		result1 *unstructured.UnstructuredList
@@ -523,8 +463,6 @@ func (fake *FakeClient) ListByGVRReturns(result1 *unstructured.UnstructuredList,
 }
 
 func (fake *FakeClient) ListByGVRReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
-	fake.listByGVRMutex.Lock()
-	defer fake.listByGVRMutex.Unlock()
 	fake.ListByGVRStub = nil
 	if fake.listByGVRReturnsOnCall == nil {
 		fake.listByGVRReturnsOnCall = make(map[int]struct {
@@ -538,24 +476,75 @@ func (fake *FakeClient) ListByGVRReturnsOnCall(i int, result1 *unstructured.Unst
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListResource(arg1 string, arg2 v1.ListOptions) (*unstructured.UnstructuredList, error) {
-	fake.listResourceMutex.Lock()
-	ret, specificReturn := fake.listResourceReturnsOnCall[len(fake.listResourceArgsForCall)]
-	fake.listResourceArgsForCall = append(fake.listResourceArgsForCall, struct {
-		arg1 string
-		arg2 v1.ListOptions
-	}{arg1, arg2})
-	stub := fake.ListResourceStub
-	fakeReturns := fake.listResourceReturns
-	fake.recordInvocation("ListResource", []interface{}{arg1, arg2})
-	fake.listResourceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
+func (fake *FakeClient) ListByGVRWithContext(arg1 context.Context, arg2 schema.GroupVersionResource, arg3 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	fake.listByGVRWithContextMutex.Lock()
+	ret, specificReturn := fake.listByGVRWithContextReturnsOnCall[len(fake.listByGVRWithContextArgsForCall)]
+	fake.listByGVRWithContextArgsForCall = append(fake.listByGVRWithContextArgsForCall, struct {
+		arg1 context.Context
+		arg2 schema.GroupVersionResource
+		arg3 metav1.ListOptions
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("ListByGVRWithContext", []interface{}{arg1, arg2, arg3})
+	fake.listByGVRWithContextMutex.Unlock()
+	if fake.ListByGVRWithContextStub != nil {
+		return fake.ListByGVRWithContextStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listByGVRWithContextReturns.result1, fake.listByGVRWithContextReturns.result2
+}
+
+func (fake *FakeClient) ListByGVRWithContextCallCount() int {
+	fake.listByGVRWithContextMutex.RLock()
+	defer fake.listByGVRWithContextMutex.RUnlock()
+	return len(fake.listByGVRWithContextArgsForCall)
+}
+
+func (fake *FakeClient) ListByGVRWithContextArgsForCall(i int) (context.Context, schema.GroupVersionResource, metav1.ListOptions) {
+	fake.listByGVRWithContextMutex.RLock()
+	defer fake.listByGVRWithContextMutex.RUnlock()
+	return fake.listByGVRWithContextArgsForCall[i].arg1, fake.listByGVRWithContextArgsForCall[i].arg2, fake.listByGVRWithContextArgsForCall[i].arg3
+}
+
+func (fake *FakeClient) ListByGVRWithContextReturns(result1 *unstructured.UnstructuredList, result2 error) {
+	fake.ListByGVRWithContextStub = nil
+	fake.listByGVRWithContextReturns = struct {
+		result1 *unstructured.UnstructuredList
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListByGVRWithContextReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
+	fake.ListByGVRWithContextStub = nil
+	if fake.listByGVRWithContextReturnsOnCall == nil {
+		fake.listByGVRWithContextReturnsOnCall = make(map[int]struct {
+			result1 *unstructured.UnstructuredList
+			result2 error
+		})
+	}
+	fake.listByGVRWithContextReturnsOnCall[i] = struct {
+		result1 *unstructured.UnstructuredList
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListResource(arg1 string, arg2 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	fake.listResourceMutex.Lock()
+	ret, specificReturn := fake.listResourceReturnsOnCall[len(fake.listResourceArgsForCall)]
+	fake.listResourceArgsForCall = append(fake.listResourceArgsForCall, struct {
+		arg1 string
+		arg2 metav1.ListOptions
+	}{arg1, arg2})
+	fake.recordInvocation("ListResource", []interface{}{arg1, arg2})
+	fake.listResourceMutex.Unlock()
+	if fake.ListResourceStub != nil {
+		return fake.ListResourceStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.listResourceReturns.result1, fake.listResourceReturns.result2
 }
 
 func (fake *FakeClient) ListResourceCallCount() int {
@@ -564,22 +553,13 @@ func (fake *FakeClient) ListResourceCallCount() int {
 	return len(fake.listResourceArgsForCall)
 }
 
-func (fake *FakeClient) ListResourceCalls(stub func(string, v1.ListOptions) (*unstructured.UnstructuredList, error)) {
-	fake.listResourceMutex.Lock()
-	defer fake.listResourceMutex.Unlock()
-	fake.ListResourceStub = stub
-}
-
-func (fake *FakeClient) ListResourceArgsForCall(i int) (string, v1.ListOptions) {
+func (fake *FakeClient) ListResourceArgsForCall(i int) (string, metav1.ListOptions) {
 	fake.listResourceMutex.RLock()
 	defer fake.listResourceMutex.RUnlock()
-	argsForCall := fake.listResourceArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
+	return fake.listResourceArgsForCall[i].arg1, fake.listResourceArgsForCall[i].arg2
 }
 
 func (fake *FakeClient) ListResourceReturns(result1 *unstructured.UnstructuredList, result2 error) {
-	fake.listResourceMutex.Lock()
-	defer fake.listResourceMutex.Unlock()
 	fake.ListResourceStub = nil
 	fake.listResourceReturns = struct {
 		result1 *unstructured.UnstructuredList
@@ -588,8 +568,6 @@ func (fake *FakeClient) ListResourceReturns(result1 *unstructured.UnstructuredLi
 }
 
 func (fake *FakeClient) ListResourceReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
-	fake.listResourceMutex.Lock()
-	defer fake.listResourceMutex.Unlock()
 	fake.ListResourceStub = nil
 	if fake.listResourceReturnsOnCall == nil {
 		fake.listResourceReturnsOnCall = make(map[int]struct {
@@ -617,17 +595,15 @@ func (fake *FakeClient) Patch(arg1 string, arg2 string, arg3 string, arg4 []byte
 		arg3 string
 		arg4 []byte
 	}{arg1, arg2, arg3, arg4Copy})
-	stub := fake.PatchStub
-	fakeReturns := fake.patchReturns
 	fake.recordInvocation("Patch", []interface{}{arg1, arg2, arg3, arg4Copy})
 	fake.patchMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+	if fake.PatchStub != nil {
+		return fake.PatchStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fake.patchReturns.result1, fake.patchReturns.result2, fake.patchReturns.result3
 }
 
 func (fake *FakeClient) PatchCallCount() int {
@@ -636,22 +612,13 @@ func (fake *FakeClient) PatchCallCount() int {
 	return len(fake.patchArgsForCall)
 }
 
-func (fake *FakeClient) PatchCalls(stub func(string, string, string, []byte) (kubernetes.Metadata, *unstructured.Unstructured, error)) {
-	fake.patchMutex.Lock()
-	defer fake.patchMutex.Unlock()
-	fake.PatchStub = stub
-}
-
 func (fake *FakeClient) PatchArgsForCall(i int) (string, string, string, []byte) {
 	fake.patchMutex.RLock()
 	defer fake.patchMutex.RUnlock()
-	argsForCall := fake.patchArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+	return fake.patchArgsForCall[i].arg1, fake.patchArgsForCall[i].arg2, fake.patchArgsForCall[i].arg3, fake.patchArgsForCall[i].arg4
 }
 
 func (fake *FakeClient) PatchReturns(result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
-	fake.patchMutex.Lock()
-	defer fake.patchMutex.Unlock()
 	fake.PatchStub = nil
 	fake.patchReturns = struct {
 		result1 kubernetes.Metadata
@@ -661,8 +628,6 @@ func (fake *FakeClient) PatchReturns(result1 kubernetes.Metadata, result2 *unstr
 }
 
 func (fake *FakeClient) PatchReturnsOnCall(i int, result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
-	fake.patchMutex.Lock()
-	defer fake.patchMutex.Unlock()
 	fake.PatchStub = nil
 	if fake.patchReturnsOnCall == nil {
 		fake.patchReturnsOnCall = make(map[int]struct {
@@ -693,17 +658,15 @@ func (fake *FakeClient) PatchUsingStrategy(arg1 string, arg2 string, arg3 string
 		arg4 []byte
 		arg5 types.PatchType
 	}{arg1, arg2, arg3, arg4Copy, arg5})
-	stub := fake.PatchUsingStrategyStub
-	fakeReturns := fake.patchUsingStrategyReturns
 	fake.recordInvocation("PatchUsingStrategy", []interface{}{arg1, arg2, arg3, arg4Copy, arg5})
 	fake.patchUsingStrategyMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+	if fake.PatchUsingStrategyStub != nil {
+		return fake.PatchUsingStrategyStub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
+	return fake.patchUsingStrategyReturns.result1, fake.patchUsingStrategyReturns.result2, fake.patchUsingStrategyReturns.result3
 }
 
 func (fake *FakeClient) PatchUsingStrategyCallCount() int {
@@ -712,22 +675,13 @@ func (fake *FakeClient) PatchUsingStrategyCallCount() int {
 	return len(fake.patchUsingStrategyArgsForCall)
 }
 
-func (fake *FakeClient) PatchUsingStrategyCalls(stub func(string, string, string, []byte, types.PatchType) (kubernetes.Metadata, *unstructured.Unstructured, error)) {
-	fake.patchUsingStrategyMutex.Lock()
-	defer fake.patchUsingStrategyMutex.Unlock()
-	fake.PatchUsingStrategyStub = stub
-}
-
 func (fake *FakeClient) PatchUsingStrategyArgsForCall(i int) (string, string, string, []byte, types.PatchType) {
 	fake.patchUsingStrategyMutex.RLock()
 	defer fake.patchUsingStrategyMutex.RUnlock()
-	argsForCall := fake.patchUsingStrategyArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
+	return fake.patchUsingStrategyArgsForCall[i].arg1, fake.patchUsingStrategyArgsForCall[i].arg2, fake.patchUsingStrategyArgsForCall[i].arg3, fake.patchUsingStrategyArgsForCall[i].arg4, fake.patchUsingStrategyArgsForCall[i].arg5
 }
 
 func (fake *FakeClient) PatchUsingStrategyReturns(result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
-	fake.patchUsingStrategyMutex.Lock()
-	defer fake.patchUsingStrategyMutex.Unlock()
 	fake.PatchUsingStrategyStub = nil
 	fake.patchUsingStrategyReturns = struct {
 		result1 kubernetes.Metadata
@@ -737,8 +691,6 @@ func (fake *FakeClient) PatchUsingStrategyReturns(result1 kubernetes.Metadata, r
 }
 
 func (fake *FakeClient) PatchUsingStrategyReturnsOnCall(i int, result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
-	fake.patchUsingStrategyMutex.Lock()
-	defer fake.patchUsingStrategyMutex.Unlock()
 	fake.PatchUsingStrategyStub = nil
 	if fake.patchUsingStrategyReturnsOnCall == nil {
 		fake.patchUsingStrategyReturnsOnCall = make(map[int]struct {
@@ -769,6 +721,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.getMutex.RUnlock()
 	fake.listByGVRMutex.RLock()
 	defer fake.listByGVRMutex.RUnlock()
+	fake.listByGVRWithContextMutex.RLock()
+	defer fake.listByGVRWithContextMutex.RUnlock()
 	fake.listResourceMutex.RLock()
 	defer fake.listResourceMutex.RUnlock()
 	fake.patchMutex.RLock()

--- a/pkg/kubernetes/kubernetesfakes/fake_controller.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_controller.go
@@ -10,30 +10,6 @@ import (
 )
 
 type FakeController struct {
-	AddSpinnakerAnnotationsStub        func(*unstructured.Unstructured, string) error
-	addSpinnakerAnnotationsMutex       sync.RWMutex
-	addSpinnakerAnnotationsArgsForCall []struct {
-		arg1 *unstructured.Unstructured
-		arg2 string
-	}
-	addSpinnakerAnnotationsReturns struct {
-		result1 error
-	}
-	addSpinnakerAnnotationsReturnsOnCall map[int]struct {
-		result1 error
-	}
-	AddSpinnakerLabelsStub        func(*unstructured.Unstructured, string) error
-	addSpinnakerLabelsMutex       sync.RWMutex
-	addSpinnakerLabelsArgsForCall []struct {
-		arg1 *unstructured.Unstructured
-		arg2 string
-	}
-	addSpinnakerLabelsReturns struct {
-		result1 error
-	}
-	addSpinnakerLabelsReturnsOnCall map[int]struct {
-		result1 error
-	}
 	NewClientStub        func(*rest.Config) (kubernetes.Client, error)
 	newClientMutex       sync.RWMutex
 	newClientArgsForCall []struct {
@@ -60,132 +36,32 @@ type FakeController struct {
 		result1 *unstructured.Unstructured
 		result2 error
 	}
+	AddSpinnakerAnnotationsStub        func(u *unstructured.Unstructured, application string) error
+	addSpinnakerAnnotationsMutex       sync.RWMutex
+	addSpinnakerAnnotationsArgsForCall []struct {
+		u           *unstructured.Unstructured
+		application string
+	}
+	addSpinnakerAnnotationsReturns struct {
+		result1 error
+	}
+	addSpinnakerAnnotationsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	AddSpinnakerLabelsStub        func(u *unstructured.Unstructured, application string) error
+	addSpinnakerLabelsMutex       sync.RWMutex
+	addSpinnakerLabelsArgsForCall []struct {
+		u           *unstructured.Unstructured
+		application string
+	}
+	addSpinnakerLabelsReturns struct {
+		result1 error
+	}
+	addSpinnakerLabelsReturnsOnCall map[int]struct {
+		result1 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeController) AddSpinnakerAnnotations(arg1 *unstructured.Unstructured, arg2 string) error {
-	fake.addSpinnakerAnnotationsMutex.Lock()
-	ret, specificReturn := fake.addSpinnakerAnnotationsReturnsOnCall[len(fake.addSpinnakerAnnotationsArgsForCall)]
-	fake.addSpinnakerAnnotationsArgsForCall = append(fake.addSpinnakerAnnotationsArgsForCall, struct {
-		arg1 *unstructured.Unstructured
-		arg2 string
-	}{arg1, arg2})
-	stub := fake.AddSpinnakerAnnotationsStub
-	fakeReturns := fake.addSpinnakerAnnotationsReturns
-	fake.recordInvocation("AddSpinnakerAnnotations", []interface{}{arg1, arg2})
-	fake.addSpinnakerAnnotationsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsCallCount() int {
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	return len(fake.addSpinnakerAnnotationsArgsForCall)
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsCalls(stub func(*unstructured.Unstructured, string) error) {
-	fake.addSpinnakerAnnotationsMutex.Lock()
-	defer fake.addSpinnakerAnnotationsMutex.Unlock()
-	fake.AddSpinnakerAnnotationsStub = stub
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsArgsForCall(i int) (*unstructured.Unstructured, string) {
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	argsForCall := fake.addSpinnakerAnnotationsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsReturns(result1 error) {
-	fake.addSpinnakerAnnotationsMutex.Lock()
-	defer fake.addSpinnakerAnnotationsMutex.Unlock()
-	fake.AddSpinnakerAnnotationsStub = nil
-	fake.addSpinnakerAnnotationsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsReturnsOnCall(i int, result1 error) {
-	fake.addSpinnakerAnnotationsMutex.Lock()
-	defer fake.addSpinnakerAnnotationsMutex.Unlock()
-	fake.AddSpinnakerAnnotationsStub = nil
-	if fake.addSpinnakerAnnotationsReturnsOnCall == nil {
-		fake.addSpinnakerAnnotationsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.addSpinnakerAnnotationsReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerLabels(arg1 *unstructured.Unstructured, arg2 string) error {
-	fake.addSpinnakerLabelsMutex.Lock()
-	ret, specificReturn := fake.addSpinnakerLabelsReturnsOnCall[len(fake.addSpinnakerLabelsArgsForCall)]
-	fake.addSpinnakerLabelsArgsForCall = append(fake.addSpinnakerLabelsArgsForCall, struct {
-		arg1 *unstructured.Unstructured
-		arg2 string
-	}{arg1, arg2})
-	stub := fake.AddSpinnakerLabelsStub
-	fakeReturns := fake.addSpinnakerLabelsReturns
-	fake.recordInvocation("AddSpinnakerLabels", []interface{}{arg1, arg2})
-	fake.addSpinnakerLabelsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fakeReturns.result1
-}
-
-func (fake *FakeController) AddSpinnakerLabelsCallCount() int {
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
-	return len(fake.addSpinnakerLabelsArgsForCall)
-}
-
-func (fake *FakeController) AddSpinnakerLabelsCalls(stub func(*unstructured.Unstructured, string) error) {
-	fake.addSpinnakerLabelsMutex.Lock()
-	defer fake.addSpinnakerLabelsMutex.Unlock()
-	fake.AddSpinnakerLabelsStub = stub
-}
-
-func (fake *FakeController) AddSpinnakerLabelsArgsForCall(i int) (*unstructured.Unstructured, string) {
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
-	argsForCall := fake.addSpinnakerLabelsArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeController) AddSpinnakerLabelsReturns(result1 error) {
-	fake.addSpinnakerLabelsMutex.Lock()
-	defer fake.addSpinnakerLabelsMutex.Unlock()
-	fake.AddSpinnakerLabelsStub = nil
-	fake.addSpinnakerLabelsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerLabelsReturnsOnCall(i int, result1 error) {
-	fake.addSpinnakerLabelsMutex.Lock()
-	defer fake.addSpinnakerLabelsMutex.Unlock()
-	fake.AddSpinnakerLabelsStub = nil
-	if fake.addSpinnakerLabelsReturnsOnCall == nil {
-		fake.addSpinnakerLabelsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.addSpinnakerLabelsReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakeController) NewClient(arg1 *rest.Config) (kubernetes.Client, error) {
@@ -194,17 +70,15 @@ func (fake *FakeController) NewClient(arg1 *rest.Config) (kubernetes.Client, err
 	fake.newClientArgsForCall = append(fake.newClientArgsForCall, struct {
 		arg1 *rest.Config
 	}{arg1})
-	stub := fake.NewClientStub
-	fakeReturns := fake.newClientReturns
 	fake.recordInvocation("NewClient", []interface{}{arg1})
 	fake.newClientMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.NewClientStub != nil {
+		return fake.NewClientStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.newClientReturns.result1, fake.newClientReturns.result2
 }
 
 func (fake *FakeController) NewClientCallCount() int {
@@ -213,22 +87,13 @@ func (fake *FakeController) NewClientCallCount() int {
 	return len(fake.newClientArgsForCall)
 }
 
-func (fake *FakeController) NewClientCalls(stub func(*rest.Config) (kubernetes.Client, error)) {
-	fake.newClientMutex.Lock()
-	defer fake.newClientMutex.Unlock()
-	fake.NewClientStub = stub
-}
-
 func (fake *FakeController) NewClientArgsForCall(i int) *rest.Config {
 	fake.newClientMutex.RLock()
 	defer fake.newClientMutex.RUnlock()
-	argsForCall := fake.newClientArgsForCall[i]
-	return argsForCall.arg1
+	return fake.newClientArgsForCall[i].arg1
 }
 
 func (fake *FakeController) NewClientReturns(result1 kubernetes.Client, result2 error) {
-	fake.newClientMutex.Lock()
-	defer fake.newClientMutex.Unlock()
 	fake.NewClientStub = nil
 	fake.newClientReturns = struct {
 		result1 kubernetes.Client
@@ -237,8 +102,6 @@ func (fake *FakeController) NewClientReturns(result1 kubernetes.Client, result2 
 }
 
 func (fake *FakeController) NewClientReturnsOnCall(i int, result1 kubernetes.Client, result2 error) {
-	fake.newClientMutex.Lock()
-	defer fake.newClientMutex.Unlock()
 	fake.NewClientStub = nil
 	if fake.newClientReturnsOnCall == nil {
 		fake.newClientReturnsOnCall = make(map[int]struct {
@@ -258,17 +121,15 @@ func (fake *FakeController) ToUnstructured(arg1 map[string]interface{}) (*unstru
 	fake.toUnstructuredArgsForCall = append(fake.toUnstructuredArgsForCall, struct {
 		arg1 map[string]interface{}
 	}{arg1})
-	stub := fake.ToUnstructuredStub
-	fakeReturns := fake.toUnstructuredReturns
 	fake.recordInvocation("ToUnstructured", []interface{}{arg1})
 	fake.toUnstructuredMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ToUnstructuredStub != nil {
+		return fake.ToUnstructuredStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.toUnstructuredReturns.result1, fake.toUnstructuredReturns.result2
 }
 
 func (fake *FakeController) ToUnstructuredCallCount() int {
@@ -277,22 +138,13 @@ func (fake *FakeController) ToUnstructuredCallCount() int {
 	return len(fake.toUnstructuredArgsForCall)
 }
 
-func (fake *FakeController) ToUnstructuredCalls(stub func(map[string]interface{}) (*unstructured.Unstructured, error)) {
-	fake.toUnstructuredMutex.Lock()
-	defer fake.toUnstructuredMutex.Unlock()
-	fake.ToUnstructuredStub = stub
-}
-
 func (fake *FakeController) ToUnstructuredArgsForCall(i int) map[string]interface{} {
 	fake.toUnstructuredMutex.RLock()
 	defer fake.toUnstructuredMutex.RUnlock()
-	argsForCall := fake.toUnstructuredArgsForCall[i]
-	return argsForCall.arg1
+	return fake.toUnstructuredArgsForCall[i].arg1
 }
 
 func (fake *FakeController) ToUnstructuredReturns(result1 *unstructured.Unstructured, result2 error) {
-	fake.toUnstructuredMutex.Lock()
-	defer fake.toUnstructuredMutex.Unlock()
 	fake.ToUnstructuredStub = nil
 	fake.toUnstructuredReturns = struct {
 		result1 *unstructured.Unstructured
@@ -301,8 +153,6 @@ func (fake *FakeController) ToUnstructuredReturns(result1 *unstructured.Unstruct
 }
 
 func (fake *FakeController) ToUnstructuredReturnsOnCall(i int, result1 *unstructured.Unstructured, result2 error) {
-	fake.toUnstructuredMutex.Lock()
-	defer fake.toUnstructuredMutex.Unlock()
 	fake.ToUnstructuredStub = nil
 	if fake.toUnstructuredReturnsOnCall == nil {
 		fake.toUnstructuredReturnsOnCall = make(map[int]struct {
@@ -316,17 +166,115 @@ func (fake *FakeController) ToUnstructuredReturnsOnCall(i int, result1 *unstruct
 	}{result1, result2}
 }
 
+func (fake *FakeController) AddSpinnakerAnnotations(u *unstructured.Unstructured, application string) error {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	ret, specificReturn := fake.addSpinnakerAnnotationsReturnsOnCall[len(fake.addSpinnakerAnnotationsArgsForCall)]
+	fake.addSpinnakerAnnotationsArgsForCall = append(fake.addSpinnakerAnnotationsArgsForCall, struct {
+		u           *unstructured.Unstructured
+		application string
+	}{u, application})
+	fake.recordInvocation("AddSpinnakerAnnotations", []interface{}{u, application})
+	fake.addSpinnakerAnnotationsMutex.Unlock()
+	if fake.AddSpinnakerAnnotationsStub != nil {
+		return fake.AddSpinnakerAnnotationsStub(u, application)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.addSpinnakerAnnotationsReturns.result1
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsCallCount() int {
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	return len(fake.addSpinnakerAnnotationsArgsForCall)
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsArgsForCall(i int) (*unstructured.Unstructured, string) {
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	return fake.addSpinnakerAnnotationsArgsForCall[i].u, fake.addSpinnakerAnnotationsArgsForCall[i].application
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsReturns(result1 error) {
+	fake.AddSpinnakerAnnotationsStub = nil
+	fake.addSpinnakerAnnotationsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsReturnsOnCall(i int, result1 error) {
+	fake.AddSpinnakerAnnotationsStub = nil
+	if fake.addSpinnakerAnnotationsReturnsOnCall == nil {
+		fake.addSpinnakerAnnotationsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addSpinnakerAnnotationsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerLabels(u *unstructured.Unstructured, application string) error {
+	fake.addSpinnakerLabelsMutex.Lock()
+	ret, specificReturn := fake.addSpinnakerLabelsReturnsOnCall[len(fake.addSpinnakerLabelsArgsForCall)]
+	fake.addSpinnakerLabelsArgsForCall = append(fake.addSpinnakerLabelsArgsForCall, struct {
+		u           *unstructured.Unstructured
+		application string
+	}{u, application})
+	fake.recordInvocation("AddSpinnakerLabels", []interface{}{u, application})
+	fake.addSpinnakerLabelsMutex.Unlock()
+	if fake.AddSpinnakerLabelsStub != nil {
+		return fake.AddSpinnakerLabelsStub(u, application)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fake.addSpinnakerLabelsReturns.result1
+}
+
+func (fake *FakeController) AddSpinnakerLabelsCallCount() int {
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
+	return len(fake.addSpinnakerLabelsArgsForCall)
+}
+
+func (fake *FakeController) AddSpinnakerLabelsArgsForCall(i int) (*unstructured.Unstructured, string) {
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
+	return fake.addSpinnakerLabelsArgsForCall[i].u, fake.addSpinnakerLabelsArgsForCall[i].application
+}
+
+func (fake *FakeController) AddSpinnakerLabelsReturns(result1 error) {
+	fake.AddSpinnakerLabelsStub = nil
+	fake.addSpinnakerLabelsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerLabelsReturnsOnCall(i int, result1 error) {
+	fake.AddSpinnakerLabelsStub = nil
+	if fake.addSpinnakerLabelsReturnsOnCall == nil {
+		fake.addSpinnakerLabelsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addSpinnakerLabelsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeController) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
 	fake.newClientMutex.RLock()
 	defer fake.newClientMutex.RUnlock()
 	fake.toUnstructuredMutex.RLock()
 	defer fake.toUnstructuredMutex.RUnlock()
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/sql/sqlfakes/fake_client.go
+++ b/pkg/sql/sqlfakes/fake_client.go
@@ -7,6 +7,7 @@ import (
 	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 	"github.com/homedepot/go-clouddriver/pkg/kubernetes"
 	"github.com/homedepot/go-clouddriver/pkg/sql"
+	_ "github.com/mattn/go-sqlite3"
 )
 
 type FakeClient struct {
@@ -119,9 +120,8 @@ type FakeClient struct {
 	}
 	ListKubernetesProvidersStub        func() ([]kubernetes.Provider, error)
 	listKubernetesProvidersMutex       sync.RWMutex
-	listKubernetesProvidersArgsForCall []struct {
-	}
-	listKubernetesProvidersReturns struct {
+	listKubernetesProvidersArgsForCall []struct{}
+	listKubernetesProvidersReturns     struct {
 		result1 []kubernetes.Provider
 		result2 error
 	}
@@ -131,29 +131,13 @@ type FakeClient struct {
 	}
 	ListKubernetesProvidersAndPermissionsStub        func() ([]kubernetes.Provider, error)
 	listKubernetesProvidersAndPermissionsMutex       sync.RWMutex
-	listKubernetesProvidersAndPermissionsArgsForCall []struct {
-	}
-	listKubernetesProvidersAndPermissionsReturns struct {
+	listKubernetesProvidersAndPermissionsArgsForCall []struct{}
+	listKubernetesProvidersAndPermissionsReturns     struct {
 		result1 []kubernetes.Provider
 		result2 error
 	}
 	listKubernetesProvidersAndPermissionsReturnsOnCall map[int]struct {
 		result1 []kubernetes.Provider
-		result2 error
-	}
-	ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub        func(string, string, string) ([]string, error)
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex       sync.RWMutex
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall []struct {
-		arg1 string
-		arg2 string
-		arg3 string
-	}
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns struct {
-		result1 []string
-		result2 error
-	}
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall map[int]struct {
-		result1 []string
 		result2 error
 	}
 	ListKubernetesResourcesByFieldsStub        func(...string) ([]kubernetes.Resource, error)
@@ -180,6 +164,21 @@ type FakeClient struct {
 	}
 	listKubernetesResourcesByTaskIDReturnsOnCall map[int]struct {
 		result1 []kubernetes.Resource
+		result2 error
+	}
+	ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub        func(string, string, string) ([]string, error)
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex       sync.RWMutex
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns struct {
+		result1 []string
+		result2 error
+	}
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall map[int]struct {
+		result1 []string
 		result2 error
 	}
 	ListReadGroupsByAccountNameStub        func(string) ([]string, error)
@@ -218,17 +217,15 @@ func (fake *FakeClient) CreateKubernetesProvider(arg1 kubernetes.Provider) error
 	fake.createKubernetesProviderArgsForCall = append(fake.createKubernetesProviderArgsForCall, struct {
 		arg1 kubernetes.Provider
 	}{arg1})
-	stub := fake.CreateKubernetesProviderStub
-	fakeReturns := fake.createKubernetesProviderReturns
 	fake.recordInvocation("CreateKubernetesProvider", []interface{}{arg1})
 	fake.createKubernetesProviderMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.CreateKubernetesProviderStub != nil {
+		return fake.CreateKubernetesProviderStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fakeReturns.result1
+	return fake.createKubernetesProviderReturns.result1
 }
 
 func (fake *FakeClient) CreateKubernetesProviderCallCount() int {
@@ -237,22 +234,13 @@ func (fake *FakeClient) CreateKubernetesProviderCallCount() int {
 	return len(fake.createKubernetesProviderArgsForCall)
 }
 
-func (fake *FakeClient) CreateKubernetesProviderCalls(stub func(kubernetes.Provider) error) {
-	fake.createKubernetesProviderMutex.Lock()
-	defer fake.createKubernetesProviderMutex.Unlock()
-	fake.CreateKubernetesProviderStub = stub
-}
-
 func (fake *FakeClient) CreateKubernetesProviderArgsForCall(i int) kubernetes.Provider {
 	fake.createKubernetesProviderMutex.RLock()
 	defer fake.createKubernetesProviderMutex.RUnlock()
-	argsForCall := fake.createKubernetesProviderArgsForCall[i]
-	return argsForCall.arg1
+	return fake.createKubernetesProviderArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) CreateKubernetesProviderReturns(result1 error) {
-	fake.createKubernetesProviderMutex.Lock()
-	defer fake.createKubernetesProviderMutex.Unlock()
 	fake.CreateKubernetesProviderStub = nil
 	fake.createKubernetesProviderReturns = struct {
 		result1 error
@@ -260,8 +248,6 @@ func (fake *FakeClient) CreateKubernetesProviderReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateKubernetesProviderReturnsOnCall(i int, result1 error) {
-	fake.createKubernetesProviderMutex.Lock()
-	defer fake.createKubernetesProviderMutex.Unlock()
 	fake.CreateKubernetesProviderStub = nil
 	if fake.createKubernetesProviderReturnsOnCall == nil {
 		fake.createKubernetesProviderReturnsOnCall = make(map[int]struct {
@@ -279,17 +265,15 @@ func (fake *FakeClient) CreateKubernetesResource(arg1 kubernetes.Resource) error
 	fake.createKubernetesResourceArgsForCall = append(fake.createKubernetesResourceArgsForCall, struct {
 		arg1 kubernetes.Resource
 	}{arg1})
-	stub := fake.CreateKubernetesResourceStub
-	fakeReturns := fake.createKubernetesResourceReturns
 	fake.recordInvocation("CreateKubernetesResource", []interface{}{arg1})
 	fake.createKubernetesResourceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.CreateKubernetesResourceStub != nil {
+		return fake.CreateKubernetesResourceStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fakeReturns.result1
+	return fake.createKubernetesResourceReturns.result1
 }
 
 func (fake *FakeClient) CreateKubernetesResourceCallCount() int {
@@ -298,22 +282,13 @@ func (fake *FakeClient) CreateKubernetesResourceCallCount() int {
 	return len(fake.createKubernetesResourceArgsForCall)
 }
 
-func (fake *FakeClient) CreateKubernetesResourceCalls(stub func(kubernetes.Resource) error) {
-	fake.createKubernetesResourceMutex.Lock()
-	defer fake.createKubernetesResourceMutex.Unlock()
-	fake.CreateKubernetesResourceStub = stub
-}
-
 func (fake *FakeClient) CreateKubernetesResourceArgsForCall(i int) kubernetes.Resource {
 	fake.createKubernetesResourceMutex.RLock()
 	defer fake.createKubernetesResourceMutex.RUnlock()
-	argsForCall := fake.createKubernetesResourceArgsForCall[i]
-	return argsForCall.arg1
+	return fake.createKubernetesResourceArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) CreateKubernetesResourceReturns(result1 error) {
-	fake.createKubernetesResourceMutex.Lock()
-	defer fake.createKubernetesResourceMutex.Unlock()
 	fake.CreateKubernetesResourceStub = nil
 	fake.createKubernetesResourceReturns = struct {
 		result1 error
@@ -321,8 +296,6 @@ func (fake *FakeClient) CreateKubernetesResourceReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateKubernetesResourceReturnsOnCall(i int, result1 error) {
-	fake.createKubernetesResourceMutex.Lock()
-	defer fake.createKubernetesResourceMutex.Unlock()
 	fake.CreateKubernetesResourceStub = nil
 	if fake.createKubernetesResourceReturnsOnCall == nil {
 		fake.createKubernetesResourceReturnsOnCall = make(map[int]struct {
@@ -340,17 +313,15 @@ func (fake *FakeClient) CreateReadPermission(arg1 clouddriver.ReadPermission) er
 	fake.createReadPermissionArgsForCall = append(fake.createReadPermissionArgsForCall, struct {
 		arg1 clouddriver.ReadPermission
 	}{arg1})
-	stub := fake.CreateReadPermissionStub
-	fakeReturns := fake.createReadPermissionReturns
 	fake.recordInvocation("CreateReadPermission", []interface{}{arg1})
 	fake.createReadPermissionMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.CreateReadPermissionStub != nil {
+		return fake.CreateReadPermissionStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fakeReturns.result1
+	return fake.createReadPermissionReturns.result1
 }
 
 func (fake *FakeClient) CreateReadPermissionCallCount() int {
@@ -359,22 +330,13 @@ func (fake *FakeClient) CreateReadPermissionCallCount() int {
 	return len(fake.createReadPermissionArgsForCall)
 }
 
-func (fake *FakeClient) CreateReadPermissionCalls(stub func(clouddriver.ReadPermission) error) {
-	fake.createReadPermissionMutex.Lock()
-	defer fake.createReadPermissionMutex.Unlock()
-	fake.CreateReadPermissionStub = stub
-}
-
 func (fake *FakeClient) CreateReadPermissionArgsForCall(i int) clouddriver.ReadPermission {
 	fake.createReadPermissionMutex.RLock()
 	defer fake.createReadPermissionMutex.RUnlock()
-	argsForCall := fake.createReadPermissionArgsForCall[i]
-	return argsForCall.arg1
+	return fake.createReadPermissionArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) CreateReadPermissionReturns(result1 error) {
-	fake.createReadPermissionMutex.Lock()
-	defer fake.createReadPermissionMutex.Unlock()
 	fake.CreateReadPermissionStub = nil
 	fake.createReadPermissionReturns = struct {
 		result1 error
@@ -382,8 +344,6 @@ func (fake *FakeClient) CreateReadPermissionReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateReadPermissionReturnsOnCall(i int, result1 error) {
-	fake.createReadPermissionMutex.Lock()
-	defer fake.createReadPermissionMutex.Unlock()
 	fake.CreateReadPermissionStub = nil
 	if fake.createReadPermissionReturnsOnCall == nil {
 		fake.createReadPermissionReturnsOnCall = make(map[int]struct {
@@ -401,17 +361,15 @@ func (fake *FakeClient) CreateWritePermission(arg1 clouddriver.WritePermission) 
 	fake.createWritePermissionArgsForCall = append(fake.createWritePermissionArgsForCall, struct {
 		arg1 clouddriver.WritePermission
 	}{arg1})
-	stub := fake.CreateWritePermissionStub
-	fakeReturns := fake.createWritePermissionReturns
 	fake.recordInvocation("CreateWritePermission", []interface{}{arg1})
 	fake.createWritePermissionMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.CreateWritePermissionStub != nil {
+		return fake.CreateWritePermissionStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fakeReturns.result1
+	return fake.createWritePermissionReturns.result1
 }
 
 func (fake *FakeClient) CreateWritePermissionCallCount() int {
@@ -420,22 +378,13 @@ func (fake *FakeClient) CreateWritePermissionCallCount() int {
 	return len(fake.createWritePermissionArgsForCall)
 }
 
-func (fake *FakeClient) CreateWritePermissionCalls(stub func(clouddriver.WritePermission) error) {
-	fake.createWritePermissionMutex.Lock()
-	defer fake.createWritePermissionMutex.Unlock()
-	fake.CreateWritePermissionStub = stub
-}
-
 func (fake *FakeClient) CreateWritePermissionArgsForCall(i int) clouddriver.WritePermission {
 	fake.createWritePermissionMutex.RLock()
 	defer fake.createWritePermissionMutex.RUnlock()
-	argsForCall := fake.createWritePermissionArgsForCall[i]
-	return argsForCall.arg1
+	return fake.createWritePermissionArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) CreateWritePermissionReturns(result1 error) {
-	fake.createWritePermissionMutex.Lock()
-	defer fake.createWritePermissionMutex.Unlock()
 	fake.CreateWritePermissionStub = nil
 	fake.createWritePermissionReturns = struct {
 		result1 error
@@ -443,8 +392,6 @@ func (fake *FakeClient) CreateWritePermissionReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateWritePermissionReturnsOnCall(i int, result1 error) {
-	fake.createWritePermissionMutex.Lock()
-	defer fake.createWritePermissionMutex.Unlock()
 	fake.CreateWritePermissionStub = nil
 	if fake.createWritePermissionReturnsOnCall == nil {
 		fake.createWritePermissionReturnsOnCall = make(map[int]struct {
@@ -462,17 +409,15 @@ func (fake *FakeClient) DeleteKubernetesProvider(arg1 string) error {
 	fake.deleteKubernetesProviderArgsForCall = append(fake.deleteKubernetesProviderArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.DeleteKubernetesProviderStub
-	fakeReturns := fake.deleteKubernetesProviderReturns
 	fake.recordInvocation("DeleteKubernetesProvider", []interface{}{arg1})
 	fake.deleteKubernetesProviderMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.DeleteKubernetesProviderStub != nil {
+		return fake.DeleteKubernetesProviderStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fakeReturns.result1
+	return fake.deleteKubernetesProviderReturns.result1
 }
 
 func (fake *FakeClient) DeleteKubernetesProviderCallCount() int {
@@ -481,22 +426,13 @@ func (fake *FakeClient) DeleteKubernetesProviderCallCount() int {
 	return len(fake.deleteKubernetesProviderArgsForCall)
 }
 
-func (fake *FakeClient) DeleteKubernetesProviderCalls(stub func(string) error) {
-	fake.deleteKubernetesProviderMutex.Lock()
-	defer fake.deleteKubernetesProviderMutex.Unlock()
-	fake.DeleteKubernetesProviderStub = stub
-}
-
 func (fake *FakeClient) DeleteKubernetesProviderArgsForCall(i int) string {
 	fake.deleteKubernetesProviderMutex.RLock()
 	defer fake.deleteKubernetesProviderMutex.RUnlock()
-	argsForCall := fake.deleteKubernetesProviderArgsForCall[i]
-	return argsForCall.arg1
+	return fake.deleteKubernetesProviderArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) DeleteKubernetesProviderReturns(result1 error) {
-	fake.deleteKubernetesProviderMutex.Lock()
-	defer fake.deleteKubernetesProviderMutex.Unlock()
 	fake.DeleteKubernetesProviderStub = nil
 	fake.deleteKubernetesProviderReturns = struct {
 		result1 error
@@ -504,8 +440,6 @@ func (fake *FakeClient) DeleteKubernetesProviderReturns(result1 error) {
 }
 
 func (fake *FakeClient) DeleteKubernetesProviderReturnsOnCall(i int, result1 error) {
-	fake.deleteKubernetesProviderMutex.Lock()
-	defer fake.deleteKubernetesProviderMutex.Unlock()
 	fake.DeleteKubernetesProviderStub = nil
 	if fake.deleteKubernetesProviderReturnsOnCall == nil {
 		fake.deleteKubernetesProviderReturnsOnCall = make(map[int]struct {
@@ -523,17 +457,15 @@ func (fake *FakeClient) GetKubernetesProvider(arg1 string) (kubernetes.Provider,
 	fake.getKubernetesProviderArgsForCall = append(fake.getKubernetesProviderArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.GetKubernetesProviderStub
-	fakeReturns := fake.getKubernetesProviderReturns
 	fake.recordInvocation("GetKubernetesProvider", []interface{}{arg1})
 	fake.getKubernetesProviderMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.GetKubernetesProviderStub != nil {
+		return fake.GetKubernetesProviderStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.getKubernetesProviderReturns.result1, fake.getKubernetesProviderReturns.result2
 }
 
 func (fake *FakeClient) GetKubernetesProviderCallCount() int {
@@ -542,22 +474,13 @@ func (fake *FakeClient) GetKubernetesProviderCallCount() int {
 	return len(fake.getKubernetesProviderArgsForCall)
 }
 
-func (fake *FakeClient) GetKubernetesProviderCalls(stub func(string) (kubernetes.Provider, error)) {
-	fake.getKubernetesProviderMutex.Lock()
-	defer fake.getKubernetesProviderMutex.Unlock()
-	fake.GetKubernetesProviderStub = stub
-}
-
 func (fake *FakeClient) GetKubernetesProviderArgsForCall(i int) string {
 	fake.getKubernetesProviderMutex.RLock()
 	defer fake.getKubernetesProviderMutex.RUnlock()
-	argsForCall := fake.getKubernetesProviderArgsForCall[i]
-	return argsForCall.arg1
+	return fake.getKubernetesProviderArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) GetKubernetesProviderReturns(result1 kubernetes.Provider, result2 error) {
-	fake.getKubernetesProviderMutex.Lock()
-	defer fake.getKubernetesProviderMutex.Unlock()
 	fake.GetKubernetesProviderStub = nil
 	fake.getKubernetesProviderReturns = struct {
 		result1 kubernetes.Provider
@@ -566,8 +489,6 @@ func (fake *FakeClient) GetKubernetesProviderReturns(result1 kubernetes.Provider
 }
 
 func (fake *FakeClient) GetKubernetesProviderReturnsOnCall(i int, result1 kubernetes.Provider, result2 error) {
-	fake.getKubernetesProviderMutex.Lock()
-	defer fake.getKubernetesProviderMutex.Unlock()
 	fake.GetKubernetesProviderStub = nil
 	if fake.getKubernetesProviderReturnsOnCall == nil {
 		fake.getKubernetesProviderReturnsOnCall = make(map[int]struct {
@@ -587,17 +508,15 @@ func (fake *FakeClient) ListKubernetesAccountsBySpinnakerApp(arg1 string) ([]str
 	fake.listKubernetesAccountsBySpinnakerAppArgsForCall = append(fake.listKubernetesAccountsBySpinnakerAppArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListKubernetesAccountsBySpinnakerAppStub
-	fakeReturns := fake.listKubernetesAccountsBySpinnakerAppReturns
 	fake.recordInvocation("ListKubernetesAccountsBySpinnakerApp", []interface{}{arg1})
 	fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ListKubernetesAccountsBySpinnakerAppStub != nil {
+		return fake.ListKubernetesAccountsBySpinnakerAppStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listKubernetesAccountsBySpinnakerAppReturns.result1, fake.listKubernetesAccountsBySpinnakerAppReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCallCount() int {
@@ -606,22 +525,13 @@ func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCallCount() int {
 	return len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)
 }
 
-func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCalls(stub func(string) ([]string, error)) {
-	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
-	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
-	fake.ListKubernetesAccountsBySpinnakerAppStub = stub
-}
-
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppArgsForCall(i int) string {
 	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
 	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
-	argsForCall := fake.listKubernetesAccountsBySpinnakerAppArgsForCall[i]
-	return argsForCall.arg1
+	return fake.listKubernetesAccountsBySpinnakerAppArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturns(result1 []string, result2 error) {
-	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
-	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
 	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
 	fake.listKubernetesAccountsBySpinnakerAppReturns = struct {
 		result1 []string
@@ -630,8 +540,6 @@ func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturns(result1 []st
 }
 
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
-	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
 	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
 	if fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall == nil {
 		fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall = make(map[int]struct {
@@ -651,17 +559,15 @@ func (fake *FakeClient) ListKubernetesClustersByApplication(arg1 string) ([]kube
 	fake.listKubernetesClustersByApplicationArgsForCall = append(fake.listKubernetesClustersByApplicationArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListKubernetesClustersByApplicationStub
-	fakeReturns := fake.listKubernetesClustersByApplicationReturns
 	fake.recordInvocation("ListKubernetesClustersByApplication", []interface{}{arg1})
 	fake.listKubernetesClustersByApplicationMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ListKubernetesClustersByApplicationStub != nil {
+		return fake.ListKubernetesClustersByApplicationStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listKubernetesClustersByApplicationReturns.result1, fake.listKubernetesClustersByApplicationReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesClustersByApplicationCallCount() int {
@@ -670,22 +576,13 @@ func (fake *FakeClient) ListKubernetesClustersByApplicationCallCount() int {
 	return len(fake.listKubernetesClustersByApplicationArgsForCall)
 }
 
-func (fake *FakeClient) ListKubernetesClustersByApplicationCalls(stub func(string) ([]kubernetes.Resource, error)) {
-	fake.listKubernetesClustersByApplicationMutex.Lock()
-	defer fake.listKubernetesClustersByApplicationMutex.Unlock()
-	fake.ListKubernetesClustersByApplicationStub = stub
-}
-
 func (fake *FakeClient) ListKubernetesClustersByApplicationArgsForCall(i int) string {
 	fake.listKubernetesClustersByApplicationMutex.RLock()
 	defer fake.listKubernetesClustersByApplicationMutex.RUnlock()
-	argsForCall := fake.listKubernetesClustersByApplicationArgsForCall[i]
-	return argsForCall.arg1
+	return fake.listKubernetesClustersByApplicationArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) ListKubernetesClustersByApplicationReturns(result1 []kubernetes.Resource, result2 error) {
-	fake.listKubernetesClustersByApplicationMutex.Lock()
-	defer fake.listKubernetesClustersByApplicationMutex.Unlock()
 	fake.ListKubernetesClustersByApplicationStub = nil
 	fake.listKubernetesClustersByApplicationReturns = struct {
 		result1 []kubernetes.Resource
@@ -694,8 +591,6 @@ func (fake *FakeClient) ListKubernetesClustersByApplicationReturns(result1 []kub
 }
 
 func (fake *FakeClient) ListKubernetesClustersByApplicationReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
-	fake.listKubernetesClustersByApplicationMutex.Lock()
-	defer fake.listKubernetesClustersByApplicationMutex.Unlock()
 	fake.ListKubernetesClustersByApplicationStub = nil
 	if fake.listKubernetesClustersByApplicationReturnsOnCall == nil {
 		fake.listKubernetesClustersByApplicationReturnsOnCall = make(map[int]struct {
@@ -715,17 +610,15 @@ func (fake *FakeClient) ListKubernetesClustersByFields(arg1 ...string) ([]kubern
 	fake.listKubernetesClustersByFieldsArgsForCall = append(fake.listKubernetesClustersByFieldsArgsForCall, struct {
 		arg1 []string
 	}{arg1})
-	stub := fake.ListKubernetesClustersByFieldsStub
-	fakeReturns := fake.listKubernetesClustersByFieldsReturns
 	fake.recordInvocation("ListKubernetesClustersByFields", []interface{}{arg1})
 	fake.listKubernetesClustersByFieldsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1...)
+	if fake.ListKubernetesClustersByFieldsStub != nil {
+		return fake.ListKubernetesClustersByFieldsStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listKubernetesClustersByFieldsReturns.result1, fake.listKubernetesClustersByFieldsReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesClustersByFieldsCallCount() int {
@@ -734,22 +627,13 @@ func (fake *FakeClient) ListKubernetesClustersByFieldsCallCount() int {
 	return len(fake.listKubernetesClustersByFieldsArgsForCall)
 }
 
-func (fake *FakeClient) ListKubernetesClustersByFieldsCalls(stub func(...string) ([]kubernetes.Resource, error)) {
-	fake.listKubernetesClustersByFieldsMutex.Lock()
-	defer fake.listKubernetesClustersByFieldsMutex.Unlock()
-	fake.ListKubernetesClustersByFieldsStub = stub
-}
-
 func (fake *FakeClient) ListKubernetesClustersByFieldsArgsForCall(i int) []string {
 	fake.listKubernetesClustersByFieldsMutex.RLock()
 	defer fake.listKubernetesClustersByFieldsMutex.RUnlock()
-	argsForCall := fake.listKubernetesClustersByFieldsArgsForCall[i]
-	return argsForCall.arg1
+	return fake.listKubernetesClustersByFieldsArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) ListKubernetesClustersByFieldsReturns(result1 []kubernetes.Resource, result2 error) {
-	fake.listKubernetesClustersByFieldsMutex.Lock()
-	defer fake.listKubernetesClustersByFieldsMutex.Unlock()
 	fake.ListKubernetesClustersByFieldsStub = nil
 	fake.listKubernetesClustersByFieldsReturns = struct {
 		result1 []kubernetes.Resource
@@ -758,8 +642,6 @@ func (fake *FakeClient) ListKubernetesClustersByFieldsReturns(result1 []kubernet
 }
 
 func (fake *FakeClient) ListKubernetesClustersByFieldsReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
-	fake.listKubernetesClustersByFieldsMutex.Lock()
-	defer fake.listKubernetesClustersByFieldsMutex.Unlock()
 	fake.ListKubernetesClustersByFieldsStub = nil
 	if fake.listKubernetesClustersByFieldsReturnsOnCall == nil {
 		fake.listKubernetesClustersByFieldsReturnsOnCall = make(map[int]struct {
@@ -776,19 +658,16 @@ func (fake *FakeClient) ListKubernetesClustersByFieldsReturnsOnCall(i int, resul
 func (fake *FakeClient) ListKubernetesProviders() ([]kubernetes.Provider, error) {
 	fake.listKubernetesProvidersMutex.Lock()
 	ret, specificReturn := fake.listKubernetesProvidersReturnsOnCall[len(fake.listKubernetesProvidersArgsForCall)]
-	fake.listKubernetesProvidersArgsForCall = append(fake.listKubernetesProvidersArgsForCall, struct {
-	}{})
-	stub := fake.ListKubernetesProvidersStub
-	fakeReturns := fake.listKubernetesProvidersReturns
+	fake.listKubernetesProvidersArgsForCall = append(fake.listKubernetesProvidersArgsForCall, struct{}{})
 	fake.recordInvocation("ListKubernetesProviders", []interface{}{})
 	fake.listKubernetesProvidersMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ListKubernetesProvidersStub != nil {
+		return fake.ListKubernetesProvidersStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listKubernetesProvidersReturns.result1, fake.listKubernetesProvidersReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesProvidersCallCount() int {
@@ -797,15 +676,7 @@ func (fake *FakeClient) ListKubernetesProvidersCallCount() int {
 	return len(fake.listKubernetesProvidersArgsForCall)
 }
 
-func (fake *FakeClient) ListKubernetesProvidersCalls(stub func() ([]kubernetes.Provider, error)) {
-	fake.listKubernetesProvidersMutex.Lock()
-	defer fake.listKubernetesProvidersMutex.Unlock()
-	fake.ListKubernetesProvidersStub = stub
-}
-
 func (fake *FakeClient) ListKubernetesProvidersReturns(result1 []kubernetes.Provider, result2 error) {
-	fake.listKubernetesProvidersMutex.Lock()
-	defer fake.listKubernetesProvidersMutex.Unlock()
 	fake.ListKubernetesProvidersStub = nil
 	fake.listKubernetesProvidersReturns = struct {
 		result1 []kubernetes.Provider
@@ -814,8 +685,6 @@ func (fake *FakeClient) ListKubernetesProvidersReturns(result1 []kubernetes.Prov
 }
 
 func (fake *FakeClient) ListKubernetesProvidersReturnsOnCall(i int, result1 []kubernetes.Provider, result2 error) {
-	fake.listKubernetesProvidersMutex.Lock()
-	defer fake.listKubernetesProvidersMutex.Unlock()
 	fake.ListKubernetesProvidersStub = nil
 	if fake.listKubernetesProvidersReturnsOnCall == nil {
 		fake.listKubernetesProvidersReturnsOnCall = make(map[int]struct {
@@ -832,19 +701,16 @@ func (fake *FakeClient) ListKubernetesProvidersReturnsOnCall(i int, result1 []ku
 func (fake *FakeClient) ListKubernetesProvidersAndPermissions() ([]kubernetes.Provider, error) {
 	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
 	ret, specificReturn := fake.listKubernetesProvidersAndPermissionsReturnsOnCall[len(fake.listKubernetesProvidersAndPermissionsArgsForCall)]
-	fake.listKubernetesProvidersAndPermissionsArgsForCall = append(fake.listKubernetesProvidersAndPermissionsArgsForCall, struct {
-	}{})
-	stub := fake.ListKubernetesProvidersAndPermissionsStub
-	fakeReturns := fake.listKubernetesProvidersAndPermissionsReturns
+	fake.listKubernetesProvidersAndPermissionsArgsForCall = append(fake.listKubernetesProvidersAndPermissionsArgsForCall, struct{}{})
 	fake.recordInvocation("ListKubernetesProvidersAndPermissions", []interface{}{})
 	fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ListKubernetesProvidersAndPermissionsStub != nil {
+		return fake.ListKubernetesProvidersAndPermissionsStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listKubernetesProvidersAndPermissionsReturns.result1, fake.listKubernetesProvidersAndPermissionsReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCallCount() int {
@@ -853,15 +719,7 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCallCount() int {
 	return len(fake.listKubernetesProvidersAndPermissionsArgsForCall)
 }
 
-func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCalls(stub func() ([]kubernetes.Provider, error)) {
-	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
-	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
-	fake.ListKubernetesProvidersAndPermissionsStub = stub
-}
-
 func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturns(result1 []kubernetes.Provider, result2 error) {
-	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
-	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
 	fake.ListKubernetesProvidersAndPermissionsStub = nil
 	fake.listKubernetesProvidersAndPermissionsReturns = struct {
 		result1 []kubernetes.Provider
@@ -870,8 +728,6 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturns(result1 []k
 }
 
 func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturnsOnCall(i int, result1 []kubernetes.Provider, result2 error) {
-	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
-	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
 	fake.ListKubernetesProvidersAndPermissionsStub = nil
 	if fake.listKubernetesProvidersAndPermissionsReturnsOnCall == nil {
 		fake.listKubernetesProvidersAndPermissionsReturnsOnCall = make(map[int]struct {
@@ -885,89 +741,21 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturnsOnCall(i int
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespace(arg1 string, arg2 string, arg3 string) ([]string, error) {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
-	ret, specificReturn := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)]
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall = append(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall, struct {
-		arg1 string
-		arg2 string
-		arg3 string
-	}{arg1, arg2, arg3})
-	stub := fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub
-	fakeReturns := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns
-	fake.recordInvocation("ListKubernetesResourceNamesByAccountNameAndKindAndNamespace", []interface{}{arg1, arg2, arg3})
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceCallCount() int {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
-	return len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceCalls(stub func(string, string, string) ([]string, error)) {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
-	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = stub
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall(i int) (string, string, string) {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
-	argsForCall := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns(result1 []string, result2 error) {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
-	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns = struct {
-		result1 []string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
-	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
-	if fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall == nil {
-		fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall = make(map[int]struct {
-			result1 []string
-			result2 error
-		})
-	}
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[i] = struct {
-		result1 []string
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeClient) ListKubernetesResourcesByFields(arg1 ...string) ([]kubernetes.Resource, error) {
 	fake.listKubernetesResourcesByFieldsMutex.Lock()
 	ret, specificReturn := fake.listKubernetesResourcesByFieldsReturnsOnCall[len(fake.listKubernetesResourcesByFieldsArgsForCall)]
 	fake.listKubernetesResourcesByFieldsArgsForCall = append(fake.listKubernetesResourcesByFieldsArgsForCall, struct {
 		arg1 []string
 	}{arg1})
-	stub := fake.ListKubernetesResourcesByFieldsStub
-	fakeReturns := fake.listKubernetesResourcesByFieldsReturns
 	fake.recordInvocation("ListKubernetesResourcesByFields", []interface{}{arg1})
 	fake.listKubernetesResourcesByFieldsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1...)
+	if fake.ListKubernetesResourcesByFieldsStub != nil {
+		return fake.ListKubernetesResourcesByFieldsStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listKubernetesResourcesByFieldsReturns.result1, fake.listKubernetesResourcesByFieldsReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsCallCount() int {
@@ -976,22 +764,13 @@ func (fake *FakeClient) ListKubernetesResourcesByFieldsCallCount() int {
 	return len(fake.listKubernetesResourcesByFieldsArgsForCall)
 }
 
-func (fake *FakeClient) ListKubernetesResourcesByFieldsCalls(stub func(...string) ([]kubernetes.Resource, error)) {
-	fake.listKubernetesResourcesByFieldsMutex.Lock()
-	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
-	fake.ListKubernetesResourcesByFieldsStub = stub
-}
-
 func (fake *FakeClient) ListKubernetesResourcesByFieldsArgsForCall(i int) []string {
 	fake.listKubernetesResourcesByFieldsMutex.RLock()
 	defer fake.listKubernetesResourcesByFieldsMutex.RUnlock()
-	argsForCall := fake.listKubernetesResourcesByFieldsArgsForCall[i]
-	return argsForCall.arg1
+	return fake.listKubernetesResourcesByFieldsArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsReturns(result1 []kubernetes.Resource, result2 error) {
-	fake.listKubernetesResourcesByFieldsMutex.Lock()
-	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
 	fake.ListKubernetesResourcesByFieldsStub = nil
 	fake.listKubernetesResourcesByFieldsReturns = struct {
 		result1 []kubernetes.Resource
@@ -1000,8 +779,6 @@ func (fake *FakeClient) ListKubernetesResourcesByFieldsReturns(result1 []kuberne
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
-	fake.listKubernetesResourcesByFieldsMutex.Lock()
-	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
 	fake.ListKubernetesResourcesByFieldsStub = nil
 	if fake.listKubernetesResourcesByFieldsReturnsOnCall == nil {
 		fake.listKubernetesResourcesByFieldsReturnsOnCall = make(map[int]struct {
@@ -1021,17 +798,15 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskID(arg1 string) ([]kubernet
 	fake.listKubernetesResourcesByTaskIDArgsForCall = append(fake.listKubernetesResourcesByTaskIDArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListKubernetesResourcesByTaskIDStub
-	fakeReturns := fake.listKubernetesResourcesByTaskIDReturns
 	fake.recordInvocation("ListKubernetesResourcesByTaskID", []interface{}{arg1})
 	fake.listKubernetesResourcesByTaskIDMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ListKubernetesResourcesByTaskIDStub != nil {
+		return fake.ListKubernetesResourcesByTaskIDStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listKubernetesResourcesByTaskIDReturns.result1, fake.listKubernetesResourcesByTaskIDReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDCallCount() int {
@@ -1040,22 +815,13 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDCallCount() int {
 	return len(fake.listKubernetesResourcesByTaskIDArgsForCall)
 }
 
-func (fake *FakeClient) ListKubernetesResourcesByTaskIDCalls(stub func(string) ([]kubernetes.Resource, error)) {
-	fake.listKubernetesResourcesByTaskIDMutex.Lock()
-	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
-	fake.ListKubernetesResourcesByTaskIDStub = stub
-}
-
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDArgsForCall(i int) string {
 	fake.listKubernetesResourcesByTaskIDMutex.RLock()
 	defer fake.listKubernetesResourcesByTaskIDMutex.RUnlock()
-	argsForCall := fake.listKubernetesResourcesByTaskIDArgsForCall[i]
-	return argsForCall.arg1
+	return fake.listKubernetesResourcesByTaskIDArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturns(result1 []kubernetes.Resource, result2 error) {
-	fake.listKubernetesResourcesByTaskIDMutex.Lock()
-	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
 	fake.ListKubernetesResourcesByTaskIDStub = nil
 	fake.listKubernetesResourcesByTaskIDReturns = struct {
 		result1 []kubernetes.Resource
@@ -1064,8 +830,6 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturns(result1 []kuberne
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
-	fake.listKubernetesResourcesByTaskIDMutex.Lock()
-	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
 	fake.ListKubernetesResourcesByTaskIDStub = nil
 	if fake.listKubernetesResourcesByTaskIDReturnsOnCall == nil {
 		fake.listKubernetesResourcesByTaskIDReturnsOnCall = make(map[int]struct {
@@ -1079,23 +843,74 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturnsOnCall(i int, resu
 	}{result1, result2}
 }
 
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespace(arg1 string, arg2 string, arg3 string) ([]string, error) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
+	ret, specificReturn := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)]
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall = append(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("ListKubernetesResourceNamesByAccountNameAndKindAndNamespace", []interface{}{arg1, arg2, arg3})
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
+	if fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub != nil {
+		return fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns.result1, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns.result2
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceCallCount() int {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
+	return len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall(i int) (string, string, string) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
+	return fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg1, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg2, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg3
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns(result1 []string, result2 error) {
+	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
+	if fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall == nil {
+		fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[i] = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) ListReadGroupsByAccountName(arg1 string) ([]string, error) {
 	fake.listReadGroupsByAccountNameMutex.Lock()
 	ret, specificReturn := fake.listReadGroupsByAccountNameReturnsOnCall[len(fake.listReadGroupsByAccountNameArgsForCall)]
 	fake.listReadGroupsByAccountNameArgsForCall = append(fake.listReadGroupsByAccountNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListReadGroupsByAccountNameStub
-	fakeReturns := fake.listReadGroupsByAccountNameReturns
 	fake.recordInvocation("ListReadGroupsByAccountName", []interface{}{arg1})
 	fake.listReadGroupsByAccountNameMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ListReadGroupsByAccountNameStub != nil {
+		return fake.ListReadGroupsByAccountNameStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listReadGroupsByAccountNameReturns.result1, fake.listReadGroupsByAccountNameReturns.result2
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameCallCount() int {
@@ -1104,22 +919,13 @@ func (fake *FakeClient) ListReadGroupsByAccountNameCallCount() int {
 	return len(fake.listReadGroupsByAccountNameArgsForCall)
 }
 
-func (fake *FakeClient) ListReadGroupsByAccountNameCalls(stub func(string) ([]string, error)) {
-	fake.listReadGroupsByAccountNameMutex.Lock()
-	defer fake.listReadGroupsByAccountNameMutex.Unlock()
-	fake.ListReadGroupsByAccountNameStub = stub
-}
-
 func (fake *FakeClient) ListReadGroupsByAccountNameArgsForCall(i int) string {
 	fake.listReadGroupsByAccountNameMutex.RLock()
 	defer fake.listReadGroupsByAccountNameMutex.RUnlock()
-	argsForCall := fake.listReadGroupsByAccountNameArgsForCall[i]
-	return argsForCall.arg1
+	return fake.listReadGroupsByAccountNameArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameReturns(result1 []string, result2 error) {
-	fake.listReadGroupsByAccountNameMutex.Lock()
-	defer fake.listReadGroupsByAccountNameMutex.Unlock()
 	fake.ListReadGroupsByAccountNameStub = nil
 	fake.listReadGroupsByAccountNameReturns = struct {
 		result1 []string
@@ -1128,8 +934,6 @@ func (fake *FakeClient) ListReadGroupsByAccountNameReturns(result1 []string, res
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.listReadGroupsByAccountNameMutex.Lock()
-	defer fake.listReadGroupsByAccountNameMutex.Unlock()
 	fake.ListReadGroupsByAccountNameStub = nil
 	if fake.listReadGroupsByAccountNameReturnsOnCall == nil {
 		fake.listReadGroupsByAccountNameReturnsOnCall = make(map[int]struct {
@@ -1149,17 +953,15 @@ func (fake *FakeClient) ListWriteGroupsByAccountName(arg1 string) ([]string, err
 	fake.listWriteGroupsByAccountNameArgsForCall = append(fake.listWriteGroupsByAccountNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListWriteGroupsByAccountNameStub
-	fakeReturns := fake.listWriteGroupsByAccountNameReturns
 	fake.recordInvocation("ListWriteGroupsByAccountName", []interface{}{arg1})
 	fake.listWriteGroupsByAccountNameMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ListWriteGroupsByAccountNameStub != nil {
+		return fake.ListWriteGroupsByAccountNameStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fakeReturns.result1, fakeReturns.result2
+	return fake.listWriteGroupsByAccountNameReturns.result1, fake.listWriteGroupsByAccountNameReturns.result2
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameCallCount() int {
@@ -1168,22 +970,13 @@ func (fake *FakeClient) ListWriteGroupsByAccountNameCallCount() int {
 	return len(fake.listWriteGroupsByAccountNameArgsForCall)
 }
 
-func (fake *FakeClient) ListWriteGroupsByAccountNameCalls(stub func(string) ([]string, error)) {
-	fake.listWriteGroupsByAccountNameMutex.Lock()
-	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
-	fake.ListWriteGroupsByAccountNameStub = stub
-}
-
 func (fake *FakeClient) ListWriteGroupsByAccountNameArgsForCall(i int) string {
 	fake.listWriteGroupsByAccountNameMutex.RLock()
 	defer fake.listWriteGroupsByAccountNameMutex.RUnlock()
-	argsForCall := fake.listWriteGroupsByAccountNameArgsForCall[i]
-	return argsForCall.arg1
+	return fake.listWriteGroupsByAccountNameArgsForCall[i].arg1
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameReturns(result1 []string, result2 error) {
-	fake.listWriteGroupsByAccountNameMutex.Lock()
-	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
 	fake.ListWriteGroupsByAccountNameStub = nil
 	fake.listWriteGroupsByAccountNameReturns = struct {
 		result1 []string
@@ -1192,8 +985,6 @@ func (fake *FakeClient) ListWriteGroupsByAccountNameReturns(result1 []string, re
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.listWriteGroupsByAccountNameMutex.Lock()
-	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
 	fake.ListWriteGroupsByAccountNameStub = nil
 	if fake.listWriteGroupsByAccountNameReturnsOnCall == nil {
 		fake.listWriteGroupsByAccountNameReturnsOnCall = make(map[int]struct {
@@ -1232,12 +1023,12 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listKubernetesProvidersMutex.RUnlock()
 	fake.listKubernetesProvidersAndPermissionsMutex.RLock()
 	defer fake.listKubernetesProvidersAndPermissionsMutex.RUnlock()
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
 	fake.listKubernetesResourcesByFieldsMutex.RLock()
 	defer fake.listKubernetesResourcesByFieldsMutex.RUnlock()
 	fake.listKubernetesResourcesByTaskIDMutex.RLock()
 	defer fake.listKubernetesResourcesByTaskIDMutex.RUnlock()
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
 	fake.listReadGroupsByAccountNameMutex.RLock()
 	defer fake.listReadGroupsByAccountNameMutex.RUnlock()
 	fake.listWriteGroupsByAccountNameMutex.RLock()


### PR DESCRIPTION
Listing namespaces was not timing out at 5 seconds like we were specifying in the `ListOptions`, so we now pass in a context with a timeout to our `ListbyGVR` func.