### PR TITLE
add base64 validation when onboarding kubernetes providers

### DIFF
--- a/pkg/http/v1/payload_test.go
+++ b/pkg/http/v1/payload_test.go
@@ -7,6 +7,20 @@ const payloadBadRequest = `{
 const payloadRequestKubernetesProviders = `{
 						"name": "test-name",
 						"host": "test-host",
+						"caData": "dGVzdC1jYS1kYXRhCg==",
+						"permissions": {
+						  "read": [
+							  "gg_test"
+							],
+							"write": [
+							  "gg_test"
+							]
+						}
+          }`
+
+const payloadRequestKubernetesProvidersBadCAData = `{
+						"name": "test-name",
+						"host": "test-host",
 						"caData": "test-ca-data",
 						"permissions": {
 						  "read": [
@@ -34,10 +48,14 @@ const payloadErrorCreatingWritePermission = `{
             "error": "error creating write permission"
           }`
 
+const payloadErrorDecodingBase64 = `{
+            "error": "error decoding base64 CA data: illegal base64 data at input byte 4"
+          }`
+
 const payloadKubernetesProviderCreated = `{
             "name": "test-name",
             "host": "test-host",
-            "caData": "test-ca-data",
+            "caData": "dGVzdC1jYS1kYXRhCg==",
             "permissions": {
               "read": [
                 "gg_test"

--- a/pkg/http/v1/provider.go
+++ b/pkg/http/v1/provider.go
@@ -1,6 +1,8 @@
 package v1
 
 import (
+	"encoding/base64"
+	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
@@ -24,6 +26,12 @@ func CreateKubernetesProvider(c *gin.Context) {
 	_, err = sc.GetKubernetesProvider(p.Name)
 	if err == nil {
 		c.JSON(http.StatusConflict, gin.H{"error": "provider already exists"})
+		return
+	}
+
+	_, err = base64.StdEncoding.DecodeString(p.CAData)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("error decoding base64 CA data: %s", err.Error())})
 		return
 	}
 

--- a/pkg/http/v1/provider_test.go
+++ b/pkg/http/v1/provider_test.go
@@ -44,6 +44,19 @@ var _ = Describe("Provider", func() {
 			})
 		})
 
+		When("the ca data in the request is bad", func() {
+			BeforeEach(func() {
+				body = &bytes.Buffer{}
+				body.Write([]byte(payloadRequestKubernetesProvidersBadCAData))
+				createRequest(http.MethodPost)
+			})
+
+			It("returns status bad request", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+				validateResponse(payloadErrorDecodingBase64)
+			})
+		})
+
 		When("the provider already exists", func() {
 			BeforeEach(func() {
 				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, nil)


### PR DESCRIPTION
This will be patch 0.10.1.

Reference to the original: https://github.com/homedepot/go-clouddriver/pull/16