### PR TITLE
use a resources defined URLs when fetching a chart

### DIFF
--- a/pkg/helm/client.go
+++ b/pkg/helm/client.go
@@ -14,6 +14,10 @@ const (
 	ClientInstanceKey = `HelmClient`
 )
 
+var (
+	errUnableToFindResource = errors.New("unable to find resource")
+)
+
 type Index struct {
 	APIVersion string                `json:"apiVersion" yaml:"apiVersion"`
 	Entries    map[string][]Resource `json:"entries" yaml:"entries"`
@@ -102,15 +106,22 @@ func (c *client) GetIndex() (Index, error) {
 }
 
 func (c *client) GetChart(name, version string) ([]byte, error) {
-	var err error
+	var (
+		err error
+		b   []byte
+	)
 
-	b := []byte{}
-	resource := findResource(name, version)
+	resource, err := c.findResource(name, version)
+	if err != nil {
+		return b, fmt.Errorf("helm: unable to find chart %s-%s: %w", name, version, err)
+	}
 
-	// Loop through all the resource's URLs to get the chart,
-	// including a default url of the format https://helm.example/chart_name-chart_version.tgz
-	urls := append(resource.Urls, fmt.Sprintf("%s/%s-%s.tgz", c.u, name, version))
-	for _, url := range urls {
+	if len(resource.Urls) == 0 {
+		return b, fmt.Errorf("helm: no resource urls defined for chart %s-%s", name, version)
+	}
+
+	// Loop through all the resource's URLs to get the chart.
+	for _, url := range resource.Urls {
 		res, e := http.Get(url)
 		if e != nil {
 			err = e
@@ -136,7 +147,17 @@ func (c *client) GetChart(name, version string) ([]byte, error) {
 	return b, err
 }
 
-func findResource(name, version string) Resource {
+// findResource resets the helm index's cache then gets the resource
+// from the cache by name and version.
+//
+// If it is unable to find the resource it returns an error.
+func (c *client) findResource(name, version string) (Resource, error) {
+	// Refresh the cached index.
+	_, err := c.GetIndex()
+	if err != nil {
+		return Resource{}, err
+	}
+
 	// Lock since we are accessing the cached index.
 	mux.Lock()
 	defer mux.Unlock()
@@ -145,10 +166,10 @@ func findResource(name, version string) Resource {
 		resources := cache.Entries[name]
 		for _, resource := range resources {
 			if resource.Version == version {
-				return resource
+				return resource, nil
 			}
 		}
 	}
 
-	return Resource{}
+	return Resource{}, errUnableToFindResource
 }

--- a/pkg/helm/client_test.go
+++ b/pkg/helm/client_test.go
@@ -137,8 +137,59 @@ entries:
 	})
 
 	Describe("#GetChart", func() {
+		var name string
+
+		BeforeEach(func() {
+			name = "hello-app"
+			server.AppendHandlers(ghttp.CombineHandlers(
+				ghttp.VerifyRequest(http.MethodGet, "/index.yaml"),
+				ghttp.RespondWith(http.StatusOK, fmt.Sprintf(`apiVersion: v1
+entries:
+  hello-app:
+  - apiVersion: v2
+    appVersion: "1.0"
+    created: 2020-03-20T13:13:42.956Z
+    description: A Helm chart for deploying hello-app to Kuberntes
+    digest: a934a39ba7f77e8e16b609d01c493d7ead5ec24c78d2918d3a00ebaa3c3fdfd2
+    home: https://pages.github.com/test
+    maintainers:
+    - email: me@test.com
+      name: CD Team
+    name: hello-app
+    urls:
+    - %s/artifactory/helm/hello-app-1.0.0.tgz
+    version: 1.0.0
+  invalid-url-chart:
+  - apiVersion: v2
+    appVersion: "1.0"
+    created: 2020-03-20T13:13:42.956Z
+    description: A Helm chart for deploying hello-app to Kuberntes
+    digest: a934a39ba7f77e8e16b609d01c493d7ead5ec24c78d2918d3a00ebaa3c3fdfd2
+    home: https://pages.github.com/test
+    maintainers:
+    - email: me@test.com
+      name: CD Team
+    name: hello-app
+    urls:
+    - haha
+    version: 1.0.0
+  no-urls-chart:
+  - apiVersion: v2
+    appVersion: "2.0"
+    created: 2020-08-14T22:11:19.894Z
+    description: A Helm chart for deploying hello-app to Kubernetes
+    digest: c9c2663958ffdf2c790ebfd0f502176c3ac663014e9d6ce49955c4178c2f43d7
+    home: https://pages.github.com/test
+    maintainers:
+    - email: me@test.com
+      name: CD Team
+    name: no-urls-chart
+    version: 1.0.0`, server.URL())),
+			))
+		})
+
 		JustBeforeEach(func() {
-			b, err = client.GetChart("test-name", "0.1.0")
+			b, err = client.GetChart(name, "1.0.0")
 		})
 
 		When("the uri is invalid", func() {
@@ -148,6 +199,40 @@ entries:
 
 			It("returns an error", func() {
 				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("helm: unable to find chart hello-app-1.0.0: parse \"::haha/index.yaml\": missing protocol scheme"))
+			})
+		})
+
+		When("the chart does not exist", func() {
+			BeforeEach(func() {
+				name = "invalid-chart"
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("helm: unable to find chart invalid-chart-1.0.0: unable to find resource"))
+			})
+		})
+
+		When("the chart has no associated urls", func() {
+			BeforeEach(func() {
+				name = "no-urls-chart"
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("helm: no resource urls defined for chart no-urls-chart-1.0.0"))
+			})
+		})
+
+		When("the chart url is invalid", func() {
+			BeforeEach(func() {
+				name = "invalid-url-chart"
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("Get \"haha\": unsupported protocol scheme \"\""))
 			})
 		})
 
@@ -174,59 +259,10 @@ entries:
 			})
 		})
 
-		When("the resources are cached", func() {
-			BeforeEach(func() {
-				server.AppendHandlers(ghttp.CombineHandlers(
-					ghttp.VerifyRequest(http.MethodGet, "/index.yaml"),
-					ghttp.RespondWith(http.StatusOK, fmt.Sprintf(`apiVersion: v1
-entries:
-  test-name:
-  - apiVersion: v2
-    appVersion: "1.0"
-    created: 2020-03-20T13:13:42.956Z
-    description: A Helm chart for deploying hello-app to Kuberntes
-    digest: a934a39ba7f77e8e16b609d01c493d7ead5ec24c78d2918d3a00ebaa3c3fdfd2
-    home: https://pages.github.com/test
-    maintainers:
-    - email: me@test.com
-      name: CD Team
-    name: hello-app
-    urls:
-    - %s/artifactory/helm/packages/test-name-0.1.0.tgz
-    version: 0.1.0
-  thd-cd-hello-app:
-  - apiVersion: v2
-    appVersion: "2.0"
-    created: 2020-08-14T22:11:19.894Z
-    description: A Helm chart for deploying hello-app to Kubernetes
-    digest: c9c2663958ffdf2c790ebfd0f502176c3ac663014e9d6ce49955c4178c2f43d7
-    home: https://pages.github.com/test
-    maintainers:
-    - email: me@test.com
-      name: CD Team
-    name: thd-cd-hello-app
-    urls:
-    - https://helm..com/artifactory/helm/packages/test-3.0.2.tgz
-    version: 3.0.2`, server.URL()),
-					)))
-				server.AppendHandlers(ghttp.CombineHandlers(
-					ghttp.VerifyRequest(http.MethodGet, "/artifactory/helm/packages/test-name-0.1.0.tgz"),
-					ghttp.RespondWith(http.StatusOK, `some-binary-data`),
-				))
-				_, err = client.GetIndex()
-				Expect(err).To(BeNil())
-			})
-
-			It("calls the url in the cached entry", func() {
-				Expect(err).To(BeNil())
-				Expect(string(b)).To(Equal("some-binary-data"))
-			})
-		})
-
 		When("it succeeds", func() {
 			BeforeEach(func() {
 				server.AppendHandlers(ghttp.CombineHandlers(
-					ghttp.VerifyRequest(http.MethodGet, "/test-name-0.1.0.tgz"),
+					ghttp.VerifyRequest(http.MethodGet, "/artifactory/helm/hello-app-1.0.0.tgz"),
 					ghttp.RespondWith(http.StatusOK, `some-binary-data`),
 				))
 			})

--- a/pkg/helm/client_test.go
+++ b/pkg/helm/client_test.go
@@ -1,6 +1,7 @@
 package helm_test
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/homedepot/go-clouddriver/pkg/helm"
@@ -169,7 +170,56 @@ entries:
 
 			It("returns an error", func() {
 				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(Equal("error getting helm chart: 500 Internal Server Error"))
+				Expect(err.Error()).To(Equal("helm: error getting chart: 500 Internal Server Error"))
+			})
+		})
+
+		When("the resources are cached", func() {
+			BeforeEach(func() {
+				server.AppendHandlers(ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/index.yaml"),
+					ghttp.RespondWith(http.StatusOK, fmt.Sprintf(`apiVersion: v1
+entries:
+  test-name:
+  - apiVersion: v2
+    appVersion: "1.0"
+    created: 2020-03-20T13:13:42.956Z
+    description: A Helm chart for deploying hello-app to Kuberntes
+    digest: a934a39ba7f77e8e16b609d01c493d7ead5ec24c78d2918d3a00ebaa3c3fdfd2
+    home: https://pages.github.com/test
+    maintainers:
+    - email: me@test.com
+      name: CD Team
+    name: hello-app
+    urls:
+    - %s/artifactory/helm/packages/test-name-0.1.0.tgz
+    version: 0.1.0
+  thd-cd-hello-app:
+  - apiVersion: v2
+    appVersion: "2.0"
+    created: 2020-08-14T22:11:19.894Z
+    description: A Helm chart for deploying hello-app to Kubernetes
+    digest: c9c2663958ffdf2c790ebfd0f502176c3ac663014e9d6ce49955c4178c2f43d7
+    home: https://pages.github.com/test
+    maintainers:
+    - email: me@test.com
+      name: CD Team
+    name: thd-cd-hello-app
+    urls:
+    - https://helm..com/artifactory/helm/packages/test-3.0.2.tgz
+    version: 3.0.2`, server.URL()),
+					)))
+				server.AppendHandlers(ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/artifactory/helm/packages/test-name-0.1.0.tgz"),
+					ghttp.RespondWith(http.StatusOK, `some-binary-data`),
+				))
+				_, err = client.GetIndex()
+				Expect(err).To(BeNil())
+			})
+
+			It("calls the url in the cached entry", func() {
+				Expect(err).To(BeNil())
+				Expect(string(b)).To(Equal("some-binary-data"))
 			})
 		})
 


### PR DESCRIPTION
- This makes our helm client loop through a resources defined URLs to get the resource, instead of assuming the resource is available at `https://example-helm-repo.com/chart_name-chart_version.tgz`

NOTE: this is a patch for release 0.9.x.