### PR TITLE
add clouddriver logger

### DIFF
--- a/pkg/error.go
+++ b/pkg/error.go
@@ -1,9 +1,11 @@
 package clouddriver
 
 import (
+	"runtime"
 	"time"
 
 	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
 )
 
 // This represents a clouddriver error.
@@ -12,6 +14,13 @@ type ErrorResponse struct {
 	Message   string `json:"message"`
 	Status    int    `json:"status"`
 	Timestamp int64  `json:"timestamp"`
+}
+
+type ErrorMeta struct {
+	FuncName string
+	FileName string
+	GUID     string
+	LineNum  int
 }
 
 // Example.
@@ -32,6 +41,17 @@ func NewError(err, message string, status int) ErrorResponse {
 
 // Error attaches a given Go error to a gin context and sets its type to public.
 func Error(c *gin.Context, status int, err error) {
+	pc, fn, ln, _ := runtime.Caller(1)
+	m := ErrorMeta{
+		FuncName: runtime.FuncForPC(pc).Name(),
+		FileName: fn,
+		GUID:     uuid.New().String(),
+		LineNum:  ln,
+	}
 	c.Status(status)
-	_ = c.Error(err).SetType(gin.ErrorTypePublic)
+	_ = c.Error(err).SetType(gin.ErrorTypePublic).SetMeta(m)
+}
+
+func Meta(msg *gin.Error) ErrorMeta {
+	return msg.Meta.(ErrorMeta)
 }

--- a/pkg/error.go
+++ b/pkg/error.go
@@ -48,6 +48,7 @@ func Error(c *gin.Context, status int, err error) {
 		GUID:     uuid.New().String(),
 		LineNum:  ln,
 	}
+
 	c.Status(status)
 	_ = c.Error(err).SetType(gin.ErrorTypePublic).SetMeta(m)
 }

--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -3,7 +3,6 @@ package core
 import (
 	"encoding/base64"
 	"fmt"
-	"log"
 	"net/http"
 	"sort"
 	"strconv"
@@ -206,19 +205,19 @@ func listServerGroupManagers(c *gin.Context, wg *sync.WaitGroup, sgms chan Serve
 
 	provider, err := sc.GetKubernetesProvider(account)
 	if err != nil {
-		log.Println("unable to get kubernetes provider for account", account)
+		clouddriver.Log(err)
 		return
 	}
 
 	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
 	if err != nil {
-		log.Println("error decoding ca data for account", account)
+		clouddriver.Log(err)
 		return
 	}
 
 	token, err := ac.Token()
 	if err != nil {
-		log.Println("error getting token", err.Error())
+		clouddriver.Log(err)
 		return
 	}
 
@@ -232,7 +231,7 @@ func listServerGroupManagers(c *gin.Context, wg *sync.WaitGroup, sgms chan Serve
 
 	client, err := kc.NewClient(config)
 	if err != nil {
-		log.Println("error creating dynamic client for account", account)
+		clouddriver.Log(err)
 		return
 	}
 
@@ -243,13 +242,13 @@ func listServerGroupManagers(c *gin.Context, wg *sync.WaitGroup, sgms chan Serve
 
 	deployments, err := client.ListResource("deployments", lo)
 	if err != nil {
-		log.Println("error listing deployments:", err.Error())
+		clouddriver.Log(err)
 		return
 	}
 
 	replicaSets, err := client.ListResource("replicaSets", lo)
 	if err != nil {
-		log.Println("error listing replicaSets:", err.Error())
+		clouddriver.Log(err)
 		return
 	}
 
@@ -417,19 +416,19 @@ func listLoadBalancers(c *gin.Context, wg *sync.WaitGroup, lbs chan LoadBalancer
 
 	provider, err := sc.GetKubernetesProvider(account)
 	if err != nil {
-		log.Println("unable to get kubernetes provider for account", account)
+		clouddriver.Log(err)
 		return
 	}
 
 	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
 	if err != nil {
-		log.Println("error decoding ca data for account", account)
+		clouddriver.Log(err)
 		return
 	}
 
 	token, err := ac.Token()
 	if err != nil {
-		log.Println("error getting token", err.Error())
+		clouddriver.Log(err)
 		return
 	}
 
@@ -443,7 +442,7 @@ func listLoadBalancers(c *gin.Context, wg *sync.WaitGroup, lbs chan LoadBalancer
 
 	client, err := kc.NewClient(config)
 	if err != nil {
-		log.Println("error creating dynamic client for account", account)
+		clouddriver.Log(err)
 		return
 	}
 
@@ -457,7 +456,7 @@ func listLoadBalancers(c *gin.Context, wg *sync.WaitGroup, lbs chan LoadBalancer
 	for _, resource := range resources {
 		results, err := client.ListResource(resource, lo)
 		if err != nil {
-			log.Printf("error listing %s: %s", resource, err.Error())
+			clouddriver.Log(err)
 			continue
 		}
 
@@ -680,19 +679,19 @@ func listServerGroups(c *gin.Context, wg *sync.WaitGroup, sgs chan ServerGroup,
 
 	provider, err := sc.GetKubernetesProvider(account)
 	if err != nil {
-		log.Println("unable to get kubernetes provider for account", account)
+		clouddriver.Log(err)
 		return
 	}
 
 	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
 	if err != nil {
-		log.Println("error decoding ca data for account", account)
+		clouddriver.Log(err)
 		return
 	}
 
 	token, err := ac.Token()
 	if err != nil {
-		log.Println("error getting token", err.Error())
+		clouddriver.Log(err)
 		return
 	}
 
@@ -706,7 +705,7 @@ func listServerGroups(c *gin.Context, wg *sync.WaitGroup, sgs chan ServerGroup,
 
 	client, err := kc.NewClient(config)
 	if err != nil {
-		log.Println("error creating dynamic client for account", account)
+		clouddriver.Log(err)
 		return
 	}
 
@@ -717,14 +716,14 @@ func listServerGroups(c *gin.Context, wg *sync.WaitGroup, sgs chan ServerGroup,
 
 	pods, err := client.ListResource("pods", lo)
 	if err != nil {
-		log.Println("error listing pods:", err.Error())
+		clouddriver.Log(err)
 		return
 	}
 
 	for _, resource := range resources {
 		results, err := client.ListResource(resource, lo)
 		if err != nil {
-			log.Printf("error listing %s: %s\n", resource, err.Error())
+			clouddriver.Log(err)
 			continue
 		}
 

--- a/pkg/http/core/applications_test.go
+++ b/pkg/http/core/applications_test.go
@@ -59,7 +59,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error listing resources"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -153,7 +153,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error listing accounts"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -292,7 +292,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error listing accounts"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -408,7 +408,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error listing clusters"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -624,7 +624,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error listing accounts"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -808,7 +808,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting provider"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -824,7 +824,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("illegal base64 data at input byte 0"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -838,7 +838,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting token"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -852,7 +852,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("bad config"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -866,7 +866,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting resource"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -880,7 +880,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error listing pods"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -952,7 +952,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting provider"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -968,7 +968,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("illegal base64 data at input byte 0"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -982,7 +982,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting token"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -996,7 +996,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("bad config"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -1010,7 +1010,7 @@ var _ = Describe("Application", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting resource"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})

--- a/pkg/http/core/artifacts_test.go
+++ b/pkg/http/core/artifacts_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Artifacts", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error getting helm client"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -82,7 +82,7 @@ var _ = Describe("Artifacts", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting index"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -138,7 +138,7 @@ var _ = Describe("Artifacts", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error getting helm client"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -152,7 +152,7 @@ var _ = Describe("Artifacts", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting index"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -190,7 +190,7 @@ var _ = Describe("Artifacts", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("invalid character ';' looking for beginning of value"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -211,7 +211,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Bad Request"))
+					Expect(ce.Error).To(HavePrefix("Bad Request"))
 					Expect(ce.Message).To(Equal("error getting helm client"))
 					Expect(ce.Status).To(Equal(http.StatusBadRequest))
 				})
@@ -225,7 +225,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
+					Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 					Expect(ce.Message).To(Equal("error getting chart"))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
@@ -255,7 +255,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
+					Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 					Expect(ce.Message).To(Equal("illegal base64 data at input byte 3"))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
@@ -283,7 +283,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Bad Request"))
+					Expect(ce.Error).To(HavePrefix("Bad Request"))
 					Expect(ce.Message).To(Equal("error getting git client"))
 					Expect(ce.Status).To(Equal(http.StatusBadRequest))
 				})
@@ -299,7 +299,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Bad Request"))
+					Expect(ce.Error).To(HavePrefix("Bad Request"))
 					Expect(ce.Message).To(Equal(fmt.Sprintf("content URL https://bad-reference/api/v3/repos/homedepot/kubernetes-engine-samples/contents/hello-app/manifests/helloweb-deployment.yaml should have base URL %s",
 						fakeGithubClient.BaseURL.String())))
 					Expect(ce.Status).To(Equal(http.StatusBadRequest))
@@ -315,7 +315,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
+					Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 					Expect(ce.Message).To(Equal(fmt.Sprintf(`BaseURL must have a trailing slash, but "%s" does not`, fakeGithubClient.BaseURL.String())))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
@@ -366,7 +366,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
+					Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 					Expect(ce.Message).To(Equal(fmt.Sprintf(`Get "%s/api/v3/repos/homedepot/kubernetes-engine-samples/contents/hello-app/manifests/helloweb-deployment.yaml?ref=master": dial tcp %s: connect: connection refused`, url, addr)))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
@@ -403,7 +403,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
+					Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 					Expect(ce.Message).To(Equal("illegal base64 data at input byte 0"))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
@@ -485,7 +485,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Bad Request"))
+					Expect(ce.Error).To(HavePrefix("Bad Request"))
 					Expect(ce.Message).To(Equal("error getting http client"))
 					Expect(ce.Status).To(Equal(http.StatusBadRequest))
 				})
@@ -503,7 +503,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
+					Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 					Expect(ce.Message).To(Equal(fmt.Sprintf(`Get "%s/git-repo/archive/master.tar.gz": dial tcp %s: connect: connection refused`, url, addr)))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
@@ -523,7 +523,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
+					Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 					Expect(ce.Message).To(Equal(fmt.Sprintf(`error getting git/repo (repo: %s/git-repo, branch: master): 404 Not Found`, url)))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
@@ -609,7 +609,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Bad Request"))
+					Expect(ce.Error).To(HavePrefix("Bad Request"))
 					Expect(ce.Message).To(Equal("error getting http client"))
 					Expect(ce.Status).To(Equal(http.StatusBadRequest))
 				})
@@ -627,7 +627,7 @@ var _ = Describe("Artifacts", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
+					Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 					Expect(ce.Message).To(Equal(fmt.Sprintf(`Get "%s/hello": dial tcp %s: connect: connection refused`, url, addr)))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
@@ -657,7 +657,7 @@ var _ = Describe("Artifacts", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusNotImplemented))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Not Implemented"))
+				Expect(ce.Error).To(HavePrefix("Not Implemented"))
 				Expect(ce.Message).To(Equal("getting artifact of type unknown/type not implemented"))
 				Expect(ce.Status).To(Equal(http.StatusNotImplemented))
 			})

--- a/pkg/http/core/core_test.go
+++ b/pkg/http/core/core_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"io/ioutil"
+	"log"
 	"mime"
 	"net/http"
 	"net/http/httptest"
@@ -200,6 +201,8 @@ func setup() {
 	server.Setup(r, c)
 	svr = httptest.NewServer(r)
 	body = &bytes.Buffer{}
+	// Ignore log output.
+	log.SetOutput(ioutil.Discard)
 }
 
 func teardown() {

--- a/pkg/http/core/credentials.go
+++ b/pkg/http/core/credentials.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"encoding/base64"
-	"log"
 	"net/http"
 	"strings"
 	"sync"
@@ -147,13 +146,13 @@ func listNamespaces(provider kubernetes.Provider,
 
 	cd, err := base64.StdEncoding.DecodeString(provider.CAData)
 	if err != nil {
-		log.Println("/credentials error decoding provider ca data for "+provider.Name+":", err.Error())
+		clouddriver.Log(err)
 		return
 	}
 
 	token, err := ac.Token()
 	if err != nil {
-		log.Println("error getting arcade token:", err.Error())
+		clouddriver.Log(err)
 		return
 	}
 
@@ -167,7 +166,7 @@ func listNamespaces(provider kubernetes.Provider,
 
 	client, err := kc.NewClient(config)
 	if err != nil {
-		log.Println("/credentials error creating dynamic account:", err.Error())
+		clouddriver.Log(err)
 		return
 	}
 
@@ -184,7 +183,7 @@ func listNamespaces(provider kubernetes.Provider,
 		TimeoutSeconds: &listNamespacesTimeout,
 	})
 	if err != nil {
-		log.Println("/credentials error listing using kubernetes account "+provider.Name+":", err.Error())
+		clouddriver.Log(err)
 		return
 	}
 

--- a/pkg/http/core/credentials_test.go
+++ b/pkg/http/core/credentials_test.go
@@ -69,7 +69,7 @@ var _ = Describe("Credential", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
+					Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 					Expect(ce.Message).To(Equal("error listing providers"))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
@@ -155,7 +155,7 @@ var _ = Describe("Credential", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Internal Server Error"))
+					Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 					Expect(ce.Message).To(Equal("error listing providers"))
 					Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 				})
@@ -299,7 +299,7 @@ var _ = Describe("Credential", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting kubernetes provider"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -313,7 +313,7 @@ var _ = Describe("Credential", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error listing read groups"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -327,7 +327,7 @@ var _ = Describe("Credential", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error listing write groups"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})

--- a/pkg/http/core/manifest_test.go
+++ b/pkg/http/core/manifest_test.go
@@ -35,7 +35,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting provider"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -51,7 +51,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("illegal base64 data at input byte 0"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -65,7 +65,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting token"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -79,7 +79,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("bad config"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -93,7 +93,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting manifest"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -132,7 +132,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting provider"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -148,7 +148,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("illegal base64 data at input byte 0"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -162,7 +162,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting token"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -176,7 +176,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("bad config"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -190,7 +190,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting gvr"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -204,7 +204,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error listing resources"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -218,7 +218,7 @@ var _ = Describe("Manifest", func() {
 			It("returns status not found", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusNotFound))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Not Found"))
+				Expect(ce.Error).To(HavePrefix("Not Found"))
 				Expect(ce.Message).To(Equal("no resources found for cluster deployment test-deployment"))
 				Expect(ce.Status).To(Equal(http.StatusNotFound))
 			})
@@ -249,7 +249,7 @@ var _ = Describe("Manifest", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Bad Request"))
+					Expect(ce.Error).To(HavePrefix("Bad Request"))
 					Expect(ce.Message).To(Equal("requested target \"Second Newest\" for cluster deployment test-deployment, but only one resource was found"))
 					Expect(ce.Status).To(Equal(http.StatusBadRequest))
 				})
@@ -287,7 +287,7 @@ var _ = Describe("Manifest", func() {
 				It("returns an error", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Bad Request"))
+					Expect(ce.Error).To(HavePrefix("Bad Request"))
 					Expect(ce.Message).To(Equal("requested target \"Oldest\" for cluster deployment test-deployment, but only one resource was found"))
 					Expect(ce.Status).To(Equal(http.StatusBadRequest))
 				})
@@ -309,7 +309,7 @@ var _ = Describe("Manifest", func() {
 				It("succeeds", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusNotImplemented))
 					ce := getClouddriverError()
-					Expect(ce.Error).To(Equal("Not Implemented"))
+					Expect(ce.Error).To(HavePrefix("Not Implemented"))
 					Expect(ce.Message).To(Equal("requested target \"not_supported\" for cluster deployment test-deployment is not supported"))
 					Expect(ce.Status).To(Equal(http.StatusNotImplemented))
 				})

--- a/pkg/http/core/ops_test.go
+++ b/pkg/http/core/ops_test.go
@@ -39,7 +39,7 @@ var _ = Describe("Kubernetes", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("invalid character 'd' looking for beginning of value"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -53,7 +53,7 @@ var _ = Describe("Kubernetes", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error getting kubernetes provider"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -70,7 +70,7 @@ var _ = Describe("Kubernetes", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error getting kubernetes provider"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -87,7 +87,7 @@ var _ = Describe("Kubernetes", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error getting kubernetes provider"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -104,7 +104,7 @@ var _ = Describe("Kubernetes", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error converting to unstructured"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -121,7 +121,7 @@ var _ = Describe("Kubernetes", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error getting kubernetes provider"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -138,7 +138,7 @@ var _ = Describe("Kubernetes", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error getting kubernetes provider"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -156,7 +156,7 @@ var _ = Describe("Kubernetes", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error getting kubernetes provider"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -173,7 +173,7 @@ var _ = Describe("Kubernetes", func() {
 			It("returns an error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error getting kubernetes provider"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})

--- a/pkg/http/core/search_test.go
+++ b/pkg/http/core/search_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Search", func() {
 			It("returns status bad request", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("must provide query params 'q' to specify the namespace and 'type' to specify the kind"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})

--- a/pkg/http/core/task_test.go
+++ b/pkg/http/core/task_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Task", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Bad Request"))
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
 				Expect(ce.Message).To(Equal("error listing resources"))
 				Expect(ce.Status).To(Equal(http.StatusBadRequest))
 			})
@@ -57,7 +57,7 @@ var _ = Describe("Task", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("bad config"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -71,7 +71,7 @@ var _ = Describe("Task", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting provider"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -87,7 +87,7 @@ var _ = Describe("Task", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("illegal base64 data at input byte 0"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -101,7 +101,7 @@ var _ = Describe("Task", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting token"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
@@ -131,7 +131,7 @@ var _ = Describe("Task", func() {
 			It("returns status internal server error", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
 				ce := getClouddriverError()
-				Expect(ce.Error).To(Equal("Internal Server Error"))
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
 				Expect(ce.Message).To(Equal("error getting resource"))
 				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})

--- a/pkg/logger.go
+++ b/pkg/logger.go
@@ -31,6 +31,7 @@ func Log(err error, meta ...ErrorMeta) {
 		}
 		meta = append(meta, m)
 	}
+
 	m := meta[0]
 
 	log.SetFlags(0)

--- a/pkg/logger.go
+++ b/pkg/logger.go
@@ -1,0 +1,46 @@
+package clouddriver
+
+import (
+	"log"
+	"runtime"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+const (
+	white = "\033[90;47m"
+	reset = "\033[0m"
+)
+
+// Log logs a given error. It checks if meta was passed in. If
+// no meta was passed in, it defines the meta as the function and
+// line number of what called the Log func.
+//
+// See https://stackoverflow.com/questions/24809287/how-do-you-get-a-golang-program-to-print-the-line-number-of-the-error-it-just-ca
+func Log(err error, meta ...ErrorMeta) {
+	if len(meta) == 0 {
+		// notice that we're using 1, so it will actually log the where
+		// the error happened, 0 = this function, we don't want that.
+		pc, fn, ln, _ := runtime.Caller(1)
+		m := ErrorMeta{
+			FuncName: runtime.FuncForPC(pc).Name(),
+			FileName: fn,
+			GUID:     uuid.New().String(),
+			LineNum:  ln,
+		}
+		meta = append(meta, m)
+	}
+	m := meta[0]
+
+	log.SetFlags(0)
+	log.Printf("[CLOUDDRIVER] %v |%s %s %s| %s | %s | %s:%d | %v\n",
+		time.Now().In(time.UTC).Format("2006/01/02 - 15:04:05"),
+		white, "LOG", reset,
+		m.GUID,
+		m.FuncName,
+		m.FileName,
+		m.LineNum,
+		err,
+	)
+}

--- a/pkg/middleware/error.go
+++ b/pkg/middleware/error.go
@@ -16,16 +16,19 @@ func HandleError() gin.HandlerFunc {
 		if err != nil {
 			statusCode := c.Writer.Status()
 			text := http.StatusText(statusCode)
+
 			if statusCode >= http.StatusInternalServerError {
 				meta := clouddriver.Meta(err)
 				clouddriver.Log(err, meta)
 				text += " (error ID: " + meta.GUID + ")"
 			}
+
 			ce := clouddriver.NewError(
 				text,
 				err.Error(),
 				statusCode,
 			)
+
 			c.JSON(c.Writer.Status(), ce)
 		}
 	}

--- a/pkg/middleware/log.go
+++ b/pkg/middleware/log.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/fatih/color"
 	"github.com/gin-gonic/gin"
+	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 )
 
 var (
@@ -33,7 +34,7 @@ func LogRequest() gin.HandlerFunc {
 		clone.Body = ioutil.NopCloser(bytes.NewReader(buf.Bytes()))
 
 		if err != nil {
-			log.Println("[MIDDLEWARE] error getting request body in verbose request logger:", err.Error())
+			clouddriver.Log(err)
 		} else {
 			b, _ := ioutil.ReadAll(clone.Body)
 			buffer := &bytes.Buffer{}


### PR DESCRIPTION
- Appends a unique GUID to all server side API errors which are returned to the UI
- Logs this error along with the GUID
- Logs the file, function, and line number that threw the error

This will be useful for when users complain about receiving an error that doesn't say much. We can now grep the logs for the error ID to show exactly where an error occurred in clouddriver and what that error is.

Clouddriver error logs look like this:
![image](https://user-images.githubusercontent.com/7597848/101726940-86b2f780-3a81-11eb-8695-ee70d9a86ef3.png)
