### PR TITLE
Add map to save artifacts names and refrences

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -311,6 +311,8 @@ github.com/mitchellh/go-wordwrap v1.0.0/go.mod h1:ZXFpozHsX6DPmq2I0TCekCxypsnAUb
 github.com/mitchellh/mapstructure v0.0.0-20170523030023-d0303fe80992/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.3.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=
+github.com/moby/moby v1.13.1 h1:mC5WwQwCXt/dYxZ1cIrRsnJAWw7VdtcTZUIGr4tXzOM=
+github.com/moby/moby v20.10.5+incompatible h1:X1Kfy/GrYL4UMcxWrIZCw4saZsIbd+W/++w6HA6STb8=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=

--- a/pkg/artifact/artifactfakes/fake_credentials_controller.go
+++ b/pkg/artifact/artifactfakes/fake_credentials_controller.go
@@ -11,28 +11,6 @@ import (
 )
 
 type FakeCredentialsController struct {
-	ListArtifactCredentialsNamesAndTypesStub        func() []artifact.Credentials
-	listArtifactCredentialsNamesAndTypesMutex       sync.RWMutex
-	listArtifactCredentialsNamesAndTypesArgsForCall []struct{}
-	listArtifactCredentialsNamesAndTypesReturns     struct {
-		result1 []artifact.Credentials
-	}
-	listArtifactCredentialsNamesAndTypesReturnsOnCall map[int]struct {
-		result1 []artifact.Credentials
-	}
-	HelmClientForAccountNameStub        func(string) (helm.Client, error)
-	helmClientForAccountNameMutex       sync.RWMutex
-	helmClientForAccountNameArgsForCall []struct {
-		arg1 string
-	}
-	helmClientForAccountNameReturns struct {
-		result1 helm.Client
-		result2 error
-	}
-	helmClientForAccountNameReturnsOnCall map[int]struct {
-		result1 helm.Client
-		result2 error
-	}
 	GitClientForAccountNameStub        func(string) (*github.Client, error)
 	gitClientForAccountNameMutex       sync.RWMutex
 	gitClientForAccountNameArgsForCall []struct {
@@ -44,19 +22,6 @@ type FakeCredentialsController struct {
 	}
 	gitClientForAccountNameReturnsOnCall map[int]struct {
 		result1 *github.Client
-		result2 error
-	}
-	HTTPClientForAccountNameStub        func(string) (*http.Client, error)
-	hTTPClientForAccountNameMutex       sync.RWMutex
-	hTTPClientForAccountNameArgsForCall []struct {
-		arg1 string
-	}
-	hTTPClientForAccountNameReturns struct {
-		result1 *http.Client
-		result2 error
-	}
-	hTTPClientForAccountNameReturnsOnCall map[int]struct {
-		result1 *http.Client
 		result2 error
 	}
 	GitRepoClientForAccountNameStub        func(string) (*http.Client, error)
@@ -72,99 +37,44 @@ type FakeCredentialsController struct {
 		result1 *http.Client
 		result2 error
 	}
+	HTTPClientForAccountNameStub        func(string) (*http.Client, error)
+	hTTPClientForAccountNameMutex       sync.RWMutex
+	hTTPClientForAccountNameArgsForCall []struct {
+		arg1 string
+	}
+	hTTPClientForAccountNameReturns struct {
+		result1 *http.Client
+		result2 error
+	}
+	hTTPClientForAccountNameReturnsOnCall map[int]struct {
+		result1 *http.Client
+		result2 error
+	}
+	HelmClientForAccountNameStub        func(string) (helm.Client, error)
+	helmClientForAccountNameMutex       sync.RWMutex
+	helmClientForAccountNameArgsForCall []struct {
+		arg1 string
+	}
+	helmClientForAccountNameReturns struct {
+		result1 helm.Client
+		result2 error
+	}
+	helmClientForAccountNameReturnsOnCall map[int]struct {
+		result1 helm.Client
+		result2 error
+	}
+	ListArtifactCredentialsNamesAndTypesStub        func() []artifact.Credentials
+	listArtifactCredentialsNamesAndTypesMutex       sync.RWMutex
+	listArtifactCredentialsNamesAndTypesArgsForCall []struct {
+	}
+	listArtifactCredentialsNamesAndTypesReturns struct {
+		result1 []artifact.Credentials
+	}
+	listArtifactCredentialsNamesAndTypesReturnsOnCall map[int]struct {
+		result1 []artifact.Credentials
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypes() []artifact.Credentials {
-	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
-	ret, specificReturn := fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)]
-	fake.listArtifactCredentialsNamesAndTypesArgsForCall = append(fake.listArtifactCredentialsNamesAndTypesArgsForCall, struct{}{})
-	fake.recordInvocation("ListArtifactCredentialsNamesAndTypes", []interface{}{})
-	fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
-	if fake.ListArtifactCredentialsNamesAndTypesStub != nil {
-		return fake.ListArtifactCredentialsNamesAndTypesStub()
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.listArtifactCredentialsNamesAndTypesReturns.result1
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCallCount() int {
-	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
-	return len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturns(result1 []artifact.Credentials) {
-	fake.ListArtifactCredentialsNamesAndTypesStub = nil
-	fake.listArtifactCredentialsNamesAndTypesReturns = struct {
-		result1 []artifact.Credentials
-	}{result1}
-}
-
-func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturnsOnCall(i int, result1 []artifact.Credentials) {
-	fake.ListArtifactCredentialsNamesAndTypesStub = nil
-	if fake.listArtifactCredentialsNamesAndTypesReturnsOnCall == nil {
-		fake.listArtifactCredentialsNamesAndTypesReturnsOnCall = make(map[int]struct {
-			result1 []artifact.Credentials
-		})
-	}
-	fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[i] = struct {
-		result1 []artifact.Credentials
-	}{result1}
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountName(arg1 string) (helm.Client, error) {
-	fake.helmClientForAccountNameMutex.Lock()
-	ret, specificReturn := fake.helmClientForAccountNameReturnsOnCall[len(fake.helmClientForAccountNameArgsForCall)]
-	fake.helmClientForAccountNameArgsForCall = append(fake.helmClientForAccountNameArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("HelmClientForAccountName", []interface{}{arg1})
-	fake.helmClientForAccountNameMutex.Unlock()
-	if fake.HelmClientForAccountNameStub != nil {
-		return fake.HelmClientForAccountNameStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.helmClientForAccountNameReturns.result1, fake.helmClientForAccountNameReturns.result2
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountNameCallCount() int {
-	fake.helmClientForAccountNameMutex.RLock()
-	defer fake.helmClientForAccountNameMutex.RUnlock()
-	return len(fake.helmClientForAccountNameArgsForCall)
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountNameArgsForCall(i int) string {
-	fake.helmClientForAccountNameMutex.RLock()
-	defer fake.helmClientForAccountNameMutex.RUnlock()
-	return fake.helmClientForAccountNameArgsForCall[i].arg1
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountNameReturns(result1 helm.Client, result2 error) {
-	fake.HelmClientForAccountNameStub = nil
-	fake.helmClientForAccountNameReturns = struct {
-		result1 helm.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) HelmClientForAccountNameReturnsOnCall(i int, result1 helm.Client, result2 error) {
-	fake.HelmClientForAccountNameStub = nil
-	if fake.helmClientForAccountNameReturnsOnCall == nil {
-		fake.helmClientForAccountNameReturnsOnCall = make(map[int]struct {
-			result1 helm.Client
-			result2 error
-		})
-	}
-	fake.helmClientForAccountNameReturnsOnCall[i] = struct {
-		result1 helm.Client
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountName(arg1 string) (*github.Client, error) {
@@ -181,7 +91,8 @@ func (fake *FakeCredentialsController) GitClientForAccountName(arg1 string) (*gi
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.gitClientForAccountNameReturns.result1, fake.gitClientForAccountNameReturns.result2
+	fakeReturns := fake.gitClientForAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountNameCallCount() int {
@@ -190,13 +101,22 @@ func (fake *FakeCredentialsController) GitClientForAccountNameCallCount() int {
 	return len(fake.gitClientForAccountNameArgsForCall)
 }
 
+func (fake *FakeCredentialsController) GitClientForAccountNameCalls(stub func(string) (*github.Client, error)) {
+	fake.gitClientForAccountNameMutex.Lock()
+	defer fake.gitClientForAccountNameMutex.Unlock()
+	fake.GitClientForAccountNameStub = stub
+}
+
 func (fake *FakeCredentialsController) GitClientForAccountNameArgsForCall(i int) string {
 	fake.gitClientForAccountNameMutex.RLock()
 	defer fake.gitClientForAccountNameMutex.RUnlock()
-	return fake.gitClientForAccountNameArgsForCall[i].arg1
+	argsForCall := fake.gitClientForAccountNameArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountNameReturns(result1 *github.Client, result2 error) {
+	fake.gitClientForAccountNameMutex.Lock()
+	defer fake.gitClientForAccountNameMutex.Unlock()
 	fake.GitClientForAccountNameStub = nil
 	fake.gitClientForAccountNameReturns = struct {
 		result1 *github.Client
@@ -205,6 +125,8 @@ func (fake *FakeCredentialsController) GitClientForAccountNameReturns(result1 *g
 }
 
 func (fake *FakeCredentialsController) GitClientForAccountNameReturnsOnCall(i int, result1 *github.Client, result2 error) {
+	fake.gitClientForAccountNameMutex.Lock()
+	defer fake.gitClientForAccountNameMutex.Unlock()
 	fake.GitClientForAccountNameStub = nil
 	if fake.gitClientForAccountNameReturnsOnCall == nil {
 		fake.gitClientForAccountNameReturnsOnCall = make(map[int]struct {
@@ -214,57 +136,6 @@ func (fake *FakeCredentialsController) GitClientForAccountNameReturnsOnCall(i in
 	}
 	fake.gitClientForAccountNameReturnsOnCall[i] = struct {
 		result1 *github.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountName(arg1 string) (*http.Client, error) {
-	fake.hTTPClientForAccountNameMutex.Lock()
-	ret, specificReturn := fake.hTTPClientForAccountNameReturnsOnCall[len(fake.hTTPClientForAccountNameArgsForCall)]
-	fake.hTTPClientForAccountNameArgsForCall = append(fake.hTTPClientForAccountNameArgsForCall, struct {
-		arg1 string
-	}{arg1})
-	fake.recordInvocation("HTTPClientForAccountName", []interface{}{arg1})
-	fake.hTTPClientForAccountNameMutex.Unlock()
-	if fake.HTTPClientForAccountNameStub != nil {
-		return fake.HTTPClientForAccountNameStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.hTTPClientForAccountNameReturns.result1, fake.hTTPClientForAccountNameReturns.result2
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountNameCallCount() int {
-	fake.hTTPClientForAccountNameMutex.RLock()
-	defer fake.hTTPClientForAccountNameMutex.RUnlock()
-	return len(fake.hTTPClientForAccountNameArgsForCall)
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountNameArgsForCall(i int) string {
-	fake.hTTPClientForAccountNameMutex.RLock()
-	defer fake.hTTPClientForAccountNameMutex.RUnlock()
-	return fake.hTTPClientForAccountNameArgsForCall[i].arg1
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountNameReturns(result1 *http.Client, result2 error) {
-	fake.HTTPClientForAccountNameStub = nil
-	fake.hTTPClientForAccountNameReturns = struct {
-		result1 *http.Client
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeCredentialsController) HTTPClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
-	fake.HTTPClientForAccountNameStub = nil
-	if fake.hTTPClientForAccountNameReturnsOnCall == nil {
-		fake.hTTPClientForAccountNameReturnsOnCall = make(map[int]struct {
-			result1 *http.Client
-			result2 error
-		})
-	}
-	fake.hTTPClientForAccountNameReturnsOnCall[i] = struct {
-		result1 *http.Client
 		result2 error
 	}{result1, result2}
 }
@@ -283,7 +154,8 @@ func (fake *FakeCredentialsController) GitRepoClientForAccountName(arg1 string) 
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.gitRepoClientForAccountNameReturns.result1, fake.gitRepoClientForAccountNameReturns.result2
+	fakeReturns := fake.gitRepoClientForAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCredentialsController) GitRepoClientForAccountNameCallCount() int {
@@ -292,13 +164,22 @@ func (fake *FakeCredentialsController) GitRepoClientForAccountNameCallCount() in
 	return len(fake.gitRepoClientForAccountNameArgsForCall)
 }
 
+func (fake *FakeCredentialsController) GitRepoClientForAccountNameCalls(stub func(string) (*http.Client, error)) {
+	fake.gitRepoClientForAccountNameMutex.Lock()
+	defer fake.gitRepoClientForAccountNameMutex.Unlock()
+	fake.GitRepoClientForAccountNameStub = stub
+}
+
 func (fake *FakeCredentialsController) GitRepoClientForAccountNameArgsForCall(i int) string {
 	fake.gitRepoClientForAccountNameMutex.RLock()
 	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
-	return fake.gitRepoClientForAccountNameArgsForCall[i].arg1
+	argsForCall := fake.gitRepoClientForAccountNameArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturns(result1 *http.Client, result2 error) {
+	fake.gitRepoClientForAccountNameMutex.Lock()
+	defer fake.gitRepoClientForAccountNameMutex.Unlock()
 	fake.GitRepoClientForAccountNameStub = nil
 	fake.gitRepoClientForAccountNameReturns = struct {
 		result1 *http.Client
@@ -307,6 +188,8 @@ func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturns(result
 }
 
 func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
+	fake.gitRepoClientForAccountNameMutex.Lock()
+	defer fake.gitRepoClientForAccountNameMutex.Unlock()
 	fake.GitRepoClientForAccountNameStub = nil
 	if fake.gitRepoClientForAccountNameReturnsOnCall == nil {
 		fake.gitRepoClientForAccountNameReturnsOnCall = make(map[int]struct {
@@ -320,19 +203,197 @@ func (fake *FakeCredentialsController) GitRepoClientForAccountNameReturnsOnCall(
 	}{result1, result2}
 }
 
+func (fake *FakeCredentialsController) HTTPClientForAccountName(arg1 string) (*http.Client, error) {
+	fake.hTTPClientForAccountNameMutex.Lock()
+	ret, specificReturn := fake.hTTPClientForAccountNameReturnsOnCall[len(fake.hTTPClientForAccountNameArgsForCall)]
+	fake.hTTPClientForAccountNameArgsForCall = append(fake.hTTPClientForAccountNameArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("HTTPClientForAccountName", []interface{}{arg1})
+	fake.hTTPClientForAccountNameMutex.Unlock()
+	if fake.HTTPClientForAccountNameStub != nil {
+		return fake.HTTPClientForAccountNameStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.hTTPClientForAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeCredentialsController) HTTPClientForAccountNameCallCount() int {
+	fake.hTTPClientForAccountNameMutex.RLock()
+	defer fake.hTTPClientForAccountNameMutex.RUnlock()
+	return len(fake.hTTPClientForAccountNameArgsForCall)
+}
+
+func (fake *FakeCredentialsController) HTTPClientForAccountNameCalls(stub func(string) (*http.Client, error)) {
+	fake.hTTPClientForAccountNameMutex.Lock()
+	defer fake.hTTPClientForAccountNameMutex.Unlock()
+	fake.HTTPClientForAccountNameStub = stub
+}
+
+func (fake *FakeCredentialsController) HTTPClientForAccountNameArgsForCall(i int) string {
+	fake.hTTPClientForAccountNameMutex.RLock()
+	defer fake.hTTPClientForAccountNameMutex.RUnlock()
+	argsForCall := fake.hTTPClientForAccountNameArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCredentialsController) HTTPClientForAccountNameReturns(result1 *http.Client, result2 error) {
+	fake.hTTPClientForAccountNameMutex.Lock()
+	defer fake.hTTPClientForAccountNameMutex.Unlock()
+	fake.HTTPClientForAccountNameStub = nil
+	fake.hTTPClientForAccountNameReturns = struct {
+		result1 *http.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) HTTPClientForAccountNameReturnsOnCall(i int, result1 *http.Client, result2 error) {
+	fake.hTTPClientForAccountNameMutex.Lock()
+	defer fake.hTTPClientForAccountNameMutex.Unlock()
+	fake.HTTPClientForAccountNameStub = nil
+	if fake.hTTPClientForAccountNameReturnsOnCall == nil {
+		fake.hTTPClientForAccountNameReturnsOnCall = make(map[int]struct {
+			result1 *http.Client
+			result2 error
+		})
+	}
+	fake.hTTPClientForAccountNameReturnsOnCall[i] = struct {
+		result1 *http.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountName(arg1 string) (helm.Client, error) {
+	fake.helmClientForAccountNameMutex.Lock()
+	ret, specificReturn := fake.helmClientForAccountNameReturnsOnCall[len(fake.helmClientForAccountNameArgsForCall)]
+	fake.helmClientForAccountNameArgsForCall = append(fake.helmClientForAccountNameArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("HelmClientForAccountName", []interface{}{arg1})
+	fake.helmClientForAccountNameMutex.Unlock()
+	if fake.HelmClientForAccountNameStub != nil {
+		return fake.HelmClientForAccountNameStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.helmClientForAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameCallCount() int {
+	fake.helmClientForAccountNameMutex.RLock()
+	defer fake.helmClientForAccountNameMutex.RUnlock()
+	return len(fake.helmClientForAccountNameArgsForCall)
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameCalls(stub func(string) (helm.Client, error)) {
+	fake.helmClientForAccountNameMutex.Lock()
+	defer fake.helmClientForAccountNameMutex.Unlock()
+	fake.HelmClientForAccountNameStub = stub
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameArgsForCall(i int) string {
+	fake.helmClientForAccountNameMutex.RLock()
+	defer fake.helmClientForAccountNameMutex.RUnlock()
+	argsForCall := fake.helmClientForAccountNameArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameReturns(result1 helm.Client, result2 error) {
+	fake.helmClientForAccountNameMutex.Lock()
+	defer fake.helmClientForAccountNameMutex.Unlock()
+	fake.HelmClientForAccountNameStub = nil
+	fake.helmClientForAccountNameReturns = struct {
+		result1 helm.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) HelmClientForAccountNameReturnsOnCall(i int, result1 helm.Client, result2 error) {
+	fake.helmClientForAccountNameMutex.Lock()
+	defer fake.helmClientForAccountNameMutex.Unlock()
+	fake.HelmClientForAccountNameStub = nil
+	if fake.helmClientForAccountNameReturnsOnCall == nil {
+		fake.helmClientForAccountNameReturnsOnCall = make(map[int]struct {
+			result1 helm.Client
+			result2 error
+		})
+	}
+	fake.helmClientForAccountNameReturnsOnCall[i] = struct {
+		result1 helm.Client
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypes() []artifact.Credentials {
+	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
+	ret, specificReturn := fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)]
+	fake.listArtifactCredentialsNamesAndTypesArgsForCall = append(fake.listArtifactCredentialsNamesAndTypesArgsForCall, struct {
+	}{})
+	fake.recordInvocation("ListArtifactCredentialsNamesAndTypes", []interface{}{})
+	fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
+	if fake.ListArtifactCredentialsNamesAndTypesStub != nil {
+		return fake.ListArtifactCredentialsNamesAndTypesStub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.listArtifactCredentialsNamesAndTypesReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCallCount() int {
+	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
+	return len(fake.listArtifactCredentialsNamesAndTypesArgsForCall)
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesCalls(stub func() []artifact.Credentials) {
+	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
+	fake.ListArtifactCredentialsNamesAndTypesStub = stub
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturns(result1 []artifact.Credentials) {
+	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
+	fake.ListArtifactCredentialsNamesAndTypesStub = nil
+	fake.listArtifactCredentialsNamesAndTypesReturns = struct {
+		result1 []artifact.Credentials
+	}{result1}
+}
+
+func (fake *FakeCredentialsController) ListArtifactCredentialsNamesAndTypesReturnsOnCall(i int, result1 []artifact.Credentials) {
+	fake.listArtifactCredentialsNamesAndTypesMutex.Lock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.Unlock()
+	fake.ListArtifactCredentialsNamesAndTypesStub = nil
+	if fake.listArtifactCredentialsNamesAndTypesReturnsOnCall == nil {
+		fake.listArtifactCredentialsNamesAndTypesReturnsOnCall = make(map[int]struct {
+			result1 []artifact.Credentials
+		})
+	}
+	fake.listArtifactCredentialsNamesAndTypesReturnsOnCall[i] = struct {
+		result1 []artifact.Credentials
+	}{result1}
+}
+
 func (fake *FakeCredentialsController) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
-	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
-	fake.helmClientForAccountNameMutex.RLock()
-	defer fake.helmClientForAccountNameMutex.RUnlock()
 	fake.gitClientForAccountNameMutex.RLock()
 	defer fake.gitClientForAccountNameMutex.RUnlock()
-	fake.hTTPClientForAccountNameMutex.RLock()
-	defer fake.hTTPClientForAccountNameMutex.RUnlock()
 	fake.gitRepoClientForAccountNameMutex.RLock()
 	defer fake.gitRepoClientForAccountNameMutex.RUnlock()
+	fake.hTTPClientForAccountNameMutex.RLock()
+	defer fake.hTTPClientForAccountNameMutex.RUnlock()
+	fake.helmClientForAccountNameMutex.RLock()
+	defer fake.helmClientForAccountNameMutex.RUnlock()
+	fake.listArtifactCredentialsNamesAndTypesMutex.RLock()
+	defer fake.listArtifactCredentialsNamesAndTypesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/fiat/fiatfakes/fake_client.go
+++ b/pkg/fiat/fiatfakes/fake_client.go
@@ -8,10 +8,10 @@ import (
 )
 
 type FakeClient struct {
-	AuthorizeStub        func(account string) (fiat.Response, error)
+	AuthorizeStub        func(string) (fiat.Response, error)
 	authorizeMutex       sync.RWMutex
 	authorizeArgsForCall []struct {
-		account string
+		arg1 string
 	}
 	authorizeReturns struct {
 		result1 fiat.Response
@@ -25,21 +25,22 @@ type FakeClient struct {
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeClient) Authorize(account string) (fiat.Response, error) {
+func (fake *FakeClient) Authorize(arg1 string) (fiat.Response, error) {
 	fake.authorizeMutex.Lock()
 	ret, specificReturn := fake.authorizeReturnsOnCall[len(fake.authorizeArgsForCall)]
 	fake.authorizeArgsForCall = append(fake.authorizeArgsForCall, struct {
-		account string
-	}{account})
-	fake.recordInvocation("Authorize", []interface{}{account})
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("Authorize", []interface{}{arg1})
 	fake.authorizeMutex.Unlock()
 	if fake.AuthorizeStub != nil {
-		return fake.AuthorizeStub(account)
+		return fake.AuthorizeStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.authorizeReturns.result1, fake.authorizeReturns.result2
+	fakeReturns := fake.authorizeReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) AuthorizeCallCount() int {
@@ -48,13 +49,22 @@ func (fake *FakeClient) AuthorizeCallCount() int {
 	return len(fake.authorizeArgsForCall)
 }
 
+func (fake *FakeClient) AuthorizeCalls(stub func(string) (fiat.Response, error)) {
+	fake.authorizeMutex.Lock()
+	defer fake.authorizeMutex.Unlock()
+	fake.AuthorizeStub = stub
+}
+
 func (fake *FakeClient) AuthorizeArgsForCall(i int) string {
 	fake.authorizeMutex.RLock()
 	defer fake.authorizeMutex.RUnlock()
-	return fake.authorizeArgsForCall[i].account
+	argsForCall := fake.authorizeArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) AuthorizeReturns(result1 fiat.Response, result2 error) {
+	fake.authorizeMutex.Lock()
+	defer fake.authorizeMutex.Unlock()
 	fake.AuthorizeStub = nil
 	fake.authorizeReturns = struct {
 		result1 fiat.Response
@@ -63,6 +73,8 @@ func (fake *FakeClient) AuthorizeReturns(result1 fiat.Response, result2 error) {
 }
 
 func (fake *FakeClient) AuthorizeReturnsOnCall(i int, result1 fiat.Response, result2 error) {
+	fake.authorizeMutex.Lock()
+	defer fake.authorizeMutex.Unlock()
 	fake.AuthorizeStub = nil
 	if fake.authorizeReturnsOnCall == nil {
 		fake.authorizeReturnsOnCall = make(map[int]struct {

--- a/pkg/helm/helmfakes/fake_client.go
+++ b/pkg/helm/helmfakes/fake_client.go
@@ -8,17 +8,6 @@ import (
 )
 
 type FakeClient struct {
-	GetIndexStub        func() (helm.Index, error)
-	getIndexMutex       sync.RWMutex
-	getIndexArgsForCall []struct{}
-	getIndexReturns     struct {
-		result1 helm.Index
-		result2 error
-	}
-	getIndexReturnsOnCall map[int]struct {
-		result1 helm.Index
-		result2 error
-	}
 	GetChartStub        func(string, string) ([]byte, error)
 	getChartMutex       sync.RWMutex
 	getChartArgsForCall []struct {
@@ -33,51 +22,20 @@ type FakeClient struct {
 		result1 []byte
 		result2 error
 	}
+	GetIndexStub        func() (helm.Index, error)
+	getIndexMutex       sync.RWMutex
+	getIndexArgsForCall []struct {
+	}
+	getIndexReturns struct {
+		result1 helm.Index
+		result2 error
+	}
+	getIndexReturnsOnCall map[int]struct {
+		result1 helm.Index
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
-}
-
-func (fake *FakeClient) GetIndex() (helm.Index, error) {
-	fake.getIndexMutex.Lock()
-	ret, specificReturn := fake.getIndexReturnsOnCall[len(fake.getIndexArgsForCall)]
-	fake.getIndexArgsForCall = append(fake.getIndexArgsForCall, struct{}{})
-	fake.recordInvocation("GetIndex", []interface{}{})
-	fake.getIndexMutex.Unlock()
-	if fake.GetIndexStub != nil {
-		return fake.GetIndexStub()
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.getIndexReturns.result1, fake.getIndexReturns.result2
-}
-
-func (fake *FakeClient) GetIndexCallCount() int {
-	fake.getIndexMutex.RLock()
-	defer fake.getIndexMutex.RUnlock()
-	return len(fake.getIndexArgsForCall)
-}
-
-func (fake *FakeClient) GetIndexReturns(result1 helm.Index, result2 error) {
-	fake.GetIndexStub = nil
-	fake.getIndexReturns = struct {
-		result1 helm.Index
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) GetIndexReturnsOnCall(i int, result1 helm.Index, result2 error) {
-	fake.GetIndexStub = nil
-	if fake.getIndexReturnsOnCall == nil {
-		fake.getIndexReturnsOnCall = make(map[int]struct {
-			result1 helm.Index
-			result2 error
-		})
-	}
-	fake.getIndexReturnsOnCall[i] = struct {
-		result1 helm.Index
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *FakeClient) GetChart(arg1 string, arg2 string) ([]byte, error) {
@@ -95,7 +53,8 @@ func (fake *FakeClient) GetChart(arg1 string, arg2 string) ([]byte, error) {
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getChartReturns.result1, fake.getChartReturns.result2
+	fakeReturns := fake.getChartReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) GetChartCallCount() int {
@@ -104,13 +63,22 @@ func (fake *FakeClient) GetChartCallCount() int {
 	return len(fake.getChartArgsForCall)
 }
 
+func (fake *FakeClient) GetChartCalls(stub func(string, string) ([]byte, error)) {
+	fake.getChartMutex.Lock()
+	defer fake.getChartMutex.Unlock()
+	fake.GetChartStub = stub
+}
+
 func (fake *FakeClient) GetChartArgsForCall(i int) (string, string) {
 	fake.getChartMutex.RLock()
 	defer fake.getChartMutex.RUnlock()
-	return fake.getChartArgsForCall[i].arg1, fake.getChartArgsForCall[i].arg2
+	argsForCall := fake.getChartArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) GetChartReturns(result1 []byte, result2 error) {
+	fake.getChartMutex.Lock()
+	defer fake.getChartMutex.Unlock()
 	fake.GetChartStub = nil
 	fake.getChartReturns = struct {
 		result1 []byte
@@ -119,6 +87,8 @@ func (fake *FakeClient) GetChartReturns(result1 []byte, result2 error) {
 }
 
 func (fake *FakeClient) GetChartReturnsOnCall(i int, result1 []byte, result2 error) {
+	fake.getChartMutex.Lock()
+	defer fake.getChartMutex.Unlock()
 	fake.GetChartStub = nil
 	if fake.getChartReturnsOnCall == nil {
 		fake.getChartReturnsOnCall = make(map[int]struct {
@@ -132,13 +102,68 @@ func (fake *FakeClient) GetChartReturnsOnCall(i int, result1 []byte, result2 err
 	}{result1, result2}
 }
 
+func (fake *FakeClient) GetIndex() (helm.Index, error) {
+	fake.getIndexMutex.Lock()
+	ret, specificReturn := fake.getIndexReturnsOnCall[len(fake.getIndexArgsForCall)]
+	fake.getIndexArgsForCall = append(fake.getIndexArgsForCall, struct {
+	}{})
+	fake.recordInvocation("GetIndex", []interface{}{})
+	fake.getIndexMutex.Unlock()
+	if fake.GetIndexStub != nil {
+		return fake.GetIndexStub()
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getIndexReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) GetIndexCallCount() int {
+	fake.getIndexMutex.RLock()
+	defer fake.getIndexMutex.RUnlock()
+	return len(fake.getIndexArgsForCall)
+}
+
+func (fake *FakeClient) GetIndexCalls(stub func() (helm.Index, error)) {
+	fake.getIndexMutex.Lock()
+	defer fake.getIndexMutex.Unlock()
+	fake.GetIndexStub = stub
+}
+
+func (fake *FakeClient) GetIndexReturns(result1 helm.Index, result2 error) {
+	fake.getIndexMutex.Lock()
+	defer fake.getIndexMutex.Unlock()
+	fake.GetIndexStub = nil
+	fake.getIndexReturns = struct {
+		result1 helm.Index
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetIndexReturnsOnCall(i int, result1 helm.Index, result2 error) {
+	fake.getIndexMutex.Lock()
+	defer fake.getIndexMutex.Unlock()
+	fake.GetIndexStub = nil
+	if fake.getIndexReturnsOnCall == nil {
+		fake.getIndexReturnsOnCall = make(map[int]struct {
+			result1 helm.Index
+			result2 error
+		})
+	}
+	fake.getIndexReturnsOnCall[i] = struct {
+		result1 helm.Index
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.getIndexMutex.RLock()
-	defer fake.getIndexMutex.RUnlock()
 	fake.getChartMutex.RLock()
 	defer fake.getChartMutex.RUnlock()
+	fake.getIndexMutex.RLock()
+	defer fake.getIndexMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/http/core/kubernetes/deploy.go
+++ b/pkg/http/core/kubernetes/deploy.go
@@ -30,10 +30,9 @@ var (
 
 func Deploy(c *gin.Context, dm DeployManifestRequest) {
 	kubeController := kube.ControllerInstance(c)
-
 	sqlClient := sql.Instance(c)
 
-	config, err, status := getKubeClientConfig(c, sqlClient, dm.Account)
+	config, err, status := kubeClientConfig(c, sqlClient, dm.Account)
 	if err != nil {
 		clouddriver.Error(c, status, err)
 		return
@@ -239,7 +238,7 @@ func mergeManifests(kubeController kube.Controller, manifests []map[string]inter
 	return mergedManifests, nil
 }
 
-func getKubeClientConfig(c *gin.Context, sqlClient sql.Client, account string) (*rest.Config, error, int) {
+func kubeClientConfig(c *gin.Context, sqlClient sql.Client, account string) (*rest.Config, error, int) {
 	config := &rest.Config{}
 
 	provider, err := sqlClient.GetKubernetesProvider(account)

--- a/pkg/http/core/kubernetes/kubernetes_test.go
+++ b/pkg/http/core/kubernetes/kubernetes_test.go
@@ -114,6 +114,20 @@ func newDeployManifestRequest() DeployManifestRequest {
 				"apiVersion": "v1",
 			},
 		},
+		OptionalArtifacts: []clouddriver.TaskCreatedArtifact{
+			{
+				Reference: "gke-versioned-volume-config2-v004",
+				Name:      "gke-versioned-volume-config2",
+				Type:      "kubernetes/configMap",
+			},
+		},
+		RequiredArtifacts: []clouddriver.TaskCreatedArtifact{
+			{
+				Reference: "gke-versioned-volume-config2-v004",
+				Name:      "gke-versioned-volume-config2",
+				Type:      "kubernetes/configMap",
+			},
+		},
 	}
 }
 

--- a/pkg/http/core/kubernetes/ops.go
+++ b/pkg/http/core/kubernetes/ops.go
@@ -26,7 +26,6 @@ type Operation struct {
 type DeployManifestRequest struct {
 	EnableTraffic     bool                     `json:"enableTraffic"`
 	NamespaceOverride string                   `json:"namespaceOverride"`
-	OptionalArtifacts []interface{}            `json:"optionalArtifacts"`
 	CloudProvider     string                   `json:"cloudProvider"`
 	Manifests         []map[string]interface{} `json:"manifests"`
 	TrafficManagement struct {
@@ -42,6 +41,7 @@ type DeployManifestRequest struct {
 	Account                  string                            `json:"account"`
 	SkipExpressionEvaluation bool                              `json:"skipExpressionEvaluation"`
 	RequiredArtifacts        []clouddriver.TaskCreatedArtifact `json:"requiredArtifacts"`
+	OptionalArtifacts        []clouddriver.TaskCreatedArtifact `json:"optionalArtifacts"`
 }
 
 type PatchManifestRequest struct {

--- a/pkg/kubernetes/cached/disk/diskfakes/fake_cache_round_tripper.go
+++ b/pkg/kubernetes/cached/disk/diskfakes/fake_cache_round_tripper.go
@@ -9,10 +9,15 @@ import (
 )
 
 type FakeCacheRoundTripper struct {
-	RoundTripStub        func(req *http.Request) (*http.Response, error)
+	CancelRequestStub        func(*http.Request)
+	cancelRequestMutex       sync.RWMutex
+	cancelRequestArgsForCall []struct {
+		arg1 *http.Request
+	}
+	RoundTripStub        func(*http.Request) (*http.Response, error)
 	roundTripMutex       sync.RWMutex
 	roundTripArgsForCall []struct {
-		req *http.Request
+		arg1 *http.Request
 	}
 	roundTripReturns struct {
 		result1 *http.Response
@@ -22,30 +27,57 @@ type FakeCacheRoundTripper struct {
 		result1 *http.Response
 		result2 error
 	}
-	CancelRequestStub        func(req *http.Request)
-	cancelRequestMutex       sync.RWMutex
-	cancelRequestArgsForCall []struct {
-		req *http.Request
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
 
-func (fake *FakeCacheRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+func (fake *FakeCacheRoundTripper) CancelRequest(arg1 *http.Request) {
+	fake.cancelRequestMutex.Lock()
+	fake.cancelRequestArgsForCall = append(fake.cancelRequestArgsForCall, struct {
+		arg1 *http.Request
+	}{arg1})
+	fake.recordInvocation("CancelRequest", []interface{}{arg1})
+	fake.cancelRequestMutex.Unlock()
+	if fake.CancelRequestStub != nil {
+		fake.CancelRequestStub(arg1)
+	}
+}
+
+func (fake *FakeCacheRoundTripper) CancelRequestCallCount() int {
+	fake.cancelRequestMutex.RLock()
+	defer fake.cancelRequestMutex.RUnlock()
+	return len(fake.cancelRequestArgsForCall)
+}
+
+func (fake *FakeCacheRoundTripper) CancelRequestCalls(stub func(*http.Request)) {
+	fake.cancelRequestMutex.Lock()
+	defer fake.cancelRequestMutex.Unlock()
+	fake.CancelRequestStub = stub
+}
+
+func (fake *FakeCacheRoundTripper) CancelRequestArgsForCall(i int) *http.Request {
+	fake.cancelRequestMutex.RLock()
+	defer fake.cancelRequestMutex.RUnlock()
+	argsForCall := fake.cancelRequestArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeCacheRoundTripper) RoundTrip(arg1 *http.Request) (*http.Response, error) {
 	fake.roundTripMutex.Lock()
 	ret, specificReturn := fake.roundTripReturnsOnCall[len(fake.roundTripArgsForCall)]
 	fake.roundTripArgsForCall = append(fake.roundTripArgsForCall, struct {
-		req *http.Request
-	}{req})
-	fake.recordInvocation("RoundTrip", []interface{}{req})
+		arg1 *http.Request
+	}{arg1})
+	fake.recordInvocation("RoundTrip", []interface{}{arg1})
 	fake.roundTripMutex.Unlock()
 	if fake.RoundTripStub != nil {
-		return fake.RoundTripStub(req)
+		return fake.RoundTripStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.roundTripReturns.result1, fake.roundTripReturns.result2
+	fakeReturns := fake.roundTripReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeCacheRoundTripper) RoundTripCallCount() int {
@@ -54,13 +86,22 @@ func (fake *FakeCacheRoundTripper) RoundTripCallCount() int {
 	return len(fake.roundTripArgsForCall)
 }
 
+func (fake *FakeCacheRoundTripper) RoundTripCalls(stub func(*http.Request) (*http.Response, error)) {
+	fake.roundTripMutex.Lock()
+	defer fake.roundTripMutex.Unlock()
+	fake.RoundTripStub = stub
+}
+
 func (fake *FakeCacheRoundTripper) RoundTripArgsForCall(i int) *http.Request {
 	fake.roundTripMutex.RLock()
 	defer fake.roundTripMutex.RUnlock()
-	return fake.roundTripArgsForCall[i].req
+	argsForCall := fake.roundTripArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeCacheRoundTripper) RoundTripReturns(result1 *http.Response, result2 error) {
+	fake.roundTripMutex.Lock()
+	defer fake.roundTripMutex.Unlock()
 	fake.RoundTripStub = nil
 	fake.roundTripReturns = struct {
 		result1 *http.Response
@@ -69,6 +110,8 @@ func (fake *FakeCacheRoundTripper) RoundTripReturns(result1 *http.Response, resu
 }
 
 func (fake *FakeCacheRoundTripper) RoundTripReturnsOnCall(i int, result1 *http.Response, result2 error) {
+	fake.roundTripMutex.Lock()
+	defer fake.roundTripMutex.Unlock()
 	fake.RoundTripStub = nil
 	if fake.roundTripReturnsOnCall == nil {
 		fake.roundTripReturnsOnCall = make(map[int]struct {
@@ -82,37 +125,13 @@ func (fake *FakeCacheRoundTripper) RoundTripReturnsOnCall(i int, result1 *http.R
 	}{result1, result2}
 }
 
-func (fake *FakeCacheRoundTripper) CancelRequest(req *http.Request) {
-	fake.cancelRequestMutex.Lock()
-	fake.cancelRequestArgsForCall = append(fake.cancelRequestArgsForCall, struct {
-		req *http.Request
-	}{req})
-	fake.recordInvocation("CancelRequest", []interface{}{req})
-	fake.cancelRequestMutex.Unlock()
-	if fake.CancelRequestStub != nil {
-		fake.CancelRequestStub(req)
-	}
-}
-
-func (fake *FakeCacheRoundTripper) CancelRequestCallCount() int {
-	fake.cancelRequestMutex.RLock()
-	defer fake.cancelRequestMutex.RUnlock()
-	return len(fake.cancelRequestArgsForCall)
-}
-
-func (fake *FakeCacheRoundTripper) CancelRequestArgsForCall(i int) *http.Request {
-	fake.cancelRequestMutex.RLock()
-	defer fake.cancelRequestMutex.RUnlock()
-	return fake.cancelRequestArgsForCall[i].req
-}
-
 func (fake *FakeCacheRoundTripper) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.roundTripMutex.RLock()
-	defer fake.roundTripMutex.RUnlock()
 	fake.cancelRequestMutex.RLock()
 	defer fake.cancelRequestMutex.RUnlock()
+	fake.roundTripMutex.RLock()
+	defer fake.roundTripMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/kubernetes/controller.go
+++ b/pkg/kubernetes/controller.go
@@ -31,7 +31,7 @@ type Controller interface {
 	GetCurrentVersion(ul *unstructured.UnstructuredList, kind, name string) string
 	IsVersioned(u *unstructured.Unstructured) bool
 	IncrementVersion(currentVersion string) SpinnakerVersion
-	VersionVolumes(u *unstructured.Unstructured, requiredArtifacts []clouddriver.TaskCreatedArtifact) error
+	VersionVolumes(u *unstructured.Unstructured, pipelineArtifacts map[string]clouddriver.TaskCreatedArtifact) error
 }
 
 func NewController() Controller {

--- a/pkg/kubernetes/kubernetesfakes/fake_client.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_client.go
@@ -6,7 +6,7 @@ import (
 	"sync"
 
 	"github.com/homedepot/go-clouddriver/pkg/kubernetes"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
@@ -40,13 +40,13 @@ type FakeClient struct {
 		result1 kubernetes.Metadata
 		result2 error
 	}
-	DeleteResourceByKindAndNameAndNamespaceStub        func(string, string, string, metav1.DeleteOptions) error
+	DeleteResourceByKindAndNameAndNamespaceStub        func(string, string, string, v1.DeleteOptions) error
 	deleteResourceByKindAndNameAndNamespaceMutex       sync.RWMutex
 	deleteResourceByKindAndNameAndNamespaceArgsForCall []struct {
 		arg1 string
 		arg2 string
 		arg3 string
-		arg4 metav1.DeleteOptions
+		arg4 v1.DeleteOptions
 	}
 	deleteResourceByKindAndNameAndNamespaceReturns struct {
 		result1 error
@@ -82,11 +82,11 @@ type FakeClient struct {
 		result1 *unstructured.Unstructured
 		result2 error
 	}
-	ListByGVRStub        func(schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	ListByGVRStub        func(schema.GroupVersionResource, v1.ListOptions) (*unstructured.UnstructuredList, error)
 	listByGVRMutex       sync.RWMutex
 	listByGVRArgsForCall []struct {
 		arg1 schema.GroupVersionResource
-		arg2 metav1.ListOptions
+		arg2 v1.ListOptions
 	}
 	listByGVRReturns struct {
 		result1 *unstructured.UnstructuredList
@@ -96,12 +96,12 @@ type FakeClient struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
 	}
-	ListByGVRWithContextStub        func(context.Context, schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	ListByGVRWithContextStub        func(context.Context, schema.GroupVersionResource, v1.ListOptions) (*unstructured.UnstructuredList, error)
 	listByGVRWithContextMutex       sync.RWMutex
 	listByGVRWithContextArgsForCall []struct {
 		arg1 context.Context
 		arg2 schema.GroupVersionResource
-		arg3 metav1.ListOptions
+		arg3 v1.ListOptions
 	}
 	listByGVRWithContextReturns struct {
 		result1 *unstructured.UnstructuredList
@@ -111,17 +111,32 @@ type FakeClient struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
 	}
-	ListResourceStub        func(string, metav1.ListOptions) (*unstructured.UnstructuredList, error)
+	ListResourceStub        func(string, v1.ListOptions) (*unstructured.UnstructuredList, error)
 	listResourceMutex       sync.RWMutex
 	listResourceArgsForCall []struct {
 		arg1 string
-		arg2 metav1.ListOptions
+		arg2 v1.ListOptions
 	}
 	listResourceReturns struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
 	}
 	listResourceReturnsOnCall map[int]struct {
+		result1 *unstructured.UnstructuredList
+		result2 error
+	}
+	ListResourcesByKindAndNamespaceStub        func(string, string, v1.ListOptions) (*unstructured.UnstructuredList, error)
+	listResourcesByKindAndNamespaceMutex       sync.RWMutex
+	listResourcesByKindAndNamespaceArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 v1.ListOptions
+	}
+	listResourcesByKindAndNamespaceReturns struct {
+		result1 *unstructured.UnstructuredList
+		result2 error
+	}
+	listResourcesByKindAndNamespaceReturnsOnCall map[int]struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
 	}
@@ -162,21 +177,6 @@ type FakeClient struct {
 		result2 *unstructured.Unstructured
 		result3 error
 	}
-	ListResourcesByKindAndNamespaceStub        func(string, string, metav1.ListOptions) (*unstructured.UnstructuredList, error)
-	listResourcesByKindAndNamespaceMutex       sync.RWMutex
-	listResourcesByKindAndNamespaceArgsForCall []struct {
-		arg1 string
-		arg2 string
-		arg3 metav1.ListOptions
-	}
-	listResourcesByKindAndNamespaceReturns struct {
-		result1 *unstructured.UnstructuredList
-		result2 error
-	}
-	listResourcesByKindAndNamespaceReturnsOnCall map[int]struct {
-		result1 *unstructured.UnstructuredList
-		result2 error
-	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -195,7 +195,8 @@ func (fake *FakeClient) Apply(arg1 *unstructured.Unstructured) (kubernetes.Metad
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.applyReturns.result1, fake.applyReturns.result2
+	fakeReturns := fake.applyReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ApplyCallCount() int {
@@ -204,13 +205,22 @@ func (fake *FakeClient) ApplyCallCount() int {
 	return len(fake.applyArgsForCall)
 }
 
+func (fake *FakeClient) ApplyCalls(stub func(*unstructured.Unstructured) (kubernetes.Metadata, error)) {
+	fake.applyMutex.Lock()
+	defer fake.applyMutex.Unlock()
+	fake.ApplyStub = stub
+}
+
 func (fake *FakeClient) ApplyArgsForCall(i int) *unstructured.Unstructured {
 	fake.applyMutex.RLock()
 	defer fake.applyMutex.RUnlock()
-	return fake.applyArgsForCall[i].arg1
+	argsForCall := fake.applyArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ApplyReturns(result1 kubernetes.Metadata, result2 error) {
+	fake.applyMutex.Lock()
+	defer fake.applyMutex.Unlock()
 	fake.ApplyStub = nil
 	fake.applyReturns = struct {
 		result1 kubernetes.Metadata
@@ -219,6 +229,8 @@ func (fake *FakeClient) ApplyReturns(result1 kubernetes.Metadata, result2 error)
 }
 
 func (fake *FakeClient) ApplyReturnsOnCall(i int, result1 kubernetes.Metadata, result2 error) {
+	fake.applyMutex.Lock()
+	defer fake.applyMutex.Unlock()
 	fake.ApplyStub = nil
 	if fake.applyReturnsOnCall == nil {
 		fake.applyReturnsOnCall = make(map[int]struct {
@@ -247,7 +259,8 @@ func (fake *FakeClient) ApplyWithNamespaceOverride(arg1 *unstructured.Unstructur
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.applyWithNamespaceOverrideReturns.result1, fake.applyWithNamespaceOverrideReturns.result2
+	fakeReturns := fake.applyWithNamespaceOverrideReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideCallCount() int {
@@ -256,13 +269,22 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideCallCount() int {
 	return len(fake.applyWithNamespaceOverrideArgsForCall)
 }
 
+func (fake *FakeClient) ApplyWithNamespaceOverrideCalls(stub func(*unstructured.Unstructured, string) (kubernetes.Metadata, error)) {
+	fake.applyWithNamespaceOverrideMutex.Lock()
+	defer fake.applyWithNamespaceOverrideMutex.Unlock()
+	fake.ApplyWithNamespaceOverrideStub = stub
+}
+
 func (fake *FakeClient) ApplyWithNamespaceOverrideArgsForCall(i int) (*unstructured.Unstructured, string) {
 	fake.applyWithNamespaceOverrideMutex.RLock()
 	defer fake.applyWithNamespaceOverrideMutex.RUnlock()
-	return fake.applyWithNamespaceOverrideArgsForCall[i].arg1, fake.applyWithNamespaceOverrideArgsForCall[i].arg2
+	argsForCall := fake.applyWithNamespaceOverrideArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideReturns(result1 kubernetes.Metadata, result2 error) {
+	fake.applyWithNamespaceOverrideMutex.Lock()
+	defer fake.applyWithNamespaceOverrideMutex.Unlock()
 	fake.ApplyWithNamespaceOverrideStub = nil
 	fake.applyWithNamespaceOverrideReturns = struct {
 		result1 kubernetes.Metadata
@@ -271,6 +293,8 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideReturns(result1 kubernetes.Met
 }
 
 func (fake *FakeClient) ApplyWithNamespaceOverrideReturnsOnCall(i int, result1 kubernetes.Metadata, result2 error) {
+	fake.applyWithNamespaceOverrideMutex.Lock()
+	defer fake.applyWithNamespaceOverrideMutex.Unlock()
 	fake.ApplyWithNamespaceOverrideStub = nil
 	if fake.applyWithNamespaceOverrideReturnsOnCall == nil {
 		fake.applyWithNamespaceOverrideReturnsOnCall = make(map[int]struct {
@@ -284,14 +308,14 @@ func (fake *FakeClient) ApplyWithNamespaceOverrideReturnsOnCall(i int, result1 k
 	}{result1, result2}
 }
 
-func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg2 string, arg3 string, arg4 metav1.DeleteOptions) error {
+func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg2 string, arg3 string, arg4 v1.DeleteOptions) error {
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
 	ret, specificReturn := fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall[len(fake.deleteResourceByKindAndNameAndNamespaceArgsForCall)]
 	fake.deleteResourceByKindAndNameAndNamespaceArgsForCall = append(fake.deleteResourceByKindAndNameAndNamespaceArgsForCall, struct {
 		arg1 string
 		arg2 string
 		arg3 string
-		arg4 metav1.DeleteOptions
+		arg4 v1.DeleteOptions
 	}{arg1, arg2, arg3, arg4})
 	fake.recordInvocation("DeleteResourceByKindAndNameAndNamespace", []interface{}{arg1, arg2, arg3, arg4})
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
@@ -301,7 +325,8 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.deleteResourceByKindAndNameAndNamespaceReturns.result1
+	fakeReturns := fake.deleteResourceByKindAndNameAndNamespaceReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceCallCount() int {
@@ -310,13 +335,22 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceCallCount() int {
 	return len(fake.deleteResourceByKindAndNameAndNamespaceArgsForCall)
 }
 
-func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceArgsForCall(i int) (string, string, string, metav1.DeleteOptions) {
+func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceCalls(stub func(string, string, string, v1.DeleteOptions) error) {
+	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
+	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
+	fake.DeleteResourceByKindAndNameAndNamespaceStub = stub
+}
+
+func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceArgsForCall(i int) (string, string, string, v1.DeleteOptions) {
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.RLock()
 	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.RUnlock()
-	return fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg1, fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg2, fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg3, fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i].arg4
+	argsForCall := fake.deleteResourceByKindAndNameAndNamespaceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceReturns(result1 error) {
+	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
+	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
 	fake.DeleteResourceByKindAndNameAndNamespaceStub = nil
 	fake.deleteResourceByKindAndNameAndNamespaceReturns = struct {
 		result1 error
@@ -324,6 +358,8 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceReturns(result1 e
 }
 
 func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceReturnsOnCall(i int, result1 error) {
+	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
+	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
 	fake.DeleteResourceByKindAndNameAndNamespaceStub = nil
 	if fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall == nil {
 		fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall = make(map[int]struct {
@@ -349,7 +385,8 @@ func (fake *FakeClient) GVRForKind(arg1 string) (schema.GroupVersionResource, er
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.gVRForKindReturns.result1, fake.gVRForKindReturns.result2
+	fakeReturns := fake.gVRForKindReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) GVRForKindCallCount() int {
@@ -358,13 +395,22 @@ func (fake *FakeClient) GVRForKindCallCount() int {
 	return len(fake.gVRForKindArgsForCall)
 }
 
+func (fake *FakeClient) GVRForKindCalls(stub func(string) (schema.GroupVersionResource, error)) {
+	fake.gVRForKindMutex.Lock()
+	defer fake.gVRForKindMutex.Unlock()
+	fake.GVRForKindStub = stub
+}
+
 func (fake *FakeClient) GVRForKindArgsForCall(i int) string {
 	fake.gVRForKindMutex.RLock()
 	defer fake.gVRForKindMutex.RUnlock()
-	return fake.gVRForKindArgsForCall[i].arg1
+	argsForCall := fake.gVRForKindArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) GVRForKindReturns(result1 schema.GroupVersionResource, result2 error) {
+	fake.gVRForKindMutex.Lock()
+	defer fake.gVRForKindMutex.Unlock()
 	fake.GVRForKindStub = nil
 	fake.gVRForKindReturns = struct {
 		result1 schema.GroupVersionResource
@@ -373,6 +419,8 @@ func (fake *FakeClient) GVRForKindReturns(result1 schema.GroupVersionResource, r
 }
 
 func (fake *FakeClient) GVRForKindReturnsOnCall(i int, result1 schema.GroupVersionResource, result2 error) {
+	fake.gVRForKindMutex.Lock()
+	defer fake.gVRForKindMutex.Unlock()
 	fake.GVRForKindStub = nil
 	if fake.gVRForKindReturnsOnCall == nil {
 		fake.gVRForKindReturnsOnCall = make(map[int]struct {
@@ -402,7 +450,8 @@ func (fake *FakeClient) Get(arg1 string, arg2 string, arg3 string) (*unstructure
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getReturns.result1, fake.getReturns.result2
+	fakeReturns := fake.getReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) GetCallCount() int {
@@ -411,13 +460,22 @@ func (fake *FakeClient) GetCallCount() int {
 	return len(fake.getArgsForCall)
 }
 
+func (fake *FakeClient) GetCalls(stub func(string, string, string) (*unstructured.Unstructured, error)) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
+	fake.GetStub = stub
+}
+
 func (fake *FakeClient) GetArgsForCall(i int) (string, string, string) {
 	fake.getMutex.RLock()
 	defer fake.getMutex.RUnlock()
-	return fake.getArgsForCall[i].arg1, fake.getArgsForCall[i].arg2, fake.getArgsForCall[i].arg3
+	argsForCall := fake.getArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeClient) GetReturns(result1 *unstructured.Unstructured, result2 error) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
 	fake.GetStub = nil
 	fake.getReturns = struct {
 		result1 *unstructured.Unstructured
@@ -426,6 +484,8 @@ func (fake *FakeClient) GetReturns(result1 *unstructured.Unstructured, result2 e
 }
 
 func (fake *FakeClient) GetReturnsOnCall(i int, result1 *unstructured.Unstructured, result2 error) {
+	fake.getMutex.Lock()
+	defer fake.getMutex.Unlock()
 	fake.GetStub = nil
 	if fake.getReturnsOnCall == nil {
 		fake.getReturnsOnCall = make(map[int]struct {
@@ -439,12 +499,12 @@ func (fake *FakeClient) GetReturnsOnCall(i int, result1 *unstructured.Unstructur
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 v1.ListOptions) (*unstructured.UnstructuredList, error) {
 	fake.listByGVRMutex.Lock()
 	ret, specificReturn := fake.listByGVRReturnsOnCall[len(fake.listByGVRArgsForCall)]
 	fake.listByGVRArgsForCall = append(fake.listByGVRArgsForCall, struct {
 		arg1 schema.GroupVersionResource
-		arg2 metav1.ListOptions
+		arg2 v1.ListOptions
 	}{arg1, arg2})
 	fake.recordInvocation("ListByGVR", []interface{}{arg1, arg2})
 	fake.listByGVRMutex.Unlock()
@@ -454,7 +514,8 @@ func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 metav1.
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listByGVRReturns.result1, fake.listByGVRReturns.result2
+	fakeReturns := fake.listByGVRReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListByGVRCallCount() int {
@@ -463,13 +524,22 @@ func (fake *FakeClient) ListByGVRCallCount() int {
 	return len(fake.listByGVRArgsForCall)
 }
 
-func (fake *FakeClient) ListByGVRArgsForCall(i int) (schema.GroupVersionResource, metav1.ListOptions) {
+func (fake *FakeClient) ListByGVRCalls(stub func(schema.GroupVersionResource, v1.ListOptions) (*unstructured.UnstructuredList, error)) {
+	fake.listByGVRMutex.Lock()
+	defer fake.listByGVRMutex.Unlock()
+	fake.ListByGVRStub = stub
+}
+
+func (fake *FakeClient) ListByGVRArgsForCall(i int) (schema.GroupVersionResource, v1.ListOptions) {
 	fake.listByGVRMutex.RLock()
 	defer fake.listByGVRMutex.RUnlock()
-	return fake.listByGVRArgsForCall[i].arg1, fake.listByGVRArgsForCall[i].arg2
+	argsForCall := fake.listByGVRArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) ListByGVRReturns(result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listByGVRMutex.Lock()
+	defer fake.listByGVRMutex.Unlock()
 	fake.ListByGVRStub = nil
 	fake.listByGVRReturns = struct {
 		result1 *unstructured.UnstructuredList
@@ -478,6 +548,8 @@ func (fake *FakeClient) ListByGVRReturns(result1 *unstructured.UnstructuredList,
 }
 
 func (fake *FakeClient) ListByGVRReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listByGVRMutex.Lock()
+	defer fake.listByGVRMutex.Unlock()
 	fake.ListByGVRStub = nil
 	if fake.listByGVRReturnsOnCall == nil {
 		fake.listByGVRReturnsOnCall = make(map[int]struct {
@@ -491,13 +563,13 @@ func (fake *FakeClient) ListByGVRReturnsOnCall(i int, result1 *unstructured.Unst
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListByGVRWithContext(arg1 context.Context, arg2 schema.GroupVersionResource, arg3 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (fake *FakeClient) ListByGVRWithContext(arg1 context.Context, arg2 schema.GroupVersionResource, arg3 v1.ListOptions) (*unstructured.UnstructuredList, error) {
 	fake.listByGVRWithContextMutex.Lock()
 	ret, specificReturn := fake.listByGVRWithContextReturnsOnCall[len(fake.listByGVRWithContextArgsForCall)]
 	fake.listByGVRWithContextArgsForCall = append(fake.listByGVRWithContextArgsForCall, struct {
 		arg1 context.Context
 		arg2 schema.GroupVersionResource
-		arg3 metav1.ListOptions
+		arg3 v1.ListOptions
 	}{arg1, arg2, arg3})
 	fake.recordInvocation("ListByGVRWithContext", []interface{}{arg1, arg2, arg3})
 	fake.listByGVRWithContextMutex.Unlock()
@@ -507,7 +579,8 @@ func (fake *FakeClient) ListByGVRWithContext(arg1 context.Context, arg2 schema.G
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listByGVRWithContextReturns.result1, fake.listByGVRWithContextReturns.result2
+	fakeReturns := fake.listByGVRWithContextReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListByGVRWithContextCallCount() int {
@@ -516,13 +589,22 @@ func (fake *FakeClient) ListByGVRWithContextCallCount() int {
 	return len(fake.listByGVRWithContextArgsForCall)
 }
 
-func (fake *FakeClient) ListByGVRWithContextArgsForCall(i int) (context.Context, schema.GroupVersionResource, metav1.ListOptions) {
+func (fake *FakeClient) ListByGVRWithContextCalls(stub func(context.Context, schema.GroupVersionResource, v1.ListOptions) (*unstructured.UnstructuredList, error)) {
+	fake.listByGVRWithContextMutex.Lock()
+	defer fake.listByGVRWithContextMutex.Unlock()
+	fake.ListByGVRWithContextStub = stub
+}
+
+func (fake *FakeClient) ListByGVRWithContextArgsForCall(i int) (context.Context, schema.GroupVersionResource, v1.ListOptions) {
 	fake.listByGVRWithContextMutex.RLock()
 	defer fake.listByGVRWithContextMutex.RUnlock()
-	return fake.listByGVRWithContextArgsForCall[i].arg1, fake.listByGVRWithContextArgsForCall[i].arg2, fake.listByGVRWithContextArgsForCall[i].arg3
+	argsForCall := fake.listByGVRWithContextArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
 }
 
 func (fake *FakeClient) ListByGVRWithContextReturns(result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listByGVRWithContextMutex.Lock()
+	defer fake.listByGVRWithContextMutex.Unlock()
 	fake.ListByGVRWithContextStub = nil
 	fake.listByGVRWithContextReturns = struct {
 		result1 *unstructured.UnstructuredList
@@ -531,6 +613,8 @@ func (fake *FakeClient) ListByGVRWithContextReturns(result1 *unstructured.Unstru
 }
 
 func (fake *FakeClient) ListByGVRWithContextReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listByGVRWithContextMutex.Lock()
+	defer fake.listByGVRWithContextMutex.Unlock()
 	fake.ListByGVRWithContextStub = nil
 	if fake.listByGVRWithContextReturnsOnCall == nil {
 		fake.listByGVRWithContextReturnsOnCall = make(map[int]struct {
@@ -544,12 +628,12 @@ func (fake *FakeClient) ListByGVRWithContextReturnsOnCall(i int, result1 *unstru
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ListResource(arg1 string, arg2 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+func (fake *FakeClient) ListResource(arg1 string, arg2 v1.ListOptions) (*unstructured.UnstructuredList, error) {
 	fake.listResourceMutex.Lock()
 	ret, specificReturn := fake.listResourceReturnsOnCall[len(fake.listResourceArgsForCall)]
 	fake.listResourceArgsForCall = append(fake.listResourceArgsForCall, struct {
 		arg1 string
-		arg2 metav1.ListOptions
+		arg2 v1.ListOptions
 	}{arg1, arg2})
 	fake.recordInvocation("ListResource", []interface{}{arg1, arg2})
 	fake.listResourceMutex.Unlock()
@@ -559,7 +643,8 @@ func (fake *FakeClient) ListResource(arg1 string, arg2 metav1.ListOptions) (*uns
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listResourceReturns.result1, fake.listResourceReturns.result2
+	fakeReturns := fake.listResourceReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListResourceCallCount() int {
@@ -568,13 +653,22 @@ func (fake *FakeClient) ListResourceCallCount() int {
 	return len(fake.listResourceArgsForCall)
 }
 
-func (fake *FakeClient) ListResourceArgsForCall(i int) (string, metav1.ListOptions) {
+func (fake *FakeClient) ListResourceCalls(stub func(string, v1.ListOptions) (*unstructured.UnstructuredList, error)) {
+	fake.listResourceMutex.Lock()
+	defer fake.listResourceMutex.Unlock()
+	fake.ListResourceStub = stub
+}
+
+func (fake *FakeClient) ListResourceArgsForCall(i int) (string, v1.ListOptions) {
 	fake.listResourceMutex.RLock()
 	defer fake.listResourceMutex.RUnlock()
-	return fake.listResourceArgsForCall[i].arg1, fake.listResourceArgsForCall[i].arg2
+	argsForCall := fake.listResourceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeClient) ListResourceReturns(result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listResourceMutex.Lock()
+	defer fake.listResourceMutex.Unlock()
 	fake.ListResourceStub = nil
 	fake.listResourceReturns = struct {
 		result1 *unstructured.UnstructuredList
@@ -583,6 +677,8 @@ func (fake *FakeClient) ListResourceReturns(result1 *unstructured.UnstructuredLi
 }
 
 func (fake *FakeClient) ListResourceReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listResourceMutex.Lock()
+	defer fake.listResourceMutex.Unlock()
 	fake.ListResourceStub = nil
 	if fake.listResourceReturnsOnCall == nil {
 		fake.listResourceReturnsOnCall = make(map[int]struct {
@@ -591,6 +687,71 @@ func (fake *FakeClient) ListResourceReturnsOnCall(i int, result1 *unstructured.U
 		})
 	}
 	fake.listResourceReturnsOnCall[i] = struct {
+		result1 *unstructured.UnstructuredList
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListResourcesByKindAndNamespace(arg1 string, arg2 string, arg3 v1.ListOptions) (*unstructured.UnstructuredList, error) {
+	fake.listResourcesByKindAndNamespaceMutex.Lock()
+	ret, specificReturn := fake.listResourcesByKindAndNamespaceReturnsOnCall[len(fake.listResourcesByKindAndNamespaceArgsForCall)]
+	fake.listResourcesByKindAndNamespaceArgsForCall = append(fake.listResourcesByKindAndNamespaceArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 v1.ListOptions
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("ListResourcesByKindAndNamespace", []interface{}{arg1, arg2, arg3})
+	fake.listResourcesByKindAndNamespaceMutex.Unlock()
+	if fake.ListResourcesByKindAndNamespaceStub != nil {
+		return fake.ListResourcesByKindAndNamespaceStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listResourcesByKindAndNamespaceReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListResourcesByKindAndNamespaceCallCount() int {
+	fake.listResourcesByKindAndNamespaceMutex.RLock()
+	defer fake.listResourcesByKindAndNamespaceMutex.RUnlock()
+	return len(fake.listResourcesByKindAndNamespaceArgsForCall)
+}
+
+func (fake *FakeClient) ListResourcesByKindAndNamespaceCalls(stub func(string, string, v1.ListOptions) (*unstructured.UnstructuredList, error)) {
+	fake.listResourcesByKindAndNamespaceMutex.Lock()
+	defer fake.listResourcesByKindAndNamespaceMutex.Unlock()
+	fake.ListResourcesByKindAndNamespaceStub = stub
+}
+
+func (fake *FakeClient) ListResourcesByKindAndNamespaceArgsForCall(i int) (string, string, v1.ListOptions) {
+	fake.listResourcesByKindAndNamespaceMutex.RLock()
+	defer fake.listResourcesByKindAndNamespaceMutex.RUnlock()
+	argsForCall := fake.listResourcesByKindAndNamespaceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeClient) ListResourcesByKindAndNamespaceReturns(result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listResourcesByKindAndNamespaceMutex.Lock()
+	defer fake.listResourcesByKindAndNamespaceMutex.Unlock()
+	fake.ListResourcesByKindAndNamespaceStub = nil
+	fake.listResourcesByKindAndNamespaceReturns = struct {
+		result1 *unstructured.UnstructuredList
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListResourcesByKindAndNamespaceReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
+	fake.listResourcesByKindAndNamespaceMutex.Lock()
+	defer fake.listResourcesByKindAndNamespaceMutex.Unlock()
+	fake.ListResourcesByKindAndNamespaceStub = nil
+	if fake.listResourcesByKindAndNamespaceReturnsOnCall == nil {
+		fake.listResourcesByKindAndNamespaceReturnsOnCall = make(map[int]struct {
+			result1 *unstructured.UnstructuredList
+			result2 error
+		})
+	}
+	fake.listResourcesByKindAndNamespaceReturnsOnCall[i] = struct {
 		result1 *unstructured.UnstructuredList
 		result2 error
 	}{result1, result2}
@@ -618,7 +779,8 @@ func (fake *FakeClient) Patch(arg1 string, arg2 string, arg3 string, arg4 []byte
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.patchReturns.result1, fake.patchReturns.result2, fake.patchReturns.result3
+	fakeReturns := fake.patchReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeClient) PatchCallCount() int {
@@ -627,13 +789,22 @@ func (fake *FakeClient) PatchCallCount() int {
 	return len(fake.patchArgsForCall)
 }
 
+func (fake *FakeClient) PatchCalls(stub func(string, string, string, []byte) (kubernetes.Metadata, *unstructured.Unstructured, error)) {
+	fake.patchMutex.Lock()
+	defer fake.patchMutex.Unlock()
+	fake.PatchStub = stub
+}
+
 func (fake *FakeClient) PatchArgsForCall(i int) (string, string, string, []byte) {
 	fake.patchMutex.RLock()
 	defer fake.patchMutex.RUnlock()
-	return fake.patchArgsForCall[i].arg1, fake.patchArgsForCall[i].arg2, fake.patchArgsForCall[i].arg3, fake.patchArgsForCall[i].arg4
+	argsForCall := fake.patchArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
 }
 
 func (fake *FakeClient) PatchReturns(result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.patchMutex.Lock()
+	defer fake.patchMutex.Unlock()
 	fake.PatchStub = nil
 	fake.patchReturns = struct {
 		result1 kubernetes.Metadata
@@ -643,6 +814,8 @@ func (fake *FakeClient) PatchReturns(result1 kubernetes.Metadata, result2 *unstr
 }
 
 func (fake *FakeClient) PatchReturnsOnCall(i int, result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.patchMutex.Lock()
+	defer fake.patchMutex.Unlock()
 	fake.PatchStub = nil
 	if fake.patchReturnsOnCall == nil {
 		fake.patchReturnsOnCall = make(map[int]struct {
@@ -681,7 +854,8 @@ func (fake *FakeClient) PatchUsingStrategy(arg1 string, arg2 string, arg3 string
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	return fake.patchUsingStrategyReturns.result1, fake.patchUsingStrategyReturns.result2, fake.patchUsingStrategyReturns.result3
+	fakeReturns := fake.patchUsingStrategyReturns
+	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
 func (fake *FakeClient) PatchUsingStrategyCallCount() int {
@@ -690,13 +864,22 @@ func (fake *FakeClient) PatchUsingStrategyCallCount() int {
 	return len(fake.patchUsingStrategyArgsForCall)
 }
 
+func (fake *FakeClient) PatchUsingStrategyCalls(stub func(string, string, string, []byte, types.PatchType) (kubernetes.Metadata, *unstructured.Unstructured, error)) {
+	fake.patchUsingStrategyMutex.Lock()
+	defer fake.patchUsingStrategyMutex.Unlock()
+	fake.PatchUsingStrategyStub = stub
+}
+
 func (fake *FakeClient) PatchUsingStrategyArgsForCall(i int) (string, string, string, []byte, types.PatchType) {
 	fake.patchUsingStrategyMutex.RLock()
 	defer fake.patchUsingStrategyMutex.RUnlock()
-	return fake.patchUsingStrategyArgsForCall[i].arg1, fake.patchUsingStrategyArgsForCall[i].arg2, fake.patchUsingStrategyArgsForCall[i].arg3, fake.patchUsingStrategyArgsForCall[i].arg4, fake.patchUsingStrategyArgsForCall[i].arg5
+	argsForCall := fake.patchUsingStrategyArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4, argsForCall.arg5
 }
 
 func (fake *FakeClient) PatchUsingStrategyReturns(result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.patchUsingStrategyMutex.Lock()
+	defer fake.patchUsingStrategyMutex.Unlock()
 	fake.PatchUsingStrategyStub = nil
 	fake.patchUsingStrategyReturns = struct {
 		result1 kubernetes.Metadata
@@ -706,6 +889,8 @@ func (fake *FakeClient) PatchUsingStrategyReturns(result1 kubernetes.Metadata, r
 }
 
 func (fake *FakeClient) PatchUsingStrategyReturnsOnCall(i int, result1 kubernetes.Metadata, result2 *unstructured.Unstructured, result3 error) {
+	fake.patchUsingStrategyMutex.Lock()
+	defer fake.patchUsingStrategyMutex.Unlock()
 	fake.PatchUsingStrategyStub = nil
 	if fake.patchUsingStrategyReturnsOnCall == nil {
 		fake.patchUsingStrategyReturnsOnCall = make(map[int]struct {
@@ -719,59 +904,6 @@ func (fake *FakeClient) PatchUsingStrategyReturnsOnCall(i int, result1 kubernete
 		result2 *unstructured.Unstructured
 		result3 error
 	}{result1, result2, result3}
-}
-
-func (fake *FakeClient) ListResourcesByKindAndNamespace(arg1 string, arg2 string, arg3 metav1.ListOptions) (*unstructured.UnstructuredList, error) {
-	fake.listResourcesByKindAndNamespaceMutex.Lock()
-	ret, specificReturn := fake.listResourcesByKindAndNamespaceReturnsOnCall[len(fake.listResourcesByKindAndNamespaceArgsForCall)]
-	fake.listResourcesByKindAndNamespaceArgsForCall = append(fake.listResourcesByKindAndNamespaceArgsForCall, struct {
-		arg1 string
-		arg2 string
-		arg3 metav1.ListOptions
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("ListResourcesByKindAndNamespace", []interface{}{arg1, arg2, arg3})
-	fake.listResourcesByKindAndNamespaceMutex.Unlock()
-	if fake.ListResourcesByKindAndNamespaceStub != nil {
-		return fake.ListResourcesByKindAndNamespaceStub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.listResourcesByKindAndNamespaceReturns.result1, fake.listResourcesByKindAndNamespaceReturns.result2
-}
-
-func (fake *FakeClient) ListResourcesByKindAndNamespaceCallCount() int {
-	fake.listResourcesByKindAndNamespaceMutex.RLock()
-	defer fake.listResourcesByKindAndNamespaceMutex.RUnlock()
-	return len(fake.listResourcesByKindAndNamespaceArgsForCall)
-}
-
-func (fake *FakeClient) ListResourcesByKindAndNamespaceArgsForCall(i int) (string, string, metav1.ListOptions) {
-	fake.listResourcesByKindAndNamespaceMutex.RLock()
-	defer fake.listResourcesByKindAndNamespaceMutex.RUnlock()
-	return fake.listResourcesByKindAndNamespaceArgsForCall[i].arg1, fake.listResourcesByKindAndNamespaceArgsForCall[i].arg2, fake.listResourcesByKindAndNamespaceArgsForCall[i].arg3
-}
-
-func (fake *FakeClient) ListResourcesByKindAndNamespaceReturns(result1 *unstructured.UnstructuredList, result2 error) {
-	fake.ListResourcesByKindAndNamespaceStub = nil
-	fake.listResourcesByKindAndNamespaceReturns = struct {
-		result1 *unstructured.UnstructuredList
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) ListResourcesByKindAndNamespaceReturnsOnCall(i int, result1 *unstructured.UnstructuredList, result2 error) {
-	fake.ListResourcesByKindAndNamespaceStub = nil
-	if fake.listResourcesByKindAndNamespaceReturnsOnCall == nil {
-		fake.listResourcesByKindAndNamespaceReturnsOnCall = make(map[int]struct {
-			result1 *unstructured.UnstructuredList
-			result2 error
-		})
-	}
-	fake.listResourcesByKindAndNamespaceReturnsOnCall[i] = struct {
-		result1 *unstructured.UnstructuredList
-		result2 error
-	}{result1, result2}
 }
 
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
@@ -793,12 +925,12 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listByGVRWithContextMutex.RUnlock()
 	fake.listResourceMutex.RLock()
 	defer fake.listResourceMutex.RUnlock()
+	fake.listResourcesByKindAndNamespaceMutex.RLock()
+	defer fake.listResourcesByKindAndNamespaceMutex.RUnlock()
 	fake.patchMutex.RLock()
 	defer fake.patchMutex.RUnlock()
 	fake.patchUsingStrategyMutex.RLock()
 	defer fake.patchUsingStrategyMutex.RUnlock()
-	fake.listResourcesByKindAndNamespaceMutex.RLock()
-	defer fake.listResourcesByKindAndNamespaceMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value

--- a/pkg/kubernetes/kubernetesfakes/fake_controller.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_controller.go
@@ -11,6 +11,89 @@ import (
 )
 
 type FakeController struct {
+	AddSpinnakerAnnotationsStub        func(*unstructured.Unstructured, string) error
+	addSpinnakerAnnotationsMutex       sync.RWMutex
+	addSpinnakerAnnotationsArgsForCall []struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}
+	addSpinnakerAnnotationsReturns struct {
+		result1 error
+	}
+	addSpinnakerAnnotationsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	AddSpinnakerLabelsStub        func(*unstructured.Unstructured, string) error
+	addSpinnakerLabelsMutex       sync.RWMutex
+	addSpinnakerLabelsArgsForCall []struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}
+	addSpinnakerLabelsReturns struct {
+		result1 error
+	}
+	addSpinnakerLabelsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	AddSpinnakerVersionAnnotationsStub        func(*unstructured.Unstructured, kubernetes.SpinnakerVersion) error
+	addSpinnakerVersionAnnotationsMutex       sync.RWMutex
+	addSpinnakerVersionAnnotationsArgsForCall []struct {
+		arg1 *unstructured.Unstructured
+		arg2 kubernetes.SpinnakerVersion
+	}
+	addSpinnakerVersionAnnotationsReturns struct {
+		result1 error
+	}
+	addSpinnakerVersionAnnotationsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	AddSpinnakerVersionLabelsStub        func(*unstructured.Unstructured, kubernetes.SpinnakerVersion) error
+	addSpinnakerVersionLabelsMutex       sync.RWMutex
+	addSpinnakerVersionLabelsArgsForCall []struct {
+		arg1 *unstructured.Unstructured
+		arg2 kubernetes.SpinnakerVersion
+	}
+	addSpinnakerVersionLabelsReturns struct {
+		result1 error
+	}
+	addSpinnakerVersionLabelsReturnsOnCall map[int]struct {
+		result1 error
+	}
+	GetCurrentVersionStub        func(*unstructured.UnstructuredList, string, string) string
+	getCurrentVersionMutex       sync.RWMutex
+	getCurrentVersionArgsForCall []struct {
+		arg1 *unstructured.UnstructuredList
+		arg2 string
+		arg3 string
+	}
+	getCurrentVersionReturns struct {
+		result1 string
+	}
+	getCurrentVersionReturnsOnCall map[int]struct {
+		result1 string
+	}
+	IncrementVersionStub        func(string) kubernetes.SpinnakerVersion
+	incrementVersionMutex       sync.RWMutex
+	incrementVersionArgsForCall []struct {
+		arg1 string
+	}
+	incrementVersionReturns struct {
+		result1 kubernetes.SpinnakerVersion
+	}
+	incrementVersionReturnsOnCall map[int]struct {
+		result1 kubernetes.SpinnakerVersion
+	}
+	IsVersionedStub        func(*unstructured.Unstructured) bool
+	isVersionedMutex       sync.RWMutex
+	isVersionedArgsForCall []struct {
+		arg1 *unstructured.Unstructured
+	}
+	isVersionedReturns struct {
+		result1 bool
+	}
+	isVersionedReturnsOnCall map[int]struct {
+		result1 bool
+	}
 	NewClientStub        func(*rest.Config) (kubernetes.Client, error)
 	newClientMutex       sync.RWMutex
 	newClientArgsForCall []struct {
@@ -22,6 +105,19 @@ type FakeController struct {
 	}
 	newClientReturnsOnCall map[int]struct {
 		result1 kubernetes.Client
+		result2 error
+	}
+	SortManifestsStub        func([]map[string]interface{}) ([]map[string]interface{}, error)
+	sortManifestsMutex       sync.RWMutex
+	sortManifestsArgsForCall []struct {
+		arg1 []map[string]interface{}
+	}
+	sortManifestsReturns struct {
+		result1 []map[string]interface{}
+		result2 error
+	}
+	sortManifestsReturnsOnCall map[int]struct {
+		result1 []map[string]interface{}
 		result2 error
 	}
 	ToUnstructuredStub        func(map[string]interface{}) (*unstructured.Unstructured, error)
@@ -37,107 +133,11 @@ type FakeController struct {
 		result1 *unstructured.Unstructured
 		result2 error
 	}
-	AddSpinnakerAnnotationsStub        func(u *unstructured.Unstructured, application string) error
-	addSpinnakerAnnotationsMutex       sync.RWMutex
-	addSpinnakerAnnotationsArgsForCall []struct {
-		u           *unstructured.Unstructured
-		application string
-	}
-	addSpinnakerAnnotationsReturns struct {
-		result1 error
-	}
-	addSpinnakerAnnotationsReturnsOnCall map[int]struct {
-		result1 error
-	}
-	AddSpinnakerLabelsStub        func(u *unstructured.Unstructured, application string) error
-	addSpinnakerLabelsMutex       sync.RWMutex
-	addSpinnakerLabelsArgsForCall []struct {
-		u           *unstructured.Unstructured
-		application string
-	}
-	addSpinnakerLabelsReturns struct {
-		result1 error
-	}
-	addSpinnakerLabelsReturnsOnCall map[int]struct {
-		result1 error
-	}
-	SortManifestsStub        func([]map[string]interface{}) ([]map[string]interface{}, error)
-	sortManifestsMutex       sync.RWMutex
-	sortManifestsArgsForCall []struct {
-		arg1 []map[string]interface{}
-	}
-	sortManifestsReturns struct {
-		result1 []map[string]interface{}
-		result2 error
-	}
-	sortManifestsReturnsOnCall map[int]struct {
-		result1 []map[string]interface{}
-		result2 error
-	}
-	AddSpinnakerVersionAnnotationsStub        func(u *unstructured.Unstructured, version kubernetes.SpinnakerVersion) error
-	addSpinnakerVersionAnnotationsMutex       sync.RWMutex
-	addSpinnakerVersionAnnotationsArgsForCall []struct {
-		u       *unstructured.Unstructured
-		version kubernetes.SpinnakerVersion
-	}
-	addSpinnakerVersionAnnotationsReturns struct {
-		result1 error
-	}
-	addSpinnakerVersionAnnotationsReturnsOnCall map[int]struct {
-		result1 error
-	}
-	AddSpinnakerVersionLabelsStub        func(u *unstructured.Unstructured, version kubernetes.SpinnakerVersion) error
-	addSpinnakerVersionLabelsMutex       sync.RWMutex
-	addSpinnakerVersionLabelsArgsForCall []struct {
-		u       *unstructured.Unstructured
-		version kubernetes.SpinnakerVersion
-	}
-	addSpinnakerVersionLabelsReturns struct {
-		result1 error
-	}
-	addSpinnakerVersionLabelsReturnsOnCall map[int]struct {
-		result1 error
-	}
-	GetCurrentVersionStub        func(ul *unstructured.UnstructuredList, kind, name string) string
-	getCurrentVersionMutex       sync.RWMutex
-	getCurrentVersionArgsForCall []struct {
-		ul   *unstructured.UnstructuredList
-		kind string
-		name string
-	}
-	getCurrentVersionReturns struct {
-		result1 string
-	}
-	getCurrentVersionReturnsOnCall map[int]struct {
-		result1 string
-	}
-	IsVersionedStub        func(u *unstructured.Unstructured) bool
-	isVersionedMutex       sync.RWMutex
-	isVersionedArgsForCall []struct {
-		u *unstructured.Unstructured
-	}
-	isVersionedReturns struct {
-		result1 bool
-	}
-	isVersionedReturnsOnCall map[int]struct {
-		result1 bool
-	}
-	IncrementVersionStub        func(currentVersion string) kubernetes.SpinnakerVersion
-	incrementVersionMutex       sync.RWMutex
-	incrementVersionArgsForCall []struct {
-		currentVersion string
-	}
-	incrementVersionReturns struct {
-		result1 kubernetes.SpinnakerVersion
-	}
-	incrementVersionReturnsOnCall map[int]struct {
-		result1 kubernetes.SpinnakerVersion
-	}
-	VersionVolumesStub        func(u *unstructured.Unstructured, requiredArtifacts []clouddriver.TaskCreatedArtifact) error
+	VersionVolumesStub        func(*unstructured.Unstructured, map[string]clouddriver.TaskCreatedArtifact) error
 	versionVolumesMutex       sync.RWMutex
 	versionVolumesArgsForCall []struct {
-		u                 *unstructured.Unstructured
-		requiredArtifacts []clouddriver.TaskCreatedArtifact
+		arg1 *unstructured.Unstructured
+		arg2 map[string]clouddriver.TaskCreatedArtifact
 	}
 	versionVolumesReturns struct {
 		result1 error
@@ -147,6 +147,432 @@ type FakeController struct {
 	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
+}
+
+func (fake *FakeController) AddSpinnakerAnnotations(arg1 *unstructured.Unstructured, arg2 string) error {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	ret, specificReturn := fake.addSpinnakerAnnotationsReturnsOnCall[len(fake.addSpinnakerAnnotationsArgsForCall)]
+	fake.addSpinnakerAnnotationsArgsForCall = append(fake.addSpinnakerAnnotationsArgsForCall, struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("AddSpinnakerAnnotations", []interface{}{arg1, arg2})
+	fake.addSpinnakerAnnotationsMutex.Unlock()
+	if fake.AddSpinnakerAnnotationsStub != nil {
+		return fake.AddSpinnakerAnnotationsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.addSpinnakerAnnotationsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsCallCount() int {
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	return len(fake.addSpinnakerAnnotationsArgsForCall)
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsCalls(stub func(*unstructured.Unstructured, string) error) {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	defer fake.addSpinnakerAnnotationsMutex.Unlock()
+	fake.AddSpinnakerAnnotationsStub = stub
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsArgsForCall(i int) (*unstructured.Unstructured, string) {
+	fake.addSpinnakerAnnotationsMutex.RLock()
+	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
+	argsForCall := fake.addSpinnakerAnnotationsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsReturns(result1 error) {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	defer fake.addSpinnakerAnnotationsMutex.Unlock()
+	fake.AddSpinnakerAnnotationsStub = nil
+	fake.addSpinnakerAnnotationsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerAnnotationsReturnsOnCall(i int, result1 error) {
+	fake.addSpinnakerAnnotationsMutex.Lock()
+	defer fake.addSpinnakerAnnotationsMutex.Unlock()
+	fake.AddSpinnakerAnnotationsStub = nil
+	if fake.addSpinnakerAnnotationsReturnsOnCall == nil {
+		fake.addSpinnakerAnnotationsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addSpinnakerAnnotationsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerLabels(arg1 *unstructured.Unstructured, arg2 string) error {
+	fake.addSpinnakerLabelsMutex.Lock()
+	ret, specificReturn := fake.addSpinnakerLabelsReturnsOnCall[len(fake.addSpinnakerLabelsArgsForCall)]
+	fake.addSpinnakerLabelsArgsForCall = append(fake.addSpinnakerLabelsArgsForCall, struct {
+		arg1 *unstructured.Unstructured
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("AddSpinnakerLabels", []interface{}{arg1, arg2})
+	fake.addSpinnakerLabelsMutex.Unlock()
+	if fake.AddSpinnakerLabelsStub != nil {
+		return fake.AddSpinnakerLabelsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.addSpinnakerLabelsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) AddSpinnakerLabelsCallCount() int {
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
+	return len(fake.addSpinnakerLabelsArgsForCall)
+}
+
+func (fake *FakeController) AddSpinnakerLabelsCalls(stub func(*unstructured.Unstructured, string) error) {
+	fake.addSpinnakerLabelsMutex.Lock()
+	defer fake.addSpinnakerLabelsMutex.Unlock()
+	fake.AddSpinnakerLabelsStub = stub
+}
+
+func (fake *FakeController) AddSpinnakerLabelsArgsForCall(i int) (*unstructured.Unstructured, string) {
+	fake.addSpinnakerLabelsMutex.RLock()
+	defer fake.addSpinnakerLabelsMutex.RUnlock()
+	argsForCall := fake.addSpinnakerLabelsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeController) AddSpinnakerLabelsReturns(result1 error) {
+	fake.addSpinnakerLabelsMutex.Lock()
+	defer fake.addSpinnakerLabelsMutex.Unlock()
+	fake.AddSpinnakerLabelsStub = nil
+	fake.addSpinnakerLabelsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerLabelsReturnsOnCall(i int, result1 error) {
+	fake.addSpinnakerLabelsMutex.Lock()
+	defer fake.addSpinnakerLabelsMutex.Unlock()
+	fake.AddSpinnakerLabelsStub = nil
+	if fake.addSpinnakerLabelsReturnsOnCall == nil {
+		fake.addSpinnakerLabelsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addSpinnakerLabelsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerVersionAnnotations(arg1 *unstructured.Unstructured, arg2 kubernetes.SpinnakerVersion) error {
+	fake.addSpinnakerVersionAnnotationsMutex.Lock()
+	ret, specificReturn := fake.addSpinnakerVersionAnnotationsReturnsOnCall[len(fake.addSpinnakerVersionAnnotationsArgsForCall)]
+	fake.addSpinnakerVersionAnnotationsArgsForCall = append(fake.addSpinnakerVersionAnnotationsArgsForCall, struct {
+		arg1 *unstructured.Unstructured
+		arg2 kubernetes.SpinnakerVersion
+	}{arg1, arg2})
+	fake.recordInvocation("AddSpinnakerVersionAnnotations", []interface{}{arg1, arg2})
+	fake.addSpinnakerVersionAnnotationsMutex.Unlock()
+	if fake.AddSpinnakerVersionAnnotationsStub != nil {
+		return fake.AddSpinnakerVersionAnnotationsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.addSpinnakerVersionAnnotationsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) AddSpinnakerVersionAnnotationsCallCount() int {
+	fake.addSpinnakerVersionAnnotationsMutex.RLock()
+	defer fake.addSpinnakerVersionAnnotationsMutex.RUnlock()
+	return len(fake.addSpinnakerVersionAnnotationsArgsForCall)
+}
+
+func (fake *FakeController) AddSpinnakerVersionAnnotationsCalls(stub func(*unstructured.Unstructured, kubernetes.SpinnakerVersion) error) {
+	fake.addSpinnakerVersionAnnotationsMutex.Lock()
+	defer fake.addSpinnakerVersionAnnotationsMutex.Unlock()
+	fake.AddSpinnakerVersionAnnotationsStub = stub
+}
+
+func (fake *FakeController) AddSpinnakerVersionAnnotationsArgsForCall(i int) (*unstructured.Unstructured, kubernetes.SpinnakerVersion) {
+	fake.addSpinnakerVersionAnnotationsMutex.RLock()
+	defer fake.addSpinnakerVersionAnnotationsMutex.RUnlock()
+	argsForCall := fake.addSpinnakerVersionAnnotationsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeController) AddSpinnakerVersionAnnotationsReturns(result1 error) {
+	fake.addSpinnakerVersionAnnotationsMutex.Lock()
+	defer fake.addSpinnakerVersionAnnotationsMutex.Unlock()
+	fake.AddSpinnakerVersionAnnotationsStub = nil
+	fake.addSpinnakerVersionAnnotationsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerVersionAnnotationsReturnsOnCall(i int, result1 error) {
+	fake.addSpinnakerVersionAnnotationsMutex.Lock()
+	defer fake.addSpinnakerVersionAnnotationsMutex.Unlock()
+	fake.AddSpinnakerVersionAnnotationsStub = nil
+	if fake.addSpinnakerVersionAnnotationsReturnsOnCall == nil {
+		fake.addSpinnakerVersionAnnotationsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addSpinnakerVersionAnnotationsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerVersionLabels(arg1 *unstructured.Unstructured, arg2 kubernetes.SpinnakerVersion) error {
+	fake.addSpinnakerVersionLabelsMutex.Lock()
+	ret, specificReturn := fake.addSpinnakerVersionLabelsReturnsOnCall[len(fake.addSpinnakerVersionLabelsArgsForCall)]
+	fake.addSpinnakerVersionLabelsArgsForCall = append(fake.addSpinnakerVersionLabelsArgsForCall, struct {
+		arg1 *unstructured.Unstructured
+		arg2 kubernetes.SpinnakerVersion
+	}{arg1, arg2})
+	fake.recordInvocation("AddSpinnakerVersionLabels", []interface{}{arg1, arg2})
+	fake.addSpinnakerVersionLabelsMutex.Unlock()
+	if fake.AddSpinnakerVersionLabelsStub != nil {
+		return fake.AddSpinnakerVersionLabelsStub(arg1, arg2)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.addSpinnakerVersionLabelsReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) AddSpinnakerVersionLabelsCallCount() int {
+	fake.addSpinnakerVersionLabelsMutex.RLock()
+	defer fake.addSpinnakerVersionLabelsMutex.RUnlock()
+	return len(fake.addSpinnakerVersionLabelsArgsForCall)
+}
+
+func (fake *FakeController) AddSpinnakerVersionLabelsCalls(stub func(*unstructured.Unstructured, kubernetes.SpinnakerVersion) error) {
+	fake.addSpinnakerVersionLabelsMutex.Lock()
+	defer fake.addSpinnakerVersionLabelsMutex.Unlock()
+	fake.AddSpinnakerVersionLabelsStub = stub
+}
+
+func (fake *FakeController) AddSpinnakerVersionLabelsArgsForCall(i int) (*unstructured.Unstructured, kubernetes.SpinnakerVersion) {
+	fake.addSpinnakerVersionLabelsMutex.RLock()
+	defer fake.addSpinnakerVersionLabelsMutex.RUnlock()
+	argsForCall := fake.addSpinnakerVersionLabelsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
+func (fake *FakeController) AddSpinnakerVersionLabelsReturns(result1 error) {
+	fake.addSpinnakerVersionLabelsMutex.Lock()
+	defer fake.addSpinnakerVersionLabelsMutex.Unlock()
+	fake.AddSpinnakerVersionLabelsStub = nil
+	fake.addSpinnakerVersionLabelsReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) AddSpinnakerVersionLabelsReturnsOnCall(i int, result1 error) {
+	fake.addSpinnakerVersionLabelsMutex.Lock()
+	defer fake.addSpinnakerVersionLabelsMutex.Unlock()
+	fake.AddSpinnakerVersionLabelsStub = nil
+	if fake.addSpinnakerVersionLabelsReturnsOnCall == nil {
+		fake.addSpinnakerVersionLabelsReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.addSpinnakerVersionLabelsReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeController) GetCurrentVersion(arg1 *unstructured.UnstructuredList, arg2 string, arg3 string) string {
+	fake.getCurrentVersionMutex.Lock()
+	ret, specificReturn := fake.getCurrentVersionReturnsOnCall[len(fake.getCurrentVersionArgsForCall)]
+	fake.getCurrentVersionArgsForCall = append(fake.getCurrentVersionArgsForCall, struct {
+		arg1 *unstructured.UnstructuredList
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("GetCurrentVersion", []interface{}{arg1, arg2, arg3})
+	fake.getCurrentVersionMutex.Unlock()
+	if fake.GetCurrentVersionStub != nil {
+		return fake.GetCurrentVersionStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.getCurrentVersionReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) GetCurrentVersionCallCount() int {
+	fake.getCurrentVersionMutex.RLock()
+	defer fake.getCurrentVersionMutex.RUnlock()
+	return len(fake.getCurrentVersionArgsForCall)
+}
+
+func (fake *FakeController) GetCurrentVersionCalls(stub func(*unstructured.UnstructuredList, string, string) string) {
+	fake.getCurrentVersionMutex.Lock()
+	defer fake.getCurrentVersionMutex.Unlock()
+	fake.GetCurrentVersionStub = stub
+}
+
+func (fake *FakeController) GetCurrentVersionArgsForCall(i int) (*unstructured.UnstructuredList, string, string) {
+	fake.getCurrentVersionMutex.RLock()
+	defer fake.getCurrentVersionMutex.RUnlock()
+	argsForCall := fake.getCurrentVersionArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeController) GetCurrentVersionReturns(result1 string) {
+	fake.getCurrentVersionMutex.Lock()
+	defer fake.getCurrentVersionMutex.Unlock()
+	fake.GetCurrentVersionStub = nil
+	fake.getCurrentVersionReturns = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeController) GetCurrentVersionReturnsOnCall(i int, result1 string) {
+	fake.getCurrentVersionMutex.Lock()
+	defer fake.getCurrentVersionMutex.Unlock()
+	fake.GetCurrentVersionStub = nil
+	if fake.getCurrentVersionReturnsOnCall == nil {
+		fake.getCurrentVersionReturnsOnCall = make(map[int]struct {
+			result1 string
+		})
+	}
+	fake.getCurrentVersionReturnsOnCall[i] = struct {
+		result1 string
+	}{result1}
+}
+
+func (fake *FakeController) IncrementVersion(arg1 string) kubernetes.SpinnakerVersion {
+	fake.incrementVersionMutex.Lock()
+	ret, specificReturn := fake.incrementVersionReturnsOnCall[len(fake.incrementVersionArgsForCall)]
+	fake.incrementVersionArgsForCall = append(fake.incrementVersionArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("IncrementVersion", []interface{}{arg1})
+	fake.incrementVersionMutex.Unlock()
+	if fake.IncrementVersionStub != nil {
+		return fake.IncrementVersionStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.incrementVersionReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) IncrementVersionCallCount() int {
+	fake.incrementVersionMutex.RLock()
+	defer fake.incrementVersionMutex.RUnlock()
+	return len(fake.incrementVersionArgsForCall)
+}
+
+func (fake *FakeController) IncrementVersionCalls(stub func(string) kubernetes.SpinnakerVersion) {
+	fake.incrementVersionMutex.Lock()
+	defer fake.incrementVersionMutex.Unlock()
+	fake.IncrementVersionStub = stub
+}
+
+func (fake *FakeController) IncrementVersionArgsForCall(i int) string {
+	fake.incrementVersionMutex.RLock()
+	defer fake.incrementVersionMutex.RUnlock()
+	argsForCall := fake.incrementVersionArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeController) IncrementVersionReturns(result1 kubernetes.SpinnakerVersion) {
+	fake.incrementVersionMutex.Lock()
+	defer fake.incrementVersionMutex.Unlock()
+	fake.IncrementVersionStub = nil
+	fake.incrementVersionReturns = struct {
+		result1 kubernetes.SpinnakerVersion
+	}{result1}
+}
+
+func (fake *FakeController) IncrementVersionReturnsOnCall(i int, result1 kubernetes.SpinnakerVersion) {
+	fake.incrementVersionMutex.Lock()
+	defer fake.incrementVersionMutex.Unlock()
+	fake.IncrementVersionStub = nil
+	if fake.incrementVersionReturnsOnCall == nil {
+		fake.incrementVersionReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.SpinnakerVersion
+		})
+	}
+	fake.incrementVersionReturnsOnCall[i] = struct {
+		result1 kubernetes.SpinnakerVersion
+	}{result1}
+}
+
+func (fake *FakeController) IsVersioned(arg1 *unstructured.Unstructured) bool {
+	fake.isVersionedMutex.Lock()
+	ret, specificReturn := fake.isVersionedReturnsOnCall[len(fake.isVersionedArgsForCall)]
+	fake.isVersionedArgsForCall = append(fake.isVersionedArgsForCall, struct {
+		arg1 *unstructured.Unstructured
+	}{arg1})
+	fake.recordInvocation("IsVersioned", []interface{}{arg1})
+	fake.isVersionedMutex.Unlock()
+	if fake.IsVersionedStub != nil {
+		return fake.IsVersionedStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.isVersionedReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeController) IsVersionedCallCount() int {
+	fake.isVersionedMutex.RLock()
+	defer fake.isVersionedMutex.RUnlock()
+	return len(fake.isVersionedArgsForCall)
+}
+
+func (fake *FakeController) IsVersionedCalls(stub func(*unstructured.Unstructured) bool) {
+	fake.isVersionedMutex.Lock()
+	defer fake.isVersionedMutex.Unlock()
+	fake.IsVersionedStub = stub
+}
+
+func (fake *FakeController) IsVersionedArgsForCall(i int) *unstructured.Unstructured {
+	fake.isVersionedMutex.RLock()
+	defer fake.isVersionedMutex.RUnlock()
+	argsForCall := fake.isVersionedArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeController) IsVersionedReturns(result1 bool) {
+	fake.isVersionedMutex.Lock()
+	defer fake.isVersionedMutex.Unlock()
+	fake.IsVersionedStub = nil
+	fake.isVersionedReturns = struct {
+		result1 bool
+	}{result1}
+}
+
+func (fake *FakeController) IsVersionedReturnsOnCall(i int, result1 bool) {
+	fake.isVersionedMutex.Lock()
+	defer fake.isVersionedMutex.Unlock()
+	fake.IsVersionedStub = nil
+	if fake.isVersionedReturnsOnCall == nil {
+		fake.isVersionedReturnsOnCall = make(map[int]struct {
+			result1 bool
+		})
+	}
+	fake.isVersionedReturnsOnCall[i] = struct {
+		result1 bool
+	}{result1}
 }
 
 func (fake *FakeController) NewClient(arg1 *rest.Config) (kubernetes.Client, error) {
@@ -163,7 +589,8 @@ func (fake *FakeController) NewClient(arg1 *rest.Config) (kubernetes.Client, err
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.newClientReturns.result1, fake.newClientReturns.result2
+	fakeReturns := fake.newClientReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeController) NewClientCallCount() int {
@@ -172,13 +599,22 @@ func (fake *FakeController) NewClientCallCount() int {
 	return len(fake.newClientArgsForCall)
 }
 
+func (fake *FakeController) NewClientCalls(stub func(*rest.Config) (kubernetes.Client, error)) {
+	fake.newClientMutex.Lock()
+	defer fake.newClientMutex.Unlock()
+	fake.NewClientStub = stub
+}
+
 func (fake *FakeController) NewClientArgsForCall(i int) *rest.Config {
 	fake.newClientMutex.RLock()
 	defer fake.newClientMutex.RUnlock()
-	return fake.newClientArgsForCall[i].arg1
+	argsForCall := fake.newClientArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeController) NewClientReturns(result1 kubernetes.Client, result2 error) {
+	fake.newClientMutex.Lock()
+	defer fake.newClientMutex.Unlock()
 	fake.NewClientStub = nil
 	fake.newClientReturns = struct {
 		result1 kubernetes.Client
@@ -187,6 +623,8 @@ func (fake *FakeController) NewClientReturns(result1 kubernetes.Client, result2 
 }
 
 func (fake *FakeController) NewClientReturnsOnCall(i int, result1 kubernetes.Client, result2 error) {
+	fake.newClientMutex.Lock()
+	defer fake.newClientMutex.Unlock()
 	fake.NewClientStub = nil
 	if fake.newClientReturnsOnCall == nil {
 		fake.newClientReturnsOnCall = make(map[int]struct {
@@ -198,155 +636,6 @@ func (fake *FakeController) NewClientReturnsOnCall(i int, result1 kubernetes.Cli
 		result1 kubernetes.Client
 		result2 error
 	}{result1, result2}
-}
-
-func (fake *FakeController) ToUnstructured(arg1 map[string]interface{}) (*unstructured.Unstructured, error) {
-	fake.toUnstructuredMutex.Lock()
-	ret, specificReturn := fake.toUnstructuredReturnsOnCall[len(fake.toUnstructuredArgsForCall)]
-	fake.toUnstructuredArgsForCall = append(fake.toUnstructuredArgsForCall, struct {
-		arg1 map[string]interface{}
-	}{arg1})
-	fake.recordInvocation("ToUnstructured", []interface{}{arg1})
-	fake.toUnstructuredMutex.Unlock()
-	if fake.ToUnstructuredStub != nil {
-		return fake.ToUnstructuredStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.toUnstructuredReturns.result1, fake.toUnstructuredReturns.result2
-}
-
-func (fake *FakeController) ToUnstructuredCallCount() int {
-	fake.toUnstructuredMutex.RLock()
-	defer fake.toUnstructuredMutex.RUnlock()
-	return len(fake.toUnstructuredArgsForCall)
-}
-
-func (fake *FakeController) ToUnstructuredArgsForCall(i int) map[string]interface{} {
-	fake.toUnstructuredMutex.RLock()
-	defer fake.toUnstructuredMutex.RUnlock()
-	return fake.toUnstructuredArgsForCall[i].arg1
-}
-
-func (fake *FakeController) ToUnstructuredReturns(result1 *unstructured.Unstructured, result2 error) {
-	fake.ToUnstructuredStub = nil
-	fake.toUnstructuredReturns = struct {
-		result1 *unstructured.Unstructured
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeController) ToUnstructuredReturnsOnCall(i int, result1 *unstructured.Unstructured, result2 error) {
-	fake.ToUnstructuredStub = nil
-	if fake.toUnstructuredReturnsOnCall == nil {
-		fake.toUnstructuredReturnsOnCall = make(map[int]struct {
-			result1 *unstructured.Unstructured
-			result2 error
-		})
-	}
-	fake.toUnstructuredReturnsOnCall[i] = struct {
-		result1 *unstructured.Unstructured
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeController) AddSpinnakerAnnotations(u *unstructured.Unstructured, application string) error {
-	fake.addSpinnakerAnnotationsMutex.Lock()
-	ret, specificReturn := fake.addSpinnakerAnnotationsReturnsOnCall[len(fake.addSpinnakerAnnotationsArgsForCall)]
-	fake.addSpinnakerAnnotationsArgsForCall = append(fake.addSpinnakerAnnotationsArgsForCall, struct {
-		u           *unstructured.Unstructured
-		application string
-	}{u, application})
-	fake.recordInvocation("AddSpinnakerAnnotations", []interface{}{u, application})
-	fake.addSpinnakerAnnotationsMutex.Unlock()
-	if fake.AddSpinnakerAnnotationsStub != nil {
-		return fake.AddSpinnakerAnnotationsStub(u, application)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.addSpinnakerAnnotationsReturns.result1
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsCallCount() int {
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	return len(fake.addSpinnakerAnnotationsArgsForCall)
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsArgsForCall(i int) (*unstructured.Unstructured, string) {
-	fake.addSpinnakerAnnotationsMutex.RLock()
-	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
-	return fake.addSpinnakerAnnotationsArgsForCall[i].u, fake.addSpinnakerAnnotationsArgsForCall[i].application
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsReturns(result1 error) {
-	fake.AddSpinnakerAnnotationsStub = nil
-	fake.addSpinnakerAnnotationsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerAnnotationsReturnsOnCall(i int, result1 error) {
-	fake.AddSpinnakerAnnotationsStub = nil
-	if fake.addSpinnakerAnnotationsReturnsOnCall == nil {
-		fake.addSpinnakerAnnotationsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.addSpinnakerAnnotationsReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerLabels(u *unstructured.Unstructured, application string) error {
-	fake.addSpinnakerLabelsMutex.Lock()
-	ret, specificReturn := fake.addSpinnakerLabelsReturnsOnCall[len(fake.addSpinnakerLabelsArgsForCall)]
-	fake.addSpinnakerLabelsArgsForCall = append(fake.addSpinnakerLabelsArgsForCall, struct {
-		u           *unstructured.Unstructured
-		application string
-	}{u, application})
-	fake.recordInvocation("AddSpinnakerLabels", []interface{}{u, application})
-	fake.addSpinnakerLabelsMutex.Unlock()
-	if fake.AddSpinnakerLabelsStub != nil {
-		return fake.AddSpinnakerLabelsStub(u, application)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.addSpinnakerLabelsReturns.result1
-}
-
-func (fake *FakeController) AddSpinnakerLabelsCallCount() int {
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
-	return len(fake.addSpinnakerLabelsArgsForCall)
-}
-
-func (fake *FakeController) AddSpinnakerLabelsArgsForCall(i int) (*unstructured.Unstructured, string) {
-	fake.addSpinnakerLabelsMutex.RLock()
-	defer fake.addSpinnakerLabelsMutex.RUnlock()
-	return fake.addSpinnakerLabelsArgsForCall[i].u, fake.addSpinnakerLabelsArgsForCall[i].application
-}
-
-func (fake *FakeController) AddSpinnakerLabelsReturns(result1 error) {
-	fake.AddSpinnakerLabelsStub = nil
-	fake.addSpinnakerLabelsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerLabelsReturnsOnCall(i int, result1 error) {
-	fake.AddSpinnakerLabelsStub = nil
-	if fake.addSpinnakerLabelsReturnsOnCall == nil {
-		fake.addSpinnakerLabelsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.addSpinnakerLabelsReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
 }
 
 func (fake *FakeController) SortManifests(arg1 []map[string]interface{}) ([]map[string]interface{}, error) {
@@ -368,7 +657,8 @@ func (fake *FakeController) SortManifests(arg1 []map[string]interface{}) ([]map[
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.sortManifestsReturns.result1, fake.sortManifestsReturns.result2
+	fakeReturns := fake.sortManifestsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeController) SortManifestsCallCount() int {
@@ -377,13 +667,22 @@ func (fake *FakeController) SortManifestsCallCount() int {
 	return len(fake.sortManifestsArgsForCall)
 }
 
+func (fake *FakeController) SortManifestsCalls(stub func([]map[string]interface{}) ([]map[string]interface{}, error)) {
+	fake.sortManifestsMutex.Lock()
+	defer fake.sortManifestsMutex.Unlock()
+	fake.SortManifestsStub = stub
+}
+
 func (fake *FakeController) SortManifestsArgsForCall(i int) []map[string]interface{} {
 	fake.sortManifestsMutex.RLock()
 	defer fake.sortManifestsMutex.RUnlock()
-	return fake.sortManifestsArgsForCall[i].arg1
+	argsForCall := fake.sortManifestsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeController) SortManifestsReturns(result1 []map[string]interface{}, result2 error) {
+	fake.sortManifestsMutex.Lock()
+	defer fake.sortManifestsMutex.Unlock()
 	fake.SortManifestsStub = nil
 	fake.sortManifestsReturns = struct {
 		result1 []map[string]interface{}
@@ -392,6 +691,8 @@ func (fake *FakeController) SortManifestsReturns(result1 []map[string]interface{
 }
 
 func (fake *FakeController) SortManifestsReturnsOnCall(i int, result1 []map[string]interface{}, result2 error) {
+	fake.sortManifestsMutex.Lock()
+	defer fake.sortManifestsMutex.Unlock()
 	fake.SortManifestsStub = nil
 	if fake.sortManifestsReturnsOnCall == nil {
 		fake.sortManifestsReturnsOnCall = make(map[int]struct {
@@ -405,271 +706,86 @@ func (fake *FakeController) SortManifestsReturnsOnCall(i int, result1 []map[stri
 	}{result1, result2}
 }
 
-func (fake *FakeController) AddSpinnakerVersionAnnotations(u *unstructured.Unstructured, version kubernetes.SpinnakerVersion) error {
-	fake.addSpinnakerVersionAnnotationsMutex.Lock()
-	ret, specificReturn := fake.addSpinnakerVersionAnnotationsReturnsOnCall[len(fake.addSpinnakerVersionAnnotationsArgsForCall)]
-	fake.addSpinnakerVersionAnnotationsArgsForCall = append(fake.addSpinnakerVersionAnnotationsArgsForCall, struct {
-		u       *unstructured.Unstructured
-		version kubernetes.SpinnakerVersion
-	}{u, version})
-	fake.recordInvocation("AddSpinnakerVersionAnnotations", []interface{}{u, version})
-	fake.addSpinnakerVersionAnnotationsMutex.Unlock()
-	if fake.AddSpinnakerVersionAnnotationsStub != nil {
-		return fake.AddSpinnakerVersionAnnotationsStub(u, version)
+func (fake *FakeController) ToUnstructured(arg1 map[string]interface{}) (*unstructured.Unstructured, error) {
+	fake.toUnstructuredMutex.Lock()
+	ret, specificReturn := fake.toUnstructuredReturnsOnCall[len(fake.toUnstructuredArgsForCall)]
+	fake.toUnstructuredArgsForCall = append(fake.toUnstructuredArgsForCall, struct {
+		arg1 map[string]interface{}
+	}{arg1})
+	fake.recordInvocation("ToUnstructured", []interface{}{arg1})
+	fake.toUnstructuredMutex.Unlock()
+	if fake.ToUnstructuredStub != nil {
+		return fake.ToUnstructuredStub(arg1)
 	}
 	if specificReturn {
-		return ret.result1
+		return ret.result1, ret.result2
 	}
-	return fake.addSpinnakerVersionAnnotationsReturns.result1
+	fakeReturns := fake.toUnstructuredReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
-func (fake *FakeController) AddSpinnakerVersionAnnotationsCallCount() int {
-	fake.addSpinnakerVersionAnnotationsMutex.RLock()
-	defer fake.addSpinnakerVersionAnnotationsMutex.RUnlock()
-	return len(fake.addSpinnakerVersionAnnotationsArgsForCall)
+func (fake *FakeController) ToUnstructuredCallCount() int {
+	fake.toUnstructuredMutex.RLock()
+	defer fake.toUnstructuredMutex.RUnlock()
+	return len(fake.toUnstructuredArgsForCall)
 }
 
-func (fake *FakeController) AddSpinnakerVersionAnnotationsArgsForCall(i int) (*unstructured.Unstructured, kubernetes.SpinnakerVersion) {
-	fake.addSpinnakerVersionAnnotationsMutex.RLock()
-	defer fake.addSpinnakerVersionAnnotationsMutex.RUnlock()
-	return fake.addSpinnakerVersionAnnotationsArgsForCall[i].u, fake.addSpinnakerVersionAnnotationsArgsForCall[i].version
+func (fake *FakeController) ToUnstructuredCalls(stub func(map[string]interface{}) (*unstructured.Unstructured, error)) {
+	fake.toUnstructuredMutex.Lock()
+	defer fake.toUnstructuredMutex.Unlock()
+	fake.ToUnstructuredStub = stub
 }
 
-func (fake *FakeController) AddSpinnakerVersionAnnotationsReturns(result1 error) {
-	fake.AddSpinnakerVersionAnnotationsStub = nil
-	fake.addSpinnakerVersionAnnotationsReturns = struct {
-		result1 error
-	}{result1}
+func (fake *FakeController) ToUnstructuredArgsForCall(i int) map[string]interface{} {
+	fake.toUnstructuredMutex.RLock()
+	defer fake.toUnstructuredMutex.RUnlock()
+	argsForCall := fake.toUnstructuredArgsForCall[i]
+	return argsForCall.arg1
 }
 
-func (fake *FakeController) AddSpinnakerVersionAnnotationsReturnsOnCall(i int, result1 error) {
-	fake.AddSpinnakerVersionAnnotationsStub = nil
-	if fake.addSpinnakerVersionAnnotationsReturnsOnCall == nil {
-		fake.addSpinnakerVersionAnnotationsReturnsOnCall = make(map[int]struct {
-			result1 error
+func (fake *FakeController) ToUnstructuredReturns(result1 *unstructured.Unstructured, result2 error) {
+	fake.toUnstructuredMutex.Lock()
+	defer fake.toUnstructuredMutex.Unlock()
+	fake.ToUnstructuredStub = nil
+	fake.toUnstructuredReturns = struct {
+		result1 *unstructured.Unstructured
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeController) ToUnstructuredReturnsOnCall(i int, result1 *unstructured.Unstructured, result2 error) {
+	fake.toUnstructuredMutex.Lock()
+	defer fake.toUnstructuredMutex.Unlock()
+	fake.ToUnstructuredStub = nil
+	if fake.toUnstructuredReturnsOnCall == nil {
+		fake.toUnstructuredReturnsOnCall = make(map[int]struct {
+			result1 *unstructured.Unstructured
+			result2 error
 		})
 	}
-	fake.addSpinnakerVersionAnnotationsReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
+	fake.toUnstructuredReturnsOnCall[i] = struct {
+		result1 *unstructured.Unstructured
+		result2 error
+	}{result1, result2}
 }
 
-func (fake *FakeController) AddSpinnakerVersionLabels(u *unstructured.Unstructured, version kubernetes.SpinnakerVersion) error {
-	fake.addSpinnakerVersionLabelsMutex.Lock()
-	ret, specificReturn := fake.addSpinnakerVersionLabelsReturnsOnCall[len(fake.addSpinnakerVersionLabelsArgsForCall)]
-	fake.addSpinnakerVersionLabelsArgsForCall = append(fake.addSpinnakerVersionLabelsArgsForCall, struct {
-		u       *unstructured.Unstructured
-		version kubernetes.SpinnakerVersion
-	}{u, version})
-	fake.recordInvocation("AddSpinnakerVersionLabels", []interface{}{u, version})
-	fake.addSpinnakerVersionLabelsMutex.Unlock()
-	if fake.AddSpinnakerVersionLabelsStub != nil {
-		return fake.AddSpinnakerVersionLabelsStub(u, version)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.addSpinnakerVersionLabelsReturns.result1
-}
-
-func (fake *FakeController) AddSpinnakerVersionLabelsCallCount() int {
-	fake.addSpinnakerVersionLabelsMutex.RLock()
-	defer fake.addSpinnakerVersionLabelsMutex.RUnlock()
-	return len(fake.addSpinnakerVersionLabelsArgsForCall)
-}
-
-func (fake *FakeController) AddSpinnakerVersionLabelsArgsForCall(i int) (*unstructured.Unstructured, kubernetes.SpinnakerVersion) {
-	fake.addSpinnakerVersionLabelsMutex.RLock()
-	defer fake.addSpinnakerVersionLabelsMutex.RUnlock()
-	return fake.addSpinnakerVersionLabelsArgsForCall[i].u, fake.addSpinnakerVersionLabelsArgsForCall[i].version
-}
-
-func (fake *FakeController) AddSpinnakerVersionLabelsReturns(result1 error) {
-	fake.AddSpinnakerVersionLabelsStub = nil
-	fake.addSpinnakerVersionLabelsReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) AddSpinnakerVersionLabelsReturnsOnCall(i int, result1 error) {
-	fake.AddSpinnakerVersionLabelsStub = nil
-	if fake.addSpinnakerVersionLabelsReturnsOnCall == nil {
-		fake.addSpinnakerVersionLabelsReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.addSpinnakerVersionLabelsReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeController) GetCurrentVersion(ul *unstructured.UnstructuredList, kind string, name string) string {
-	fake.getCurrentVersionMutex.Lock()
-	ret, specificReturn := fake.getCurrentVersionReturnsOnCall[len(fake.getCurrentVersionArgsForCall)]
-	fake.getCurrentVersionArgsForCall = append(fake.getCurrentVersionArgsForCall, struct {
-		ul   *unstructured.UnstructuredList
-		kind string
-		name string
-	}{ul, kind, name})
-	fake.recordInvocation("GetCurrentVersion", []interface{}{ul, kind, name})
-	fake.getCurrentVersionMutex.Unlock()
-	if fake.GetCurrentVersionStub != nil {
-		return fake.GetCurrentVersionStub(ul, kind, name)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.getCurrentVersionReturns.result1
-}
-
-func (fake *FakeController) GetCurrentVersionCallCount() int {
-	fake.getCurrentVersionMutex.RLock()
-	defer fake.getCurrentVersionMutex.RUnlock()
-	return len(fake.getCurrentVersionArgsForCall)
-}
-
-func (fake *FakeController) GetCurrentVersionArgsForCall(i int) (*unstructured.UnstructuredList, string, string) {
-	fake.getCurrentVersionMutex.RLock()
-	defer fake.getCurrentVersionMutex.RUnlock()
-	return fake.getCurrentVersionArgsForCall[i].ul, fake.getCurrentVersionArgsForCall[i].kind, fake.getCurrentVersionArgsForCall[i].name
-}
-
-func (fake *FakeController) GetCurrentVersionReturns(result1 string) {
-	fake.GetCurrentVersionStub = nil
-	fake.getCurrentVersionReturns = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *FakeController) GetCurrentVersionReturnsOnCall(i int, result1 string) {
-	fake.GetCurrentVersionStub = nil
-	if fake.getCurrentVersionReturnsOnCall == nil {
-		fake.getCurrentVersionReturnsOnCall = make(map[int]struct {
-			result1 string
-		})
-	}
-	fake.getCurrentVersionReturnsOnCall[i] = struct {
-		result1 string
-	}{result1}
-}
-
-func (fake *FakeController) IsVersioned(u *unstructured.Unstructured) bool {
-	fake.isVersionedMutex.Lock()
-	ret, specificReturn := fake.isVersionedReturnsOnCall[len(fake.isVersionedArgsForCall)]
-	fake.isVersionedArgsForCall = append(fake.isVersionedArgsForCall, struct {
-		u *unstructured.Unstructured
-	}{u})
-	fake.recordInvocation("IsVersioned", []interface{}{u})
-	fake.isVersionedMutex.Unlock()
-	if fake.IsVersionedStub != nil {
-		return fake.IsVersionedStub(u)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.isVersionedReturns.result1
-}
-
-func (fake *FakeController) IsVersionedCallCount() int {
-	fake.isVersionedMutex.RLock()
-	defer fake.isVersionedMutex.RUnlock()
-	return len(fake.isVersionedArgsForCall)
-}
-
-func (fake *FakeController) IsVersionedArgsForCall(i int) *unstructured.Unstructured {
-	fake.isVersionedMutex.RLock()
-	defer fake.isVersionedMutex.RUnlock()
-	return fake.isVersionedArgsForCall[i].u
-}
-
-func (fake *FakeController) IsVersionedReturns(result1 bool) {
-	fake.IsVersionedStub = nil
-	fake.isVersionedReturns = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *FakeController) IsVersionedReturnsOnCall(i int, result1 bool) {
-	fake.IsVersionedStub = nil
-	if fake.isVersionedReturnsOnCall == nil {
-		fake.isVersionedReturnsOnCall = make(map[int]struct {
-			result1 bool
-		})
-	}
-	fake.isVersionedReturnsOnCall[i] = struct {
-		result1 bool
-	}{result1}
-}
-
-func (fake *FakeController) IncrementVersion(currentVersion string) kubernetes.SpinnakerVersion {
-	fake.incrementVersionMutex.Lock()
-	ret, specificReturn := fake.incrementVersionReturnsOnCall[len(fake.incrementVersionArgsForCall)]
-	fake.incrementVersionArgsForCall = append(fake.incrementVersionArgsForCall, struct {
-		currentVersion string
-	}{currentVersion})
-	fake.recordInvocation("IncrementVersion", []interface{}{currentVersion})
-	fake.incrementVersionMutex.Unlock()
-	if fake.IncrementVersionStub != nil {
-		return fake.IncrementVersionStub(currentVersion)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	return fake.incrementVersionReturns.result1
-}
-
-func (fake *FakeController) IncrementVersionCallCount() int {
-	fake.incrementVersionMutex.RLock()
-	defer fake.incrementVersionMutex.RUnlock()
-	return len(fake.incrementVersionArgsForCall)
-}
-
-func (fake *FakeController) IncrementVersionArgsForCall(i int) string {
-	fake.incrementVersionMutex.RLock()
-	defer fake.incrementVersionMutex.RUnlock()
-	return fake.incrementVersionArgsForCall[i].currentVersion
-}
-
-func (fake *FakeController) IncrementVersionReturns(result1 kubernetes.SpinnakerVersion) {
-	fake.IncrementVersionStub = nil
-	fake.incrementVersionReturns = struct {
-		result1 kubernetes.SpinnakerVersion
-	}{result1}
-}
-
-func (fake *FakeController) IncrementVersionReturnsOnCall(i int, result1 kubernetes.SpinnakerVersion) {
-	fake.IncrementVersionStub = nil
-	if fake.incrementVersionReturnsOnCall == nil {
-		fake.incrementVersionReturnsOnCall = make(map[int]struct {
-			result1 kubernetes.SpinnakerVersion
-		})
-	}
-	fake.incrementVersionReturnsOnCall[i] = struct {
-		result1 kubernetes.SpinnakerVersion
-	}{result1}
-}
-
-func (fake *FakeController) VersionVolumes(u *unstructured.Unstructured, requiredArtifacts []clouddriver.TaskCreatedArtifact) error {
-	var requiredArtifactsCopy []clouddriver.TaskCreatedArtifact
-	if requiredArtifacts != nil {
-		requiredArtifactsCopy = make([]clouddriver.TaskCreatedArtifact, len(requiredArtifacts))
-		copy(requiredArtifactsCopy, requiredArtifacts)
-	}
+func (fake *FakeController) VersionVolumes(arg1 *unstructured.Unstructured, arg2 map[string]clouddriver.TaskCreatedArtifact) error {
 	fake.versionVolumesMutex.Lock()
 	ret, specificReturn := fake.versionVolumesReturnsOnCall[len(fake.versionVolumesArgsForCall)]
 	fake.versionVolumesArgsForCall = append(fake.versionVolumesArgsForCall, struct {
-		u                 *unstructured.Unstructured
-		requiredArtifacts []clouddriver.TaskCreatedArtifact
-	}{u, requiredArtifactsCopy})
-	fake.recordInvocation("VersionVolumes", []interface{}{u, requiredArtifactsCopy})
+		arg1 *unstructured.Unstructured
+		arg2 map[string]clouddriver.TaskCreatedArtifact
+	}{arg1, arg2})
+	fake.recordInvocation("VersionVolumes", []interface{}{arg1, arg2})
 	fake.versionVolumesMutex.Unlock()
 	if fake.VersionVolumesStub != nil {
-		return fake.VersionVolumesStub(u, requiredArtifacts)
+		return fake.VersionVolumesStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.versionVolumesReturns.result1
+	fakeReturns := fake.versionVolumesReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeController) VersionVolumesCallCount() int {
@@ -678,13 +794,22 @@ func (fake *FakeController) VersionVolumesCallCount() int {
 	return len(fake.versionVolumesArgsForCall)
 }
 
-func (fake *FakeController) VersionVolumesArgsForCall(i int) (*unstructured.Unstructured, []clouddriver.TaskCreatedArtifact) {
+func (fake *FakeController) VersionVolumesCalls(stub func(*unstructured.Unstructured, map[string]clouddriver.TaskCreatedArtifact) error) {
+	fake.versionVolumesMutex.Lock()
+	defer fake.versionVolumesMutex.Unlock()
+	fake.VersionVolumesStub = stub
+}
+
+func (fake *FakeController) VersionVolumesArgsForCall(i int) (*unstructured.Unstructured, map[string]clouddriver.TaskCreatedArtifact) {
 	fake.versionVolumesMutex.RLock()
 	defer fake.versionVolumesMutex.RUnlock()
-	return fake.versionVolumesArgsForCall[i].u, fake.versionVolumesArgsForCall[i].requiredArtifacts
+	argsForCall := fake.versionVolumesArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeController) VersionVolumesReturns(result1 error) {
+	fake.versionVolumesMutex.Lock()
+	defer fake.versionVolumesMutex.Unlock()
 	fake.VersionVolumesStub = nil
 	fake.versionVolumesReturns = struct {
 		result1 error
@@ -692,6 +817,8 @@ func (fake *FakeController) VersionVolumesReturns(result1 error) {
 }
 
 func (fake *FakeController) VersionVolumesReturnsOnCall(i int, result1 error) {
+	fake.versionVolumesMutex.Lock()
+	defer fake.versionVolumesMutex.Unlock()
 	fake.VersionVolumesStub = nil
 	if fake.versionVolumesReturnsOnCall == nil {
 		fake.versionVolumesReturnsOnCall = make(map[int]struct {
@@ -706,26 +833,26 @@ func (fake *FakeController) VersionVolumesReturnsOnCall(i int, result1 error) {
 func (fake *FakeController) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
-	fake.newClientMutex.RLock()
-	defer fake.newClientMutex.RUnlock()
-	fake.toUnstructuredMutex.RLock()
-	defer fake.toUnstructuredMutex.RUnlock()
 	fake.addSpinnakerAnnotationsMutex.RLock()
 	defer fake.addSpinnakerAnnotationsMutex.RUnlock()
 	fake.addSpinnakerLabelsMutex.RLock()
 	defer fake.addSpinnakerLabelsMutex.RUnlock()
-	fake.sortManifestsMutex.RLock()
-	defer fake.sortManifestsMutex.RUnlock()
 	fake.addSpinnakerVersionAnnotationsMutex.RLock()
 	defer fake.addSpinnakerVersionAnnotationsMutex.RUnlock()
 	fake.addSpinnakerVersionLabelsMutex.RLock()
 	defer fake.addSpinnakerVersionLabelsMutex.RUnlock()
 	fake.getCurrentVersionMutex.RLock()
 	defer fake.getCurrentVersionMutex.RUnlock()
-	fake.isVersionedMutex.RLock()
-	defer fake.isVersionedMutex.RUnlock()
 	fake.incrementVersionMutex.RLock()
 	defer fake.incrementVersionMutex.RUnlock()
+	fake.isVersionedMutex.RLock()
+	defer fake.isVersionedMutex.RUnlock()
+	fake.newClientMutex.RLock()
+	defer fake.newClientMutex.RUnlock()
+	fake.sortManifestsMutex.RLock()
+	defer fake.sortManifestsMutex.RUnlock()
+	fake.toUnstructuredMutex.RLock()
+	defer fake.toUnstructuredMutex.RUnlock()
 	fake.versionVolumesMutex.RLock()
 	defer fake.versionVolumesMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/pkg/kubernetes/kubernetesfakes/fake_manifest_filter.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_manifest_filter.go
@@ -57,7 +57,8 @@ func (fake *FakeManifestFilter) FilterOnClusterAnnotation(arg1 []unstructured.Un
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.filterOnClusterAnnotationReturns.result1
+	fakeReturns := fake.filterOnClusterAnnotationReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeManifestFilter) FilterOnClusterAnnotationCallCount() int {
@@ -66,13 +67,22 @@ func (fake *FakeManifestFilter) FilterOnClusterAnnotationCallCount() int {
 	return len(fake.filterOnClusterAnnotationArgsForCall)
 }
 
+func (fake *FakeManifestFilter) FilterOnClusterAnnotationCalls(stub func([]unstructured.Unstructured, string) []unstructured.Unstructured) {
+	fake.filterOnClusterAnnotationMutex.Lock()
+	defer fake.filterOnClusterAnnotationMutex.Unlock()
+	fake.FilterOnClusterAnnotationStub = stub
+}
+
 func (fake *FakeManifestFilter) FilterOnClusterAnnotationArgsForCall(i int) ([]unstructured.Unstructured, string) {
 	fake.filterOnClusterAnnotationMutex.RLock()
 	defer fake.filterOnClusterAnnotationMutex.RUnlock()
-	return fake.filterOnClusterAnnotationArgsForCall[i].arg1, fake.filterOnClusterAnnotationArgsForCall[i].arg2
+	argsForCall := fake.filterOnClusterAnnotationArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeManifestFilter) FilterOnClusterAnnotationReturns(result1 []unstructured.Unstructured) {
+	fake.filterOnClusterAnnotationMutex.Lock()
+	defer fake.filterOnClusterAnnotationMutex.Unlock()
 	fake.FilterOnClusterAnnotationStub = nil
 	fake.filterOnClusterAnnotationReturns = struct {
 		result1 []unstructured.Unstructured
@@ -80,6 +90,8 @@ func (fake *FakeManifestFilter) FilterOnClusterAnnotationReturns(result1 []unstr
 }
 
 func (fake *FakeManifestFilter) FilterOnClusterAnnotationReturnsOnCall(i int, result1 []unstructured.Unstructured) {
+	fake.filterOnClusterAnnotationMutex.Lock()
+	defer fake.filterOnClusterAnnotationMutex.Unlock()
 	fake.FilterOnClusterAnnotationStub = nil
 	if fake.filterOnClusterAnnotationReturnsOnCall == nil {
 		fake.filterOnClusterAnnotationReturnsOnCall = make(map[int]struct {
@@ -111,7 +123,8 @@ func (fake *FakeManifestFilter) FilterOnLabel(arg1 []unstructured.Unstructured, 
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.filterOnLabelReturns.result1
+	fakeReturns := fake.filterOnLabelReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeManifestFilter) FilterOnLabelCallCount() int {
@@ -120,13 +133,22 @@ func (fake *FakeManifestFilter) FilterOnLabelCallCount() int {
 	return len(fake.filterOnLabelArgsForCall)
 }
 
+func (fake *FakeManifestFilter) FilterOnLabelCalls(stub func([]unstructured.Unstructured, string) []unstructured.Unstructured) {
+	fake.filterOnLabelMutex.Lock()
+	defer fake.filterOnLabelMutex.Unlock()
+	fake.FilterOnLabelStub = stub
+}
+
 func (fake *FakeManifestFilter) FilterOnLabelArgsForCall(i int) ([]unstructured.Unstructured, string) {
 	fake.filterOnLabelMutex.RLock()
 	defer fake.filterOnLabelMutex.RUnlock()
-	return fake.filterOnLabelArgsForCall[i].arg1, fake.filterOnLabelArgsForCall[i].arg2
+	argsForCall := fake.filterOnLabelArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
 }
 
 func (fake *FakeManifestFilter) FilterOnLabelReturns(result1 []unstructured.Unstructured) {
+	fake.filterOnLabelMutex.Lock()
+	defer fake.filterOnLabelMutex.Unlock()
 	fake.FilterOnLabelStub = nil
 	fake.filterOnLabelReturns = struct {
 		result1 []unstructured.Unstructured
@@ -134,6 +156,8 @@ func (fake *FakeManifestFilter) FilterOnLabelReturns(result1 []unstructured.Unst
 }
 
 func (fake *FakeManifestFilter) FilterOnLabelReturnsOnCall(i int, result1 []unstructured.Unstructured) {
+	fake.filterOnLabelMutex.Lock()
+	defer fake.filterOnLabelMutex.Unlock()
 	fake.FilterOnLabelStub = nil
 	if fake.filterOnLabelReturnsOnCall == nil {
 		fake.filterOnLabelReturnsOnCall = make(map[int]struct {

--- a/pkg/kubernetes/version_test.go
+++ b/pkg/kubernetes/version_test.go
@@ -301,15 +301,15 @@ var _ = Describe("Version", func() {
 					},
 				}
 
-				requiredArtifacts := []clouddriver.TaskCreatedArtifact{
-					{
+				pipelineArtifacts := map[string]clouddriver.TaskCreatedArtifact{
+					"test-config-map": {
 						Name:      "test-config-map",
 						Type:      "kubernetes/configMap",
 						Reference: "test-config-map-v001",
 					},
 				}
 
-				err = kc.VersionVolumes(fakeResource, requiredArtifacts)
+				err = kc.VersionVolumes(fakeResource, pipelineArtifacts)
 				Expect(err).To(BeNil())
 				fakeDeployment = kubernetes.NewDeployment(fakeResource.Object)
 			})
@@ -341,15 +341,15 @@ var _ = Describe("Version", func() {
 					},
 				}
 
-				requiredArtifacts := []clouddriver.TaskCreatedArtifact{
-					{
+				pipelineArtifacts := map[string]clouddriver.TaskCreatedArtifact{
+					"test-secret": {
 						Name:      "test-secret",
 						Type:      "kubernetes/secret",
 						Reference: "test-secret-v001",
 					},
 				}
 
-				err = kc.VersionVolumes(fakeResource, requiredArtifacts)
+				err = kc.VersionVolumes(fakeResource, pipelineArtifacts)
 				Expect(err).To(BeNil())
 				fakeDeployment = kubernetes.NewDeployment(fakeResource.Object)
 			})
@@ -377,8 +377,8 @@ var _ = Describe("Version", func() {
 					},
 				}
 
-				requiredArtifacts := []clouddriver.TaskCreatedArtifact{
-					{
+				requiredArtifacts := map[string]clouddriver.TaskCreatedArtifact{
+					"test-config-map": {
 						Name:      "test-config-map",
 						Type:      "kubernetes/configMap",
 						Reference: "test-config-map-v001",
@@ -413,21 +413,61 @@ var _ = Describe("Version", func() {
 					},
 				}
 
-				requiredArtifacts := []clouddriver.TaskCreatedArtifact{
-					{
+				pipelineArtifacts := map[string]clouddriver.TaskCreatedArtifact{
+					"test-secret": {
 						Name:      "test-secret",
 						Type:      "kubernetes/secret",
 						Reference: "test-secret-v001",
 					},
 				}
 
-				err = kc.VersionVolumes(fakeResource, requiredArtifacts)
+				err = kc.VersionVolumes(fakeResource, pipelineArtifacts)
 				Expect(err).To(BeNil())
 				fakePod = kubernetes.NewPod(fakeResource.Object)
 			})
 			It("updates the volume name to contain the reference", func() {
 				volumes := fakePod.GetSpec().Volumes
 				Expect(volumes[0].Secret.SecretName).To(Equal("test-secret-v001"))
+			})
+		})
+		When("manifest kind is deployment and volume type is configMap", func() {
+			BeforeEach(func() {
+				fakeResource := &unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind":       "Deployment",
+						"apiVersion": "apps/v1",
+						"spec": map[string]interface{}{
+							"template": map[string]interface{}{
+								"spec": map[string]interface{}{
+									"volumes": []map[string]interface{}{
+										{
+											"configMap": map[string]interface{}{
+												"name": "test-config-map",
+											},
+											"name": "test-config-map",
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+
+				pipelineArtifacts := map[string]clouddriver.TaskCreatedArtifact{
+					"test-config-map": {
+						Name:      "test-config-map",
+						Type:      "kubernetes/configMap",
+						Reference: "test-config-map-v001",
+					},
+				}
+
+				err = kc.VersionVolumes(fakeResource, pipelineArtifacts)
+				Expect(err).To(BeNil())
+				fakeDeployment = kubernetes.NewDeployment(fakeResource.Object)
+			})
+			It("updates the volume name to contain the reference", func() {
+				volumes := fakeDeployment.GetSpec().Template.Spec.Volumes
+				Expect(volumes[0].ConfigMap.Name).To(Equal("test-config-map-v001"))
 			})
 		})
 	})

--- a/pkg/sql/sqlfakes/fake_client.go
+++ b/pkg/sql/sqlfakes/fake_client.go
@@ -7,7 +7,6 @@ import (
 	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 	"github.com/homedepot/go-clouddriver/pkg/kubernetes"
 	"github.com/homedepot/go-clouddriver/pkg/sql"
-	_ "github.com/mattn/go-sqlite3"
 )
 
 type FakeClient struct {
@@ -120,8 +119,9 @@ type FakeClient struct {
 	}
 	ListKubernetesProvidersStub        func() ([]kubernetes.Provider, error)
 	listKubernetesProvidersMutex       sync.RWMutex
-	listKubernetesProvidersArgsForCall []struct{}
-	listKubernetesProvidersReturns     struct {
+	listKubernetesProvidersArgsForCall []struct {
+	}
+	listKubernetesProvidersReturns struct {
 		result1 []kubernetes.Provider
 		result2 error
 	}
@@ -131,13 +131,29 @@ type FakeClient struct {
 	}
 	ListKubernetesProvidersAndPermissionsStub        func() ([]kubernetes.Provider, error)
 	listKubernetesProvidersAndPermissionsMutex       sync.RWMutex
-	listKubernetesProvidersAndPermissionsArgsForCall []struct{}
-	listKubernetesProvidersAndPermissionsReturns     struct {
+	listKubernetesProvidersAndPermissionsArgsForCall []struct {
+	}
+	listKubernetesProvidersAndPermissionsReturns struct {
 		result1 []kubernetes.Provider
 		result2 error
 	}
 	listKubernetesProvidersAndPermissionsReturnsOnCall map[int]struct {
 		result1 []kubernetes.Provider
+		result2 error
+	}
+	ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub        func(string, string, string) ([]string, error)
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex       sync.RWMutex
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall []struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns struct {
+		result1 []string
+		result2 error
+	}
+	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall map[int]struct {
+		result1 []string
 		result2 error
 	}
 	ListKubernetesResourcesByFieldsStub        func(...string) ([]kubernetes.Resource, error)
@@ -164,21 +180,6 @@ type FakeClient struct {
 	}
 	listKubernetesResourcesByTaskIDReturnsOnCall map[int]struct {
 		result1 []kubernetes.Resource
-		result2 error
-	}
-	ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub        func(string, string, string) ([]string, error)
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex       sync.RWMutex
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall []struct {
-		arg1 string
-		arg2 string
-		arg3 string
-	}
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns struct {
-		result1 []string
-		result2 error
-	}
-	listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall map[int]struct {
-		result1 []string
 		result2 error
 	}
 	ListReadGroupsByAccountNameStub        func(string) ([]string, error)
@@ -225,7 +226,8 @@ func (fake *FakeClient) CreateKubernetesProvider(arg1 kubernetes.Provider) error
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createKubernetesProviderReturns.result1
+	fakeReturns := fake.createKubernetesProviderReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateKubernetesProviderCallCount() int {
@@ -234,13 +236,22 @@ func (fake *FakeClient) CreateKubernetesProviderCallCount() int {
 	return len(fake.createKubernetesProviderArgsForCall)
 }
 
+func (fake *FakeClient) CreateKubernetesProviderCalls(stub func(kubernetes.Provider) error) {
+	fake.createKubernetesProviderMutex.Lock()
+	defer fake.createKubernetesProviderMutex.Unlock()
+	fake.CreateKubernetesProviderStub = stub
+}
+
 func (fake *FakeClient) CreateKubernetesProviderArgsForCall(i int) kubernetes.Provider {
 	fake.createKubernetesProviderMutex.RLock()
 	defer fake.createKubernetesProviderMutex.RUnlock()
-	return fake.createKubernetesProviderArgsForCall[i].arg1
+	argsForCall := fake.createKubernetesProviderArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateKubernetesProviderReturns(result1 error) {
+	fake.createKubernetesProviderMutex.Lock()
+	defer fake.createKubernetesProviderMutex.Unlock()
 	fake.CreateKubernetesProviderStub = nil
 	fake.createKubernetesProviderReturns = struct {
 		result1 error
@@ -248,6 +259,8 @@ func (fake *FakeClient) CreateKubernetesProviderReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateKubernetesProviderReturnsOnCall(i int, result1 error) {
+	fake.createKubernetesProviderMutex.Lock()
+	defer fake.createKubernetesProviderMutex.Unlock()
 	fake.CreateKubernetesProviderStub = nil
 	if fake.createKubernetesProviderReturnsOnCall == nil {
 		fake.createKubernetesProviderReturnsOnCall = make(map[int]struct {
@@ -273,7 +286,8 @@ func (fake *FakeClient) CreateKubernetesResource(arg1 kubernetes.Resource) error
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createKubernetesResourceReturns.result1
+	fakeReturns := fake.createKubernetesResourceReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateKubernetesResourceCallCount() int {
@@ -282,13 +296,22 @@ func (fake *FakeClient) CreateKubernetesResourceCallCount() int {
 	return len(fake.createKubernetesResourceArgsForCall)
 }
 
+func (fake *FakeClient) CreateKubernetesResourceCalls(stub func(kubernetes.Resource) error) {
+	fake.createKubernetesResourceMutex.Lock()
+	defer fake.createKubernetesResourceMutex.Unlock()
+	fake.CreateKubernetesResourceStub = stub
+}
+
 func (fake *FakeClient) CreateKubernetesResourceArgsForCall(i int) kubernetes.Resource {
 	fake.createKubernetesResourceMutex.RLock()
 	defer fake.createKubernetesResourceMutex.RUnlock()
-	return fake.createKubernetesResourceArgsForCall[i].arg1
+	argsForCall := fake.createKubernetesResourceArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateKubernetesResourceReturns(result1 error) {
+	fake.createKubernetesResourceMutex.Lock()
+	defer fake.createKubernetesResourceMutex.Unlock()
 	fake.CreateKubernetesResourceStub = nil
 	fake.createKubernetesResourceReturns = struct {
 		result1 error
@@ -296,6 +319,8 @@ func (fake *FakeClient) CreateKubernetesResourceReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateKubernetesResourceReturnsOnCall(i int, result1 error) {
+	fake.createKubernetesResourceMutex.Lock()
+	defer fake.createKubernetesResourceMutex.Unlock()
 	fake.CreateKubernetesResourceStub = nil
 	if fake.createKubernetesResourceReturnsOnCall == nil {
 		fake.createKubernetesResourceReturnsOnCall = make(map[int]struct {
@@ -321,7 +346,8 @@ func (fake *FakeClient) CreateReadPermission(arg1 clouddriver.ReadPermission) er
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createReadPermissionReturns.result1
+	fakeReturns := fake.createReadPermissionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateReadPermissionCallCount() int {
@@ -330,13 +356,22 @@ func (fake *FakeClient) CreateReadPermissionCallCount() int {
 	return len(fake.createReadPermissionArgsForCall)
 }
 
+func (fake *FakeClient) CreateReadPermissionCalls(stub func(clouddriver.ReadPermission) error) {
+	fake.createReadPermissionMutex.Lock()
+	defer fake.createReadPermissionMutex.Unlock()
+	fake.CreateReadPermissionStub = stub
+}
+
 func (fake *FakeClient) CreateReadPermissionArgsForCall(i int) clouddriver.ReadPermission {
 	fake.createReadPermissionMutex.RLock()
 	defer fake.createReadPermissionMutex.RUnlock()
-	return fake.createReadPermissionArgsForCall[i].arg1
+	argsForCall := fake.createReadPermissionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateReadPermissionReturns(result1 error) {
+	fake.createReadPermissionMutex.Lock()
+	defer fake.createReadPermissionMutex.Unlock()
 	fake.CreateReadPermissionStub = nil
 	fake.createReadPermissionReturns = struct {
 		result1 error
@@ -344,6 +379,8 @@ func (fake *FakeClient) CreateReadPermissionReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateReadPermissionReturnsOnCall(i int, result1 error) {
+	fake.createReadPermissionMutex.Lock()
+	defer fake.createReadPermissionMutex.Unlock()
 	fake.CreateReadPermissionStub = nil
 	if fake.createReadPermissionReturnsOnCall == nil {
 		fake.createReadPermissionReturnsOnCall = make(map[int]struct {
@@ -369,7 +406,8 @@ func (fake *FakeClient) CreateWritePermission(arg1 clouddriver.WritePermission) 
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.createWritePermissionReturns.result1
+	fakeReturns := fake.createWritePermissionReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) CreateWritePermissionCallCount() int {
@@ -378,13 +416,22 @@ func (fake *FakeClient) CreateWritePermissionCallCount() int {
 	return len(fake.createWritePermissionArgsForCall)
 }
 
+func (fake *FakeClient) CreateWritePermissionCalls(stub func(clouddriver.WritePermission) error) {
+	fake.createWritePermissionMutex.Lock()
+	defer fake.createWritePermissionMutex.Unlock()
+	fake.CreateWritePermissionStub = stub
+}
+
 func (fake *FakeClient) CreateWritePermissionArgsForCall(i int) clouddriver.WritePermission {
 	fake.createWritePermissionMutex.RLock()
 	defer fake.createWritePermissionMutex.RUnlock()
-	return fake.createWritePermissionArgsForCall[i].arg1
+	argsForCall := fake.createWritePermissionArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) CreateWritePermissionReturns(result1 error) {
+	fake.createWritePermissionMutex.Lock()
+	defer fake.createWritePermissionMutex.Unlock()
 	fake.CreateWritePermissionStub = nil
 	fake.createWritePermissionReturns = struct {
 		result1 error
@@ -392,6 +439,8 @@ func (fake *FakeClient) CreateWritePermissionReturns(result1 error) {
 }
 
 func (fake *FakeClient) CreateWritePermissionReturnsOnCall(i int, result1 error) {
+	fake.createWritePermissionMutex.Lock()
+	defer fake.createWritePermissionMutex.Unlock()
 	fake.CreateWritePermissionStub = nil
 	if fake.createWritePermissionReturnsOnCall == nil {
 		fake.createWritePermissionReturnsOnCall = make(map[int]struct {
@@ -417,7 +466,8 @@ func (fake *FakeClient) DeleteKubernetesProvider(arg1 string) error {
 	if specificReturn {
 		return ret.result1
 	}
-	return fake.deleteKubernetesProviderReturns.result1
+	fakeReturns := fake.deleteKubernetesProviderReturns
+	return fakeReturns.result1
 }
 
 func (fake *FakeClient) DeleteKubernetesProviderCallCount() int {
@@ -426,13 +476,22 @@ func (fake *FakeClient) DeleteKubernetesProviderCallCount() int {
 	return len(fake.deleteKubernetesProviderArgsForCall)
 }
 
+func (fake *FakeClient) DeleteKubernetesProviderCalls(stub func(string) error) {
+	fake.deleteKubernetesProviderMutex.Lock()
+	defer fake.deleteKubernetesProviderMutex.Unlock()
+	fake.DeleteKubernetesProviderStub = stub
+}
+
 func (fake *FakeClient) DeleteKubernetesProviderArgsForCall(i int) string {
 	fake.deleteKubernetesProviderMutex.RLock()
 	defer fake.deleteKubernetesProviderMutex.RUnlock()
-	return fake.deleteKubernetesProviderArgsForCall[i].arg1
+	argsForCall := fake.deleteKubernetesProviderArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) DeleteKubernetesProviderReturns(result1 error) {
+	fake.deleteKubernetesProviderMutex.Lock()
+	defer fake.deleteKubernetesProviderMutex.Unlock()
 	fake.DeleteKubernetesProviderStub = nil
 	fake.deleteKubernetesProviderReturns = struct {
 		result1 error
@@ -440,6 +499,8 @@ func (fake *FakeClient) DeleteKubernetesProviderReturns(result1 error) {
 }
 
 func (fake *FakeClient) DeleteKubernetesProviderReturnsOnCall(i int, result1 error) {
+	fake.deleteKubernetesProviderMutex.Lock()
+	defer fake.deleteKubernetesProviderMutex.Unlock()
 	fake.DeleteKubernetesProviderStub = nil
 	if fake.deleteKubernetesProviderReturnsOnCall == nil {
 		fake.deleteKubernetesProviderReturnsOnCall = make(map[int]struct {
@@ -465,7 +526,8 @@ func (fake *FakeClient) GetKubernetesProvider(arg1 string) (kubernetes.Provider,
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.getKubernetesProviderReturns.result1, fake.getKubernetesProviderReturns.result2
+	fakeReturns := fake.getKubernetesProviderReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) GetKubernetesProviderCallCount() int {
@@ -474,13 +536,22 @@ func (fake *FakeClient) GetKubernetesProviderCallCount() int {
 	return len(fake.getKubernetesProviderArgsForCall)
 }
 
+func (fake *FakeClient) GetKubernetesProviderCalls(stub func(string) (kubernetes.Provider, error)) {
+	fake.getKubernetesProviderMutex.Lock()
+	defer fake.getKubernetesProviderMutex.Unlock()
+	fake.GetKubernetesProviderStub = stub
+}
+
 func (fake *FakeClient) GetKubernetesProviderArgsForCall(i int) string {
 	fake.getKubernetesProviderMutex.RLock()
 	defer fake.getKubernetesProviderMutex.RUnlock()
-	return fake.getKubernetesProviderArgsForCall[i].arg1
+	argsForCall := fake.getKubernetesProviderArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) GetKubernetesProviderReturns(result1 kubernetes.Provider, result2 error) {
+	fake.getKubernetesProviderMutex.Lock()
+	defer fake.getKubernetesProviderMutex.Unlock()
 	fake.GetKubernetesProviderStub = nil
 	fake.getKubernetesProviderReturns = struct {
 		result1 kubernetes.Provider
@@ -489,6 +560,8 @@ func (fake *FakeClient) GetKubernetesProviderReturns(result1 kubernetes.Provider
 }
 
 func (fake *FakeClient) GetKubernetesProviderReturnsOnCall(i int, result1 kubernetes.Provider, result2 error) {
+	fake.getKubernetesProviderMutex.Lock()
+	defer fake.getKubernetesProviderMutex.Unlock()
 	fake.GetKubernetesProviderStub = nil
 	if fake.getKubernetesProviderReturnsOnCall == nil {
 		fake.getKubernetesProviderReturnsOnCall = make(map[int]struct {
@@ -516,7 +589,8 @@ func (fake *FakeClient) ListKubernetesAccountsBySpinnakerApp(arg1 string) ([]str
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesAccountsBySpinnakerAppReturns.result1, fake.listKubernetesAccountsBySpinnakerAppReturns.result2
+	fakeReturns := fake.listKubernetesAccountsBySpinnakerAppReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCallCount() int {
@@ -525,13 +599,22 @@ func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCallCount() int {
 	return len(fake.listKubernetesAccountsBySpinnakerAppArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppCalls(stub func(string) ([]string, error)) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
+	fake.ListKubernetesAccountsBySpinnakerAppStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppArgsForCall(i int) string {
 	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
 	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
-	return fake.listKubernetesAccountsBySpinnakerAppArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesAccountsBySpinnakerAppArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturns(result1 []string, result2 error) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
 	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
 	fake.listKubernetesAccountsBySpinnakerAppReturns = struct {
 		result1 []string
@@ -540,6 +623,8 @@ func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturns(result1 []st
 }
 
 func (fake *FakeClient) ListKubernetesAccountsBySpinnakerAppReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listKubernetesAccountsBySpinnakerAppMutex.Lock()
+	defer fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
 	fake.ListKubernetesAccountsBySpinnakerAppStub = nil
 	if fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall == nil {
 		fake.listKubernetesAccountsBySpinnakerAppReturnsOnCall = make(map[int]struct {
@@ -567,7 +652,8 @@ func (fake *FakeClient) ListKubernetesClustersByApplication(arg1 string) ([]kube
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesClustersByApplicationReturns.result1, fake.listKubernetesClustersByApplicationReturns.result2
+	fakeReturns := fake.listKubernetesClustersByApplicationReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesClustersByApplicationCallCount() int {
@@ -576,13 +662,22 @@ func (fake *FakeClient) ListKubernetesClustersByApplicationCallCount() int {
 	return len(fake.listKubernetesClustersByApplicationArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesClustersByApplicationCalls(stub func(string) ([]kubernetes.Resource, error)) {
+	fake.listKubernetesClustersByApplicationMutex.Lock()
+	defer fake.listKubernetesClustersByApplicationMutex.Unlock()
+	fake.ListKubernetesClustersByApplicationStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesClustersByApplicationArgsForCall(i int) string {
 	fake.listKubernetesClustersByApplicationMutex.RLock()
 	defer fake.listKubernetesClustersByApplicationMutex.RUnlock()
-	return fake.listKubernetesClustersByApplicationArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesClustersByApplicationArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesClustersByApplicationReturns(result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesClustersByApplicationMutex.Lock()
+	defer fake.listKubernetesClustersByApplicationMutex.Unlock()
 	fake.ListKubernetesClustersByApplicationStub = nil
 	fake.listKubernetesClustersByApplicationReturns = struct {
 		result1 []kubernetes.Resource
@@ -591,6 +686,8 @@ func (fake *FakeClient) ListKubernetesClustersByApplicationReturns(result1 []kub
 }
 
 func (fake *FakeClient) ListKubernetesClustersByApplicationReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesClustersByApplicationMutex.Lock()
+	defer fake.listKubernetesClustersByApplicationMutex.Unlock()
 	fake.ListKubernetesClustersByApplicationStub = nil
 	if fake.listKubernetesClustersByApplicationReturnsOnCall == nil {
 		fake.listKubernetesClustersByApplicationReturnsOnCall = make(map[int]struct {
@@ -618,7 +715,8 @@ func (fake *FakeClient) ListKubernetesClustersByFields(arg1 ...string) ([]kubern
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesClustersByFieldsReturns.result1, fake.listKubernetesClustersByFieldsReturns.result2
+	fakeReturns := fake.listKubernetesClustersByFieldsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesClustersByFieldsCallCount() int {
@@ -627,13 +725,22 @@ func (fake *FakeClient) ListKubernetesClustersByFieldsCallCount() int {
 	return len(fake.listKubernetesClustersByFieldsArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesClustersByFieldsCalls(stub func(...string) ([]kubernetes.Resource, error)) {
+	fake.listKubernetesClustersByFieldsMutex.Lock()
+	defer fake.listKubernetesClustersByFieldsMutex.Unlock()
+	fake.ListKubernetesClustersByFieldsStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesClustersByFieldsArgsForCall(i int) []string {
 	fake.listKubernetesClustersByFieldsMutex.RLock()
 	defer fake.listKubernetesClustersByFieldsMutex.RUnlock()
-	return fake.listKubernetesClustersByFieldsArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesClustersByFieldsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesClustersByFieldsReturns(result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesClustersByFieldsMutex.Lock()
+	defer fake.listKubernetesClustersByFieldsMutex.Unlock()
 	fake.ListKubernetesClustersByFieldsStub = nil
 	fake.listKubernetesClustersByFieldsReturns = struct {
 		result1 []kubernetes.Resource
@@ -642,6 +749,8 @@ func (fake *FakeClient) ListKubernetesClustersByFieldsReturns(result1 []kubernet
 }
 
 func (fake *FakeClient) ListKubernetesClustersByFieldsReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesClustersByFieldsMutex.Lock()
+	defer fake.listKubernetesClustersByFieldsMutex.Unlock()
 	fake.ListKubernetesClustersByFieldsStub = nil
 	if fake.listKubernetesClustersByFieldsReturnsOnCall == nil {
 		fake.listKubernetesClustersByFieldsReturnsOnCall = make(map[int]struct {
@@ -658,7 +767,8 @@ func (fake *FakeClient) ListKubernetesClustersByFieldsReturnsOnCall(i int, resul
 func (fake *FakeClient) ListKubernetesProviders() ([]kubernetes.Provider, error) {
 	fake.listKubernetesProvidersMutex.Lock()
 	ret, specificReturn := fake.listKubernetesProvidersReturnsOnCall[len(fake.listKubernetesProvidersArgsForCall)]
-	fake.listKubernetesProvidersArgsForCall = append(fake.listKubernetesProvidersArgsForCall, struct{}{})
+	fake.listKubernetesProvidersArgsForCall = append(fake.listKubernetesProvidersArgsForCall, struct {
+	}{})
 	fake.recordInvocation("ListKubernetesProviders", []interface{}{})
 	fake.listKubernetesProvidersMutex.Unlock()
 	if fake.ListKubernetesProvidersStub != nil {
@@ -667,7 +777,8 @@ func (fake *FakeClient) ListKubernetesProviders() ([]kubernetes.Provider, error)
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesProvidersReturns.result1, fake.listKubernetesProvidersReturns.result2
+	fakeReturns := fake.listKubernetesProvidersReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesProvidersCallCount() int {
@@ -676,7 +787,15 @@ func (fake *FakeClient) ListKubernetesProvidersCallCount() int {
 	return len(fake.listKubernetesProvidersArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesProvidersCalls(stub func() ([]kubernetes.Provider, error)) {
+	fake.listKubernetesProvidersMutex.Lock()
+	defer fake.listKubernetesProvidersMutex.Unlock()
+	fake.ListKubernetesProvidersStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesProvidersReturns(result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersMutex.Lock()
+	defer fake.listKubernetesProvidersMutex.Unlock()
 	fake.ListKubernetesProvidersStub = nil
 	fake.listKubernetesProvidersReturns = struct {
 		result1 []kubernetes.Provider
@@ -685,6 +804,8 @@ func (fake *FakeClient) ListKubernetesProvidersReturns(result1 []kubernetes.Prov
 }
 
 func (fake *FakeClient) ListKubernetesProvidersReturnsOnCall(i int, result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersMutex.Lock()
+	defer fake.listKubernetesProvidersMutex.Unlock()
 	fake.ListKubernetesProvidersStub = nil
 	if fake.listKubernetesProvidersReturnsOnCall == nil {
 		fake.listKubernetesProvidersReturnsOnCall = make(map[int]struct {
@@ -701,7 +822,8 @@ func (fake *FakeClient) ListKubernetesProvidersReturnsOnCall(i int, result1 []ku
 func (fake *FakeClient) ListKubernetesProvidersAndPermissions() ([]kubernetes.Provider, error) {
 	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
 	ret, specificReturn := fake.listKubernetesProvidersAndPermissionsReturnsOnCall[len(fake.listKubernetesProvidersAndPermissionsArgsForCall)]
-	fake.listKubernetesProvidersAndPermissionsArgsForCall = append(fake.listKubernetesProvidersAndPermissionsArgsForCall, struct{}{})
+	fake.listKubernetesProvidersAndPermissionsArgsForCall = append(fake.listKubernetesProvidersAndPermissionsArgsForCall, struct {
+	}{})
 	fake.recordInvocation("ListKubernetesProvidersAndPermissions", []interface{}{})
 	fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
 	if fake.ListKubernetesProvidersAndPermissionsStub != nil {
@@ -710,7 +832,8 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissions() ([]kubernetes.Pr
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesProvidersAndPermissionsReturns.result1, fake.listKubernetesProvidersAndPermissionsReturns.result2
+	fakeReturns := fake.listKubernetesProvidersAndPermissionsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCallCount() int {
@@ -719,7 +842,15 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCallCount() int {
 	return len(fake.listKubernetesProvidersAndPermissionsArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesProvidersAndPermissionsCalls(stub func() ([]kubernetes.Provider, error)) {
+	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
+	fake.ListKubernetesProvidersAndPermissionsStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturns(result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
 	fake.ListKubernetesProvidersAndPermissionsStub = nil
 	fake.listKubernetesProvidersAndPermissionsReturns = struct {
 		result1 []kubernetes.Provider
@@ -728,6 +859,8 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturns(result1 []k
 }
 
 func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturnsOnCall(i int, result1 []kubernetes.Provider, result2 error) {
+	fake.listKubernetesProvidersAndPermissionsMutex.Lock()
+	defer fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
 	fake.ListKubernetesProvidersAndPermissionsStub = nil
 	if fake.listKubernetesProvidersAndPermissionsReturnsOnCall == nil {
 		fake.listKubernetesProvidersAndPermissionsReturnsOnCall = make(map[int]struct {
@@ -737,6 +870,71 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissionsReturnsOnCall(i int
 	}
 	fake.listKubernetesProvidersAndPermissionsReturnsOnCall[i] = struct {
 		result1 []kubernetes.Provider
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespace(arg1 string, arg2 string, arg3 string) ([]string, error) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
+	ret, specificReturn := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)]
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall = append(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall, struct {
+		arg1 string
+		arg2 string
+		arg3 string
+	}{arg1, arg2, arg3})
+	fake.recordInvocation("ListKubernetesResourceNamesByAccountNameAndKindAndNamespace", []interface{}{arg1, arg2, arg3})
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
+	if fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub != nil {
+		return fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub(arg1, arg2, arg3)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceCallCount() int {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
+	return len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceCalls(stub func(string, string, string) ([]string, error)) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
+	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = stub
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall(i int) (string, string, string) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
+	argsForCall := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns(result1 []string, result2 error) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
+	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns = struct {
+		result1 []string
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
+	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
+	if fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall == nil {
+		fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 error
+		})
+	}
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[i] = struct {
+		result1 []string
 		result2 error
 	}{result1, result2}
 }
@@ -755,7 +953,8 @@ func (fake *FakeClient) ListKubernetesResourcesByFields(arg1 ...string) ([]kuber
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesResourcesByFieldsReturns.result1, fake.listKubernetesResourcesByFieldsReturns.result2
+	fakeReturns := fake.listKubernetesResourcesByFieldsReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsCallCount() int {
@@ -764,13 +963,22 @@ func (fake *FakeClient) ListKubernetesResourcesByFieldsCallCount() int {
 	return len(fake.listKubernetesResourcesByFieldsArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesResourcesByFieldsCalls(stub func(...string) ([]kubernetes.Resource, error)) {
+	fake.listKubernetesResourcesByFieldsMutex.Lock()
+	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
+	fake.ListKubernetesResourcesByFieldsStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesResourcesByFieldsArgsForCall(i int) []string {
 	fake.listKubernetesResourcesByFieldsMutex.RLock()
 	defer fake.listKubernetesResourcesByFieldsMutex.RUnlock()
-	return fake.listKubernetesResourcesByFieldsArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesResourcesByFieldsArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsReturns(result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByFieldsMutex.Lock()
+	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
 	fake.ListKubernetesResourcesByFieldsStub = nil
 	fake.listKubernetesResourcesByFieldsReturns = struct {
 		result1 []kubernetes.Resource
@@ -779,6 +987,8 @@ func (fake *FakeClient) ListKubernetesResourcesByFieldsReturns(result1 []kuberne
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByFieldsReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByFieldsMutex.Lock()
+	defer fake.listKubernetesResourcesByFieldsMutex.Unlock()
 	fake.ListKubernetesResourcesByFieldsStub = nil
 	if fake.listKubernetesResourcesByFieldsReturnsOnCall == nil {
 		fake.listKubernetesResourcesByFieldsReturnsOnCall = make(map[int]struct {
@@ -806,7 +1016,8 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskID(arg1 string) ([]kubernet
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listKubernetesResourcesByTaskIDReturns.result1, fake.listKubernetesResourcesByTaskIDReturns.result2
+	fakeReturns := fake.listKubernetesResourcesByTaskIDReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDCallCount() int {
@@ -815,13 +1026,22 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDCallCount() int {
 	return len(fake.listKubernetesResourcesByTaskIDArgsForCall)
 }
 
+func (fake *FakeClient) ListKubernetesResourcesByTaskIDCalls(stub func(string) ([]kubernetes.Resource, error)) {
+	fake.listKubernetesResourcesByTaskIDMutex.Lock()
+	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
+	fake.ListKubernetesResourcesByTaskIDStub = stub
+}
+
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDArgsForCall(i int) string {
 	fake.listKubernetesResourcesByTaskIDMutex.RLock()
 	defer fake.listKubernetesResourcesByTaskIDMutex.RUnlock()
-	return fake.listKubernetesResourcesByTaskIDArgsForCall[i].arg1
+	argsForCall := fake.listKubernetesResourcesByTaskIDArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturns(result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByTaskIDMutex.Lock()
+	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
 	fake.ListKubernetesResourcesByTaskIDStub = nil
 	fake.listKubernetesResourcesByTaskIDReturns = struct {
 		result1 []kubernetes.Resource
@@ -830,6 +1050,8 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturns(result1 []kuberne
 }
 
 func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturnsOnCall(i int, result1 []kubernetes.Resource, result2 error) {
+	fake.listKubernetesResourcesByTaskIDMutex.Lock()
+	defer fake.listKubernetesResourcesByTaskIDMutex.Unlock()
 	fake.ListKubernetesResourcesByTaskIDStub = nil
 	if fake.listKubernetesResourcesByTaskIDReturnsOnCall == nil {
 		fake.listKubernetesResourcesByTaskIDReturnsOnCall = make(map[int]struct {
@@ -839,59 +1061,6 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskIDReturnsOnCall(i int, resu
 	}
 	fake.listKubernetesResourcesByTaskIDReturnsOnCall[i] = struct {
 		result1 []kubernetes.Resource
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespace(arg1 string, arg2 string, arg3 string) ([]string, error) {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Lock()
-	ret, specificReturn := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)]
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall = append(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall, struct {
-		arg1 string
-		arg2 string
-		arg3 string
-	}{arg1, arg2, arg3})
-	fake.recordInvocation("ListKubernetesResourceNamesByAccountNameAndKindAndNamespace", []interface{}{arg1, arg2, arg3})
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
-	if fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub != nil {
-		return fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub(arg1, arg2, arg3)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns.result1, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns.result2
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceCallCount() int {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
-	return len(fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall)
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall(i int) (string, string, string) {
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
-	return fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg1, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg2, fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceArgsForCall[i].arg3
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns(result1 []string, result2 error) {
-	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns = struct {
-		result1 []string
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall(i int, result1 []string, result2 error) {
-	fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub = nil
-	if fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall == nil {
-		fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall = make(map[int]struct {
-			result1 []string
-			result2 error
-		})
-	}
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturnsOnCall[i] = struct {
-		result1 []string
 		result2 error
 	}{result1, result2}
 }
@@ -910,7 +1079,8 @@ func (fake *FakeClient) ListReadGroupsByAccountName(arg1 string) ([]string, erro
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listReadGroupsByAccountNameReturns.result1, fake.listReadGroupsByAccountNameReturns.result2
+	fakeReturns := fake.listReadGroupsByAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameCallCount() int {
@@ -919,13 +1089,22 @@ func (fake *FakeClient) ListReadGroupsByAccountNameCallCount() int {
 	return len(fake.listReadGroupsByAccountNameArgsForCall)
 }
 
+func (fake *FakeClient) ListReadGroupsByAccountNameCalls(stub func(string) ([]string, error)) {
+	fake.listReadGroupsByAccountNameMutex.Lock()
+	defer fake.listReadGroupsByAccountNameMutex.Unlock()
+	fake.ListReadGroupsByAccountNameStub = stub
+}
+
 func (fake *FakeClient) ListReadGroupsByAccountNameArgsForCall(i int) string {
 	fake.listReadGroupsByAccountNameMutex.RLock()
 	defer fake.listReadGroupsByAccountNameMutex.RUnlock()
-	return fake.listReadGroupsByAccountNameArgsForCall[i].arg1
+	argsForCall := fake.listReadGroupsByAccountNameArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameReturns(result1 []string, result2 error) {
+	fake.listReadGroupsByAccountNameMutex.Lock()
+	defer fake.listReadGroupsByAccountNameMutex.Unlock()
 	fake.ListReadGroupsByAccountNameStub = nil
 	fake.listReadGroupsByAccountNameReturns = struct {
 		result1 []string
@@ -934,6 +1113,8 @@ func (fake *FakeClient) ListReadGroupsByAccountNameReturns(result1 []string, res
 }
 
 func (fake *FakeClient) ListReadGroupsByAccountNameReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listReadGroupsByAccountNameMutex.Lock()
+	defer fake.listReadGroupsByAccountNameMutex.Unlock()
 	fake.ListReadGroupsByAccountNameStub = nil
 	if fake.listReadGroupsByAccountNameReturnsOnCall == nil {
 		fake.listReadGroupsByAccountNameReturnsOnCall = make(map[int]struct {
@@ -961,7 +1142,8 @@ func (fake *FakeClient) ListWriteGroupsByAccountName(arg1 string) ([]string, err
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	return fake.listWriteGroupsByAccountNameReturns.result1, fake.listWriteGroupsByAccountNameReturns.result2
+	fakeReturns := fake.listWriteGroupsByAccountNameReturns
+	return fakeReturns.result1, fakeReturns.result2
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameCallCount() int {
@@ -970,13 +1152,22 @@ func (fake *FakeClient) ListWriteGroupsByAccountNameCallCount() int {
 	return len(fake.listWriteGroupsByAccountNameArgsForCall)
 }
 
+func (fake *FakeClient) ListWriteGroupsByAccountNameCalls(stub func(string) ([]string, error)) {
+	fake.listWriteGroupsByAccountNameMutex.Lock()
+	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
+	fake.ListWriteGroupsByAccountNameStub = stub
+}
+
 func (fake *FakeClient) ListWriteGroupsByAccountNameArgsForCall(i int) string {
 	fake.listWriteGroupsByAccountNameMutex.RLock()
 	defer fake.listWriteGroupsByAccountNameMutex.RUnlock()
-	return fake.listWriteGroupsByAccountNameArgsForCall[i].arg1
+	argsForCall := fake.listWriteGroupsByAccountNameArgsForCall[i]
+	return argsForCall.arg1
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameReturns(result1 []string, result2 error) {
+	fake.listWriteGroupsByAccountNameMutex.Lock()
+	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
 	fake.ListWriteGroupsByAccountNameStub = nil
 	fake.listWriteGroupsByAccountNameReturns = struct {
 		result1 []string
@@ -985,6 +1176,8 @@ func (fake *FakeClient) ListWriteGroupsByAccountNameReturns(result1 []string, re
 }
 
 func (fake *FakeClient) ListWriteGroupsByAccountNameReturnsOnCall(i int, result1 []string, result2 error) {
+	fake.listWriteGroupsByAccountNameMutex.Lock()
+	defer fake.listWriteGroupsByAccountNameMutex.Unlock()
 	fake.ListWriteGroupsByAccountNameStub = nil
 	if fake.listWriteGroupsByAccountNameReturnsOnCall == nil {
 		fake.listWriteGroupsByAccountNameReturnsOnCall = make(map[int]struct {
@@ -1023,12 +1216,12 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.listKubernetesProvidersMutex.RUnlock()
 	fake.listKubernetesProvidersAndPermissionsMutex.RLock()
 	defer fake.listKubernetesProvidersAndPermissionsMutex.RUnlock()
+	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
+	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
 	fake.listKubernetesResourcesByFieldsMutex.RLock()
 	defer fake.listKubernetesResourcesByFieldsMutex.RUnlock()
 	fake.listKubernetesResourcesByTaskIDMutex.RLock()
 	defer fake.listKubernetesResourcesByTaskIDMutex.RUnlock()
-	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RLock()
-	defer fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.RUnlock()
 	fake.listReadGroupsByAccountNameMutex.RLock()
 	defer fake.listReadGroupsByAccountNameMutex.RUnlock()
 	fake.listWriteGroupsByAccountNameMutex.RLock()


### PR DESCRIPTION
 **Fix versioning volumes bug**: the previous version of the code would only bind artifacts that are present in the list of the required artifacts for the stage and was breaking when we use one Deploy manifest stage for defining the artifact and the deployment that is binding that artifact. There was also another issue fixed with the volume name and the artifact name which the previous version of the code expected them to match.
