### PR TITLE
add logic to sort manifests by priority

### DIFF
--- a/pkg/http/core/kubernetes/deploy.go
+++ b/pkg/http/core/kubernetes/deploy.go
@@ -4,10 +4,11 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"github.com/homedepot/go-clouddriver/pkg/util"
 	"net/http"
 	"strings"
 	"unicode"
+
+	"github.com/homedepot/go-clouddriver/pkg/util"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -87,6 +88,13 @@ func Deploy(c *gin.Context, dm DeployManifestRequest) {
 		} else {
 			manifests = append(manifests, u.Object)
 		}
+	}
+
+	// Sort the manifests by their kind's priority.
+	manifests, err = kc.SortManifests(manifests)
+	if err != nil {
+		clouddriver.Error(c, http.StatusInternalServerError, err)
+		return
 	}
 
 	for _, manifest := range manifests {

--- a/pkg/http/core/kubernetes/kubernetes_test.go
+++ b/pkg/http/core/kubernetes/kubernetes_test.go
@@ -79,6 +79,12 @@ func setup() {
 	fakeKubeController = &kubernetesfakes.FakeController{}
 	fakeKubeController.NewClientReturns(fakeKubeClient, nil)
 	fakeKubeController.ToUnstructuredReturns(&fakeUnstructured, nil)
+	fakeKubeController.SortManifestsReturns([]map[string]interface{}{
+		{
+			"kind":       "Pod",
+			"apiVersion": "v1",
+		},
+	}, nil)
 
 	req, _ := http.NewRequest(http.MethodGet, "", nil)
 	req.Header.Set("X-Spinnaker-Application", "test-app")

--- a/pkg/kubernetes/controller.go
+++ b/pkg/kubernetes/controller.go
@@ -24,6 +24,7 @@ type Controller interface {
 	ToUnstructured(map[string]interface{}) (*unstructured.Unstructured, error)
 	AddSpinnakerAnnotations(u *unstructured.Unstructured, application string) error
 	AddSpinnakerLabels(u *unstructured.Unstructured, application string) error
+	SortManifests([]map[string]interface{}) ([]map[string]interface{}, error)
 }
 
 func NewController() Controller {

--- a/pkg/kubernetes/kubernetesfakes/fake_controller.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_controller.go
@@ -60,6 +60,19 @@ type FakeController struct {
 	addSpinnakerLabelsReturnsOnCall map[int]struct {
 		result1 error
 	}
+	SortManifestsStub        func([]map[string]interface{}) ([]map[string]interface{}, error)
+	sortManifestsMutex       sync.RWMutex
+	sortManifestsArgsForCall []struct {
+		arg1 []map[string]interface{}
+	}
+	sortManifestsReturns struct {
+		result1 []map[string]interface{}
+		result2 error
+	}
+	sortManifestsReturnsOnCall map[int]struct {
+		result1 []map[string]interface{}
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -264,6 +277,62 @@ func (fake *FakeController) AddSpinnakerLabelsReturnsOnCall(i int, result1 error
 	}{result1}
 }
 
+func (fake *FakeController) SortManifests(arg1 []map[string]interface{}) ([]map[string]interface{}, error) {
+	var arg1Copy []map[string]interface{}
+	if arg1 != nil {
+		arg1Copy = make([]map[string]interface{}, len(arg1))
+		copy(arg1Copy, arg1)
+	}
+	fake.sortManifestsMutex.Lock()
+	ret, specificReturn := fake.sortManifestsReturnsOnCall[len(fake.sortManifestsArgsForCall)]
+	fake.sortManifestsArgsForCall = append(fake.sortManifestsArgsForCall, struct {
+		arg1 []map[string]interface{}
+	}{arg1Copy})
+	fake.recordInvocation("SortManifests", []interface{}{arg1Copy})
+	fake.sortManifestsMutex.Unlock()
+	if fake.SortManifestsStub != nil {
+		return fake.SortManifestsStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fake.sortManifestsReturns.result1, fake.sortManifestsReturns.result2
+}
+
+func (fake *FakeController) SortManifestsCallCount() int {
+	fake.sortManifestsMutex.RLock()
+	defer fake.sortManifestsMutex.RUnlock()
+	return len(fake.sortManifestsArgsForCall)
+}
+
+func (fake *FakeController) SortManifestsArgsForCall(i int) []map[string]interface{} {
+	fake.sortManifestsMutex.RLock()
+	defer fake.sortManifestsMutex.RUnlock()
+	return fake.sortManifestsArgsForCall[i].arg1
+}
+
+func (fake *FakeController) SortManifestsReturns(result1 []map[string]interface{}, result2 error) {
+	fake.SortManifestsStub = nil
+	fake.sortManifestsReturns = struct {
+		result1 []map[string]interface{}
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeController) SortManifestsReturnsOnCall(i int, result1 []map[string]interface{}, result2 error) {
+	fake.SortManifestsStub = nil
+	if fake.sortManifestsReturnsOnCall == nil {
+		fake.sortManifestsReturnsOnCall = make(map[int]struct {
+			result1 []map[string]interface{}
+			result2 error
+		})
+	}
+	fake.sortManifestsReturnsOnCall[i] = struct {
+		result1 []map[string]interface{}
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeController) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -275,6 +344,8 @@ func (fake *FakeController) Invocations() map[string][][]interface{} {
 	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
 	fake.addSpinnakerLabelsMutex.RLock()
 	defer fake.addSpinnakerLabelsMutex.RUnlock()
+	fake.sortManifestsMutex.RLock()
+	defer fake.sortManifestsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/kubernetes/sort.go
+++ b/pkg/kubernetes/sort.go
@@ -1,0 +1,130 @@
+package kubernetes
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+const (
+	// Priorities of Kubernetes resources are defined in the source code here:
+	// https://github.com/spinnaker/clouddriver/blob/master/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java#L129
+	lowestPriority                       = 1000
+	workloadAttachmentPriority           = 110
+	workloadControllerPriority           = 100
+	workloadPriority                     = 100
+	workloadModifierPriority             = 90
+	pdbPriority                          = 90
+	apiServicePriority                   = 80
+	networkResourcePriority              = 70
+	mountableDataPriority                = 50
+	mountableDataBackingResourcePriority = 40
+	serviceAccountPriority               = 40
+	storageClassPriority                 = 40
+	admissionPriority                    = 40
+	resourceDefinitionPriority           = 30
+	roleBindingPriority                  = 30
+	rolePriority                         = 20
+	namespacePriority                    = 0
+)
+
+var (
+	// Define the priorities in a case insensitive map.
+	// A given kind's priority can be found in each of the Kubernetes<KIND>Handler.java files here:
+	// https://github.com/spinnaker/clouddriver/tree/master/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler
+	priorities = map[string]int{
+		strings.ToLower("ApiService"):         apiServicePriority,
+		strings.ToLower("ClusterRoleBinding"): roleBindingPriority,
+		strings.ToLower("ClusterRoleHandler"): rolePriority,
+		strings.ToLower("ConfigMap"):          mountableDataPriority,
+		// Controller revisions cannot be deployed.
+		// See https://github.com/spinnaker/clouddriver/blob/master/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesControllerRevisionHandler.java#L33
+		strings.ToLower("ControllerRevision"):       lowestPriority,
+		strings.ToLower("CronJob"):                  workloadControllerPriority,
+		strings.ToLower("CustomResourceDefinition"): resourceDefinitionPriority,
+		strings.ToLower("DaemonSet"):                workloadControllerPriority,
+		strings.ToLower("Deployment"):               workloadControllerPriority,
+		// Events cannot be deployed.
+		// See https://github.com/spinnaker/clouddriver/blob/master/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesEventHandler.java#L48
+		strings.ToLower("Event"):                          lowestPriority,
+		strings.ToLower("HorizontalPodAutoscaler"):        workloadAttachmentPriority,
+		strings.ToLower("Ingress"):                        networkResourcePriority,
+		strings.ToLower("Job"):                            workloadControllerPriority,
+		strings.ToLower("LimitRange"):                     workloadModifierPriority,
+		strings.ToLower("MutatingWebhookConfiguration"):   admissionPriority,
+		strings.ToLower("Namespace"):                      namespacePriority,
+		strings.ToLower("NetworkPolicy"):                  networkResourcePriority,
+		strings.ToLower("PersistentVolumeClaim"):          mountableDataPriority,
+		strings.ToLower("PersistentVolume"):               mountableDataBackingResourcePriority,
+		strings.ToLower("PodDisruptionBudget"):            pdbPriority,
+		strings.ToLower("Pod"):                            workloadPriority,
+		strings.ToLower("PodPreset"):                      workloadModifierPriority,
+		strings.ToLower("PodSecurityPolicy"):              workloadModifierPriority,
+		strings.ToLower("ReplicaSet"):                     workloadControllerPriority,
+		strings.ToLower("RoleBinding"):                    roleBindingPriority,
+		strings.ToLower("Role"):                           rolePriority,
+		strings.ToLower("Secret"):                         mountableDataPriority,
+		strings.ToLower("ServiceAccount"):                 serviceAccountPriority,
+		strings.ToLower("Service"):                        networkResourcePriority,
+		strings.ToLower("StatefulSet"):                    workloadControllerPriority,
+		strings.ToLower("StorageClass"):                   storageClassPriority,
+		strings.ToLower("UnregisteredClusterResource"):    lowestPriority,
+		strings.ToLower("ValidatingWebhookConfiguration"): admissionPriority,
+	}
+)
+
+// SortManifests takes in a list of manifests and sorts them by the priority of their kind.
+// The kind's priorities are defined above in the var 'priorities'. Lower numbered priorities
+// should be deployed first.
+func (c *controller) SortManifests(manifests []map[string]interface{}) ([]map[string]interface{}, error) {
+	// Map of priorities to lists of manifests.
+	manifestMap := map[int][]map[string]interface{}{
+		0:    []map[string]interface{}{},
+		20:   []map[string]interface{}{},
+		30:   []map[string]interface{}{},
+		40:   []map[string]interface{}{},
+		50:   []map[string]interface{}{},
+		70:   []map[string]interface{}{},
+		80:   []map[string]interface{}{},
+		90:   []map[string]interface{}{},
+		100:  []map[string]interface{}{},
+		110:  []map[string]interface{}{},
+		1000: []map[string]interface{}{},
+	}
+
+	for _, manifest := range manifests {
+		u, err := c.ToUnstructured(manifest)
+		if err != nil {
+			return nil, fmt.Errorf("kubernetes: error sorting manifests: %w", err)
+		}
+
+		if _, ok := priorities[strings.ToLower(u.GetKind())]; ok {
+			priority := priorities[strings.ToLower(u.GetKind())]
+			s := manifestMap[priority]
+			s = append(s, manifest)
+			manifestMap[priority] = s
+		} else {
+			s := manifestMap[lowestPriority]
+			s = append(s, manifest)
+			manifestMap[lowestPriority] = s
+		}
+	}
+
+	// Store the keys in slice in sorted asc order.
+	keys := make([]int, len(manifestMap))
+	i := 0
+
+	for k := range manifestMap {
+		keys[i] = k
+		i++
+	}
+
+	sort.Ints(keys)
+
+	sortedManifests := []map[string]interface{}{}
+	for _, key := range keys {
+		sortedManifests = append(sortedManifests, manifestMap[key]...)
+	}
+
+	return sortedManifests, nil
+}

--- a/pkg/kubernetes/sort_test.go
+++ b/pkg/kubernetes/sort_test.go
@@ -1,0 +1,185 @@
+package kubernetes_test
+
+import (
+	. "github.com/homedepot/go-clouddriver/pkg/kubernetes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Sort", func() {
+	var (
+		c               Controller
+		err             error
+		m               []map[string]interface{}
+		sortedManifests []map[string]interface{}
+	)
+
+	BeforeEach(func() {
+		c = NewController()
+	})
+
+	JustBeforeEach(func() {
+		sortedManifests, err = c.SortManifests(m)
+	})
+
+	Describe("#SortManifests", func() {
+		When("the manifests are unsorted", func() {
+			BeforeEach(func() {
+				m = []map[string]interface{}{
+					{
+						"kind": "ApiService",
+					},
+					{
+						"kind": "ClusterRoleBinding",
+					},
+					{
+						"kind": "ClusterRoleHandler",
+					},
+					{
+						"kind": "ConfigMap",
+					},
+					{
+						"kind": "ControllerRevision",
+					},
+					{
+						"kind": "CronJob",
+					},
+					{
+						"kind": "CustomResourceDefinition",
+					},
+					{
+						"kind": "DaemonSet",
+					},
+					{
+						"kind": "Deployment",
+					},
+					{
+						"kind": "Event",
+					},
+					{
+						"kind": "HorizontalPodAutoscaler",
+					},
+					{
+						"kind": "Ingress",
+					},
+					{
+						"kind": "Job",
+					},
+					{
+						"kind": "LimitRange",
+					},
+					{
+						"kind": "MutatingWebhookConfiguration",
+					},
+					{
+						"kind": "Namespace",
+					},
+					{
+						"kind": "NetworkPolicy",
+					},
+					{
+						"kind": "PersistentVolumeClaim",
+					},
+					{
+						"kind": "PersistentVolume",
+					},
+					{
+						"kind": "PodDisruptionBudget",
+					},
+					{
+						"kind": "Pod",
+					},
+					{
+						"kind": "PodPreset",
+					},
+					{
+						"kind": "PodSecurityPolicy",
+					},
+					{
+						"kind": "ReplicaSet",
+					},
+					{
+						"kind": "RoleBinding",
+					},
+					{
+						"kind": "Role",
+					},
+					{
+						"kind": "Secret",
+					},
+					{
+						"kind": "ServiceAccount",
+					},
+					{
+						"kind": "Service",
+					},
+					{
+						"kind": "StatefulSet",
+					},
+					{
+						"kind": "StorageClass",
+					},
+					{
+						"kind": "UnregisteredClusterResource",
+					},
+					{
+						"kind": "ValidatingWebhookConfiguration",
+					},
+					{
+						"kind": "Unknown",
+					},
+				}
+			})
+
+			It("sorts the manifests", func() {
+				Expect(err).To(BeNil())
+				Expect(sortedManifests).To(HaveLen(len(m)))
+				// priority 0
+				Expect(sortedManifests[0]["kind"].(string)).To(Equal("Namespace"))
+				// priority 20
+				Expect(sortedManifests[1]["kind"].(string)).To(Equal("ClusterRoleHandler"))
+				Expect(sortedManifests[2]["kind"].(string)).To(Equal("Role"))
+				// priority 30
+				Expect(sortedManifests[3]["kind"].(string)).To(Equal("ClusterRoleBinding"))
+				Expect(sortedManifests[4]["kind"].(string)).To(Equal("CustomResourceDefinition"))
+				Expect(sortedManifests[5]["kind"].(string)).To(Equal("RoleBinding"))
+				// priority 40
+				Expect(sortedManifests[6]["kind"].(string)).To(Equal("MutatingWebhookConfiguration"))
+				Expect(sortedManifests[7]["kind"].(string)).To(Equal("PersistentVolume"))
+				Expect(sortedManifests[8]["kind"].(string)).To(Equal("ServiceAccount"))
+				Expect(sortedManifests[9]["kind"].(string)).To(Equal("StorageClass"))
+				Expect(sortedManifests[10]["kind"].(string)).To(Equal("ValidatingWebhookConfiguration"))
+				// priority 50
+				Expect(sortedManifests[11]["kind"].(string)).To(Equal("ConfigMap"))
+				Expect(sortedManifests[12]["kind"].(string)).To(Equal("PersistentVolumeClaim"))
+				Expect(sortedManifests[13]["kind"].(string)).To(Equal("Secret"))
+				// priority 70
+				Expect(sortedManifests[14]["kind"].(string)).To(Equal("Ingress"))
+				Expect(sortedManifests[15]["kind"].(string)).To(Equal("NetworkPolicy"))
+				Expect(sortedManifests[16]["kind"].(string)).To(Equal("Service"))
+				// priority 80
+				Expect(sortedManifests[17]["kind"].(string)).To(Equal("ApiService"))
+				// priority 90
+				Expect(sortedManifests[18]["kind"].(string)).To(Equal("LimitRange"))
+				Expect(sortedManifests[19]["kind"].(string)).To(Equal("PodDisruptionBudget"))
+				Expect(sortedManifests[20]["kind"].(string)).To(Equal("PodPreset"))
+				Expect(sortedManifests[21]["kind"].(string)).To(Equal("PodSecurityPolicy"))
+				// priority 100
+				Expect(sortedManifests[22]["kind"].(string)).To(Equal("CronJob"))
+				Expect(sortedManifests[23]["kind"].(string)).To(Equal("DaemonSet"))
+				Expect(sortedManifests[24]["kind"].(string)).To(Equal("Deployment"))
+				Expect(sortedManifests[25]["kind"].(string)).To(Equal("Job"))
+				Expect(sortedManifests[26]["kind"].(string)).To(Equal("Pod"))
+				Expect(sortedManifests[27]["kind"].(string)).To(Equal("ReplicaSet"))
+				Expect(sortedManifests[28]["kind"].(string)).To(Equal("StatefulSet"))
+				// priority 110
+				Expect(sortedManifests[29]["kind"].(string)).To(Equal("HorizontalPodAutoscaler"))
+				// priority 1000
+				Expect(sortedManifests[30]["kind"].(string)).To(Equal("ControllerRevision"))
+				Expect(sortedManifests[31]["kind"].(string)).To(Equal("Event"))
+				Expect(sortedManifests[32]["kind"].(string)).To(Equal("UnregisteredClusterResource"))
+				Expect(sortedManifests[33]["kind"].(string)).To(Equal("Unknown"))
+			})
+		})
+	})
+})


### PR DESCRIPTION
- we now sort a list of manifests by their kind's priority before applying.

This is important when applying multiple different types of manifests. For example, kind `Namespace` has the lowest number priority and is therefore deployed first. This makes sense as other manifests may be deployed to this namespace. Failing to sort the manifests properly would result in a short-circuit failure where the deployment could not succeed (as the manifest would rely on the namespace existing).

The sort priority is taken from the source code [here](https://github.com/spinnaker/clouddriver/blob/master/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/handler/KubernetesHandler.java#L128).

NOTE: this is a patch on release 0.9.x.