### PR TITLE
fix cause of kato.last.task.id=null error

### DIFF
--- a/pkg/http/core/core_test.go
+++ b/pkg/http/core/core_test.go
@@ -29,7 +29,6 @@ import (
 )
 
 var (
-	r                                 *gin.Engine
 	err                               error
 	svr                               *httptest.Server
 	uri                               string
@@ -189,7 +188,7 @@ func setup() {
 
 	// Create new gin instead of using gin.Default().
 	// This disables request logging which we don't want for tests.
-	r = gin.New()
+	r := gin.New()
 	r.Use(gin.Recovery())
 	// Sometimes when pipelines get canceled (or for unknown reasons)
 	// c.Errors is not nil, even though it contains no errors. This

--- a/pkg/http/core/kubernetes/deploy.go
+++ b/pkg/http/core/kubernetes/deploy.go
@@ -284,7 +284,6 @@ func handleVersionedManifest(kubeClient kube.Client, kubeController kube.Control
 	}
 
 	nameWithoutVersion := u.GetName()
-
 	currentVersion := kubeController.GetCurrentVersion(results, kind, nameWithoutVersion)
 	latestVersion := kubeController.IncrementVersion(currentVersion)
 	u.SetName(nameWithoutVersion + "-" + latestVersion.Long)

--- a/pkg/http/core/ops.go
+++ b/pkg/http/core/ops.go
@@ -63,7 +63,7 @@ func CreateKubernetesOperation(c *gin.Context) {
 			kubernetes.Patch(c, *req.PatchManifest)
 		}
 
-		if c.Errors != nil {
+		if c.Errors != nil && len(c.Errors) > 0 {
 			return
 		}
 	}

--- a/pkg/http/core/ops_test.go
+++ b/pkg/http/core/ops_test.go
@@ -188,7 +188,8 @@ var _ = Describe("Kubernetes", func() {
 				or := kube.OperationsResponse{}
 				b, _ := ioutil.ReadAll(res.Body)
 				json.Unmarshal(b, &or)
-				Expect(or.ID).To(HaveLen(36))
+				uuidLen := 36
+				Expect(or.ID).To(HaveLen(uuidLen))
 				Expect(or.ResourceURI).To(HavePrefix("/task"))
 			})
 		})

--- a/pkg/http/core/ops_test.go
+++ b/pkg/http/core/ops_test.go
@@ -4,9 +4,12 @@ import (
 	// . "github.com/homedepot/go-clouddriver/pkg/http/v0"
 
 	"bytes"
+	"encoding/json"
 	"errors"
+	"io/ioutil"
 	"net/http"
 
+	kube "github.com/homedepot/go-clouddriver/pkg/http/core/kubernetes"
 	"github.com/homedepot/go-clouddriver/pkg/kubernetes"
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -182,6 +185,11 @@ var _ = Describe("Kubernetes", func() {
 		When("it succeeds", func() {
 			It("succeeds", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				or := kube.OperationsResponse{}
+				b, _ := ioutil.ReadAll(res.Body)
+				json.Unmarshal(b, &or)
+				Expect(or.ID).To(HaveLen(36))
+				Expect(or.ResourceURI).To(HavePrefix("/task"))
 			})
 		})
 	})

--- a/pkg/kubernetes/version.go
+++ b/pkg/kubernetes/version.go
@@ -33,7 +33,6 @@ func (c *controller) GetCurrentVersion(ul *unstructured.UnstructuredList, kind, 
 
 	// Filter out all unassociated objects based on the moniker.spinnaker.io/cluster annotation.
 	manifestFilter := NewManifestFilter(ul.Items)
-
 	cluster = kind + " " + name
 
 	results := manifestFilter.FilterOnClusterAnnotation(cluster)
@@ -41,7 +40,7 @@ func (c *controller) GetCurrentVersion(ul *unstructured.UnstructuredList, kind, 
 		return currentVersion
 	}
 
-	//filter out empty moniker.spinnaker.io/sequence labels
+	// Filter out empty moniker.spinnaker.io/sequence labels
 	manifestFilter2 := NewManifestFilter(results)
 	results = manifestFilter2.FilterOnLabel(LabelSpinnakerMonikerSequence)
 


### PR DESCRIPTION
Go Clouddriver was occasionally returning an empty HTTP 200 response on the `/kubernetes/ops` endpoint calls. This was throwing an error [here](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/java/com/netflix/spinnaker/orca/clouddriver/tasks/artifacts/CleanupArtifactsTask.java#L64) in orca: `null value in entry: kato.last.task.id=null`. The problem seemed intermittent but mostly seemed to happen in stages where a concurrently running stage failed and the pipeline was canceled. 