### PR TITLE
Token provider

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default: all
 
-all: clean build test
+all: clean lint build test
 
 build:
 	go build cmd/clouddriver/clouddriver.go
@@ -9,7 +9,15 @@ clean:
 	go clean
 	-rm ./clouddriver
 
-run: clean build test
+lint:
+	golangci-lint run \
+		--enable misspell \
+		--enable wsl \
+		--print-issued-lines=false \
+		--out-format=colored-line-number \
+		--issues-exit-code=1 ./...
+
+run: clean lint build test
 	./clouddriver
 
 test:
@@ -22,4 +30,4 @@ tools:
 vendor:
 	go mod vendor
 
-.PHONEY: all clean build run test tools
+.PHONEY: all clean build lint run test tools

--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -269,6 +269,17 @@ paths:
       tags:
       - "kubernetes"
       summary: "Create a new Kubernetes account (provider)"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Object that describes the kubernetes provider"
+        required: true
+        schema:
+          $ref: "#/definitions/KubernetesProvider"
       responses:
         "200":
           description: "OK"
@@ -295,4 +306,47 @@ paths:
           description: "Not Found"
         "500":
           description: "Internal Server Error"
-
+definitions:
+  KubernetesProvider:
+    type: "object"
+    required:
+    - name
+    - host
+    properties:
+      name:
+        type: "string"
+        description: "The unique name identifiying this Spinnaker account"
+        example: "gke_np-platforms-cd-thd_us-east1_np-us-east1-np"
+      host:
+        type: "string"
+        description: "The endpoint (hostname or ip address) for reaching the kubernetes cluster's control plane"
+        example: "https://34.73.20.115"
+      caData:
+        type: "string"
+        description: "The base64-encoded CA certificate of the kubernetes cluster"
+        example: "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0t..."
+      tokenProvider:
+        type: "string"
+        description: "The provider of the kubernetes auth token, defaults to google"
+        enum: ["google", "rancher"]
+        example: "google"
+      permissions:
+        $ref: "#/definitions/Permissions"
+  Permissions:
+    type: "object"
+    required:
+    - read
+    - write
+    properties:
+      read:
+        type: "array"
+        items:
+          type: "string"
+        description: "List of groups that have READ access"
+        example: ["group1"]
+      write:
+        type: "array"
+        items:
+          type: "string"
+        description: "List of groups that have WRITE access"
+        example: ["group1", "group2"]

--- a/pkg/arcade/arcadefakes/fake_client.go
+++ b/pkg/arcade/arcadefakes/fake_client.go
@@ -8,10 +8,12 @@ import (
 )
 
 type FakeClient struct {
-	TokenStub        func() (string, error)
+	TokenStub        func(string) (string, error)
 	tokenMutex       sync.RWMutex
-	tokenArgsForCall []struct{}
-	tokenReturns     struct {
+	tokenArgsForCall []struct {
+		arg1 string
+	}
+	tokenReturns struct {
 		result1 string
 		result2 error
 	}
@@ -28,19 +30,22 @@ type FakeClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClient) Token() (string, error) {
+func (fake *FakeClient) Token(arg1 string) (string, error) {
 	fake.tokenMutex.Lock()
 	ret, specificReturn := fake.tokenReturnsOnCall[len(fake.tokenArgsForCall)]
-	fake.tokenArgsForCall = append(fake.tokenArgsForCall, struct{}{})
-	fake.recordInvocation("Token", []interface{}{})
+	fake.tokenArgsForCall = append(fake.tokenArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("Token", []interface{}{arg1})
 	fake.tokenMutex.Unlock()
 	if fake.TokenStub != nil {
-		return fake.TokenStub()
+		return fake.TokenStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.tokenReturns.result1, fake.tokenReturns.result2
+	fakeReturns := fake.tokenReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) TokenCallCount() int {
@@ -49,7 +54,22 @@ func (fake *FakeClient) TokenCallCount() int {
 	return len(fake.tokenArgsForCall)
 }
 
+func (fake *FakeClient) TokenCalls(stub func(string) (string, error)) {
+	fake.tokenMutex.Lock()
+	defer fake.tokenMutex.Unlock()
+	fake.TokenStub = stub
+}
+
+func (fake *FakeClient) TokenArgsForCall(i int) string {
+	fake.tokenMutex.RLock()
+	defer fake.tokenMutex.RUnlock()
+	argsForCall := fake.tokenArgsForCall[i]
+	return argsForCall.arg1
+}
+
 func (fake *FakeClient) TokenReturns(result1 string, result2 error) {
+	fake.tokenMutex.Lock()
+	defer fake.tokenMutex.Unlock()
 	fake.TokenStub = nil
 	fake.tokenReturns = struct {
 		result1 string
@@ -58,6 +78,8 @@ func (fake *FakeClient) TokenReturns(result1 string, result2 error) {
 }
 
 func (fake *FakeClient) TokenReturnsOnCall(i int, result1 string, result2 error) {
+	fake.tokenMutex.Lock()
+	defer fake.tokenMutex.Unlock()
 	fake.TokenStub = nil
 	if fake.tokenReturnsOnCall == nil {
 		fake.tokenReturnsOnCall = make(map[int]struct {
@@ -89,10 +111,17 @@ func (fake *FakeClient) WithAPIKeyCallCount() int {
 	return len(fake.withAPIKeyArgsForCall)
 }
 
+func (fake *FakeClient) WithAPIKeyCalls(stub func(string)) {
+	fake.withAPIKeyMutex.Lock()
+	defer fake.withAPIKeyMutex.Unlock()
+	fake.WithAPIKeyStub = stub
+}
+
 func (fake *FakeClient) WithAPIKeyArgsForCall(i int) string {
 	fake.withAPIKeyMutex.RLock()
 	defer fake.withAPIKeyMutex.RUnlock()
-	return fake.withAPIKeyArgsForCall[i].arg1
+	argsForCall := fake.withAPIKeyArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) Invocations() map[string][][]interface{} {

--- a/pkg/arcade/client.go
+++ b/pkg/arcade/client.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 
 	"github.com/gin-gonic/gin"
 )
@@ -15,7 +16,7 @@ const (
 
 //go:generate counterfeiter . Client
 type Client interface {
-	Token() (string, error)
+	Token(string) (string, error)
 	WithAPIKey(string)
 }
 
@@ -40,11 +41,15 @@ func (c *client) WithAPIKey(apiKey string) {
 	c.apiKey = apiKey
 }
 
-func (c *client) Token() (string, error) {
+func (c *client) Token(tokenProvider string) (string, error) {
 	req, err := http.NewRequest(http.MethodGet, c.url+"/tokens", nil)
 	if err != nil {
 		return "", err
 	}
+
+	q := url.Values{}
+	q.Add("provider", tokenProvider)
+	req.URL.RawQuery = q.Encode()
 
 	req.Header.Add("Api-Key", c.apiKey)
 

--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -215,7 +215,7 @@ func listServerGroupManagers(c *gin.Context, wg *sync.WaitGroup, sgms chan Serve
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Log(err)
 		return
@@ -426,7 +426,7 @@ func listLoadBalancers(c *gin.Context, wg *sync.WaitGroup, lbs chan LoadBalancer
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Log(err)
 		return
@@ -689,7 +689,7 @@ func listServerGroups(c *gin.Context, wg *sync.WaitGroup, sgs chan ServerGroup,
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Log(err)
 		return
@@ -959,7 +959,7 @@ func GetServerGroup(c *gin.Context) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
@@ -1166,7 +1166,7 @@ func GetJob(c *gin.Context) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/http/core/credentials.go
+++ b/pkg/http/core/credentials.go
@@ -150,7 +150,7 @@ func listNamespaces(provider kubernetes.Provider,
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Log(err)
 		return

--- a/pkg/http/core/kubernetes/cleanup.go
+++ b/pkg/http/core/kubernetes/cleanup.go
@@ -2,8 +2,9 @@ package kubernetes
 
 import (
 	"encoding/base64"
-	"github.com/homedepot/go-clouddriver/pkg/util"
 	"net/http"
+
+	"github.com/homedepot/go-clouddriver/pkg/util"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
@@ -41,7 +42,7 @@ func CleanupArtifacts(c *gin.Context, ca CleanupArtifactsRequest) {
 			return
 		}
 
-		token, err := ac.Token()
+		token, err := ac.Token(provider.TokenProvider)
 		if err != nil {
 			clouddriver.Error(c, http.StatusInternalServerError, err)
 			return

--- a/pkg/http/core/kubernetes/delete.go
+++ b/pkg/http/core/kubernetes/delete.go
@@ -37,7 +37,7 @@ func Delete(c *gin.Context, dm DeleteManifestRequest) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/http/core/kubernetes/deploy.go
+++ b/pkg/http/core/kubernetes/deploy.go
@@ -47,7 +47,7 @@ func Deploy(c *gin.Context, dm DeployManifestRequest) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/http/core/kubernetes/patch.go
+++ b/pkg/http/core/kubernetes/patch.go
@@ -36,7 +36,7 @@ func Patch(c *gin.Context, pm PatchManifestRequest) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/http/core/kubernetes/restart.go
+++ b/pkg/http/core/kubernetes/restart.go
@@ -35,7 +35,7 @@ func RollingRestart(c *gin.Context, rr RollingRestartManifestRequest) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/http/core/kubernetes/rollback.go
+++ b/pkg/http/core/kubernetes/rollback.go
@@ -72,7 +72,7 @@ func Rollback(c *gin.Context, ur UndoRolloutManifestRequest) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/http/core/kubernetes/runjob.go
+++ b/pkg/http/core/kubernetes/runjob.go
@@ -35,7 +35,7 @@ func RunJob(c *gin.Context, rj RunJobRequest) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/http/core/kubernetes/scale.go
+++ b/pkg/http/core/kubernetes/scale.go
@@ -33,7 +33,7 @@ func Scale(c *gin.Context, sm ScaleManifestRequest) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/http/core/manifest.go
+++ b/pkg/http/core/manifest.go
@@ -54,7 +54,7 @@ func GetManifest(c *gin.Context) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
@@ -137,7 +137,7 @@ func GetManifestByTarget(c *gin.Context) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/http/core/task.go
+++ b/pkg/http/core/task.go
@@ -51,7 +51,7 @@ func GetTask(c *gin.Context) {
 		return
 	}
 
-	token, err := ac.Token()
+	token, err := ac.Token(provider.TokenProvider)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/pkg/kubernetes/provider.go
+++ b/pkg/kubernetes/provider.go
@@ -1,11 +1,12 @@
 package kubernetes
 
 type Provider struct {
-	Name        string              `json:"name" gorm:"primary_key"`
-	Host        string              `json:"host"`
-	CAData      string              `json:"caData" gorm:"size:8192"`
-	BearerToken string              `json:"bearerToken,omitempty" gorm:"size:2048"`
-	Permissions ProviderPermissions `json:"permissions" gorm:"-"`
+	Name          string              `json:"name" gorm:"primary_key"`
+	Host          string              `json:"host"`
+	CAData        string              `json:"caData" gorm:"size:8192"`
+	BearerToken   string              `json:"bearerToken,omitempty" gorm:"size:2048"`
+	TokenProvider string              `json:"tokenProvider,omitempty" gorm:"size:32;not null;default:'google'"`
+	Permissions   ProviderPermissions `json:"permissions" gorm:"-"`
 }
 
 type ProviderPermissions struct {

--- a/pkg/kubernetes/version_test.go
+++ b/pkg/kubernetes/version_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Version", func() {
 				Expect(currentVersion).To(Equal("-1"))
 			})
 		})
-		When("The higest version number in the cluster is 4", func() {
+		When("The highest version number in the cluster is 4", func() {
 			BeforeEach(func() {
 				fakeUnstructuredList = &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
 					{
@@ -278,7 +278,7 @@ var _ = Describe("Version", func() {
 	})
 
 	Context("#versionVolumes", func() {
-		When("manifest kind is depolyment and volume type is configMap", func() {
+		When("manifest kind is deployment and volume type is configMap", func() {
 			BeforeEach(func() {
 				fakeResource := &unstructured.Unstructured{
 					Object: map[string]interface{}{
@@ -318,7 +318,7 @@ var _ = Describe("Version", func() {
 				Expect(volumes[0].ConfigMap.Name).To(Equal("test-config-map-v001"))
 			})
 		})
-		When("manifest kind is depolyment and volume type is secret", func() {
+		When("manifest kind is deployment and volume type is secret", func() {
 			BeforeEach(func() {
 				fakeResource := &unstructured.Unstructured{
 					Object: map[string]interface{}{

--- a/pkg/middleware/error.go
+++ b/pkg/middleware/error.go
@@ -11,7 +11,7 @@ func HandleError() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		c.Next() // execute all the handlers
 
-		// If an error occured during handling the request, write the error as a JSON response.
+		// If an error occurred during handling the request, write the error as a JSON response.
 		err := c.Errors.ByType(gin.ErrorTypePublic).Last()
 		if err != nil {
 			statusCode := c.Writer.Status()

--- a/pkg/sql/sql_test.go
+++ b/pkg/sql/sql_test.go
@@ -68,6 +68,31 @@ var _ = Describe("Sql", func() {
 			err = c.CreateKubernetesProvider(provider)
 		})
 
+		When("tokenProvider is set", func() {
+			BeforeEach(func() {
+				provider = kubernetes.Provider{
+					Name:          "test-name",
+					Host:          "test-host",
+					CAData:        "test-ca-data",
+					TokenProvider: "test-token",
+				}
+				mock.ExpectBegin()
+				mock.ExpectExec(`(?i)^INSERT INTO "kubernetes_providers" \(` +
+					`"name"` +
+					`,"host"` +
+					`,"ca_data"` +
+					`,"bearer_token"` +
+					`,"token_provider"` +
+					`\) VALUES \(\?,\?,\?,\?,\?\)$`).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectCommit()
+			})
+
+			It("succeeds", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
 		When("it succeeds", func() {
 			BeforeEach(func() {
 				mock.ExpectBegin()

--- a/pkg/sql/sql_test.go
+++ b/pkg/sql/sql_test.go
@@ -279,7 +279,7 @@ var _ = Describe("Sql", func() {
 			BeforeEach(func() {
 				sqlRows := sqlmock.NewRows([]string{"name", "host", "ca_data"}).
 					AddRow("test-name", "test-host", "test-ca-data")
-				mock.ExpectQuery(`(?i)^SELECT host, ca_data, bearer_token FROM "kubernetes_providers" ` +
+				mock.ExpectQuery(`(?i)^SELECT host, ca_data, bearer_token, token_provider FROM "kubernetes_providers" ` +
 					` WHERE \(name = \?\) ORDER BY "kubernetes_providers"."name" ASC LIMIT 1$`).
 					WillReturnRows(sqlRows)
 				mock.ExpectCommit()
@@ -447,13 +447,14 @@ var _ = Describe("Sql", func() {
 
 		When("it succeeds", func() {
 			BeforeEach(func() {
-				sqlRows := sqlmock.NewRows([]string{"name", "host", "ca_data"}).
-					AddRow("name1", "host1", "ca_data1").
-					AddRow("name2", "host2", "ca_data2")
+				sqlRows := sqlmock.NewRows([]string{"name", "host", "ca_data", "token_provider"}).
+					AddRow("name1", "host1", "ca_data1", "google").
+					AddRow("name2", "host2", "ca_data2", "rancher")
 				mock.ExpectQuery(`(?i)^SELECT ` +
 					`name, ` +
 					`host, ` +
-					`ca_data ` +
+					`ca_data, ` +
+					`token_provider ` +
 					`FROM "kubernetes_providers"$`).
 					WillReturnRows(sqlRows)
 				mock.ExpectCommit()
@@ -492,6 +493,7 @@ var _ = Describe("Sql", func() {
 					`a.name, ` +
 					`a.host, ` +
 					`a.ca_data, ` +
+					`a.token_provider, ` +
 					`b.read_group, ` +
 					`c.write_group ` +
 					`FROM kubernetes_providers a ` +
@@ -502,21 +504,22 @@ var _ = Describe("Sql", func() {
 
 			It("returns an error", func() {
 				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(Equal("sql: expected 4 destination arguments in Scan, not 5"))
+				Expect(err.Error()).To(Equal("sql: expected 4 destination arguments in Scan, not 6"))
 			})
 		})
 
 		When("it succeeds", func() {
 			BeforeEach(func() {
-				sqlRows := sqlmock.NewRows([]string{"name", "host", "ca_data", "read_group", "write_group"}).
-					AddRow("name1", "host1", "ca_data1", "read_group1", "write_group1").
-					AddRow("name1", "host1", "ca_data1", "read_group2", "write_group1").
-					AddRow("name2", "host2", "ca_data2", "read_group2", "write_group2").
-					AddRow("name2", "host2", "ca_data2", "read_group2", "write_group3")
+				sqlRows := sqlmock.NewRows([]string{"name", "host", "ca_data", "google", "read_group", "write_group"}).
+					AddRow("name1", "host1", "ca_data1", "google", "read_group1", "write_group1").
+					AddRow("name1", "host1", "ca_data1", "google", "read_group2", "write_group1").
+					AddRow("name2", "host2", "ca_data2", "rancher", "read_group2", "write_group2").
+					AddRow("name2", "host2", "ca_data2", "rancher", "read_group2", "write_group3")
 				mock.ExpectQuery(`(?i)^SELECT ` +
 					`a.name, ` +
 					`a.host, ` +
 					`a.ca_data, ` +
+					`a.token_provider, ` +
 					`b.read_group, ` +
 					`c.write_group ` +
 					`FROM kubernetes_providers a ` +


### PR DESCRIPTION
For kubernetes accounts, add support for additional provider for retrieving auth tokens.  Kubernetes credentials are retrieved from [arcade](https://github.com/homedepot/arcade), which added support for `rancher` as a token provider in addition to `google`, the default provider.

The token provider is added to the `kubernetes_providers` table as a non-nullable column with a default value of `google`, which means that existing accounts will be assigned `google` when the table is altered to include the new column

```sql
TABLE `kubernetes_providers` (
  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
  `host` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `ca_data` varchar(8192) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `bearer_token` varchar(2048) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
  `token_provider` varchar(32) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'google',
  PRIMARY KEY (`name`)
)
```