### PR TITLE
Fix delete race condition

### DIFF
--- a/pkg/http/core/kubernetes/cleanup.go
+++ b/pkg/http/core/kubernetes/cleanup.go
@@ -72,7 +72,7 @@ func CleanupArtifacts(c *gin.Context, ca CleanupArtifactsRequest) {
 			AccountName:  ca.Account,
 			ID:           uuid.New().String(),
 			TaskID:       taskID,
-			TaskType:     "cleanup",
+			TaskType:     clouddriver.TaskTypeCleanup,
 			Timestamp:    util.CurrentTimeUTC(),
 			APIGroup:     gvr.Group,
 			Name:         u.GetName(),

--- a/pkg/http/core/kubernetes/cleanup_test.go
+++ b/pkg/http/core/kubernetes/cleanup_test.go
@@ -8,6 +8,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 	. "github.com/homedepot/go-clouddriver/pkg/http/core/kubernetes"
 	"github.com/homedepot/go-clouddriver/pkg/kubernetes"
 )
@@ -101,6 +102,8 @@ var _ = Describe("CleanupArtifacts", func() {
 	When("it succeeds", func() {
 		It("succeeds", func() {
 			Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+			kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+			Expect(kr.TaskType).To(Equal(clouddriver.TaskTypeCleanup))
 		})
 	})
 })

--- a/pkg/http/core/kubernetes/delete.go
+++ b/pkg/http/core/kubernetes/delete.go
@@ -99,6 +99,7 @@ func Delete(c *gin.Context, dm DeleteManifestRequest) {
 			AccountName:  dm.Account,
 			ID:           uuid.New().String(),
 			TaskID:       taskID,
+			TaskType:     clouddriver.TaskTypeDelete,
 			Timestamp:    util.CurrentTimeUTC(),
 			APIGroup:     gvr.Group,
 			Name:         name,

--- a/pkg/http/core/kubernetes/delete_test.go
+++ b/pkg/http/core/kubernetes/delete_test.go
@@ -9,6 +9,7 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
+	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 	. "github.com/homedepot/go-clouddriver/pkg/http/core/kubernetes"
 	"github.com/homedepot/go-clouddriver/pkg/kubernetes"
 )
@@ -132,6 +133,8 @@ var _ = Describe("Delete", func() {
 			Expect(*deleteOptions.GracePeriodSeconds).To(Equal(int64(10)))
 			Expect(deleteOptions.PropagationPolicy).ToNot(BeNil())
 			Expect(*deleteOptions.PropagationPolicy).To(Equal(v1.DeletePropagationForeground))
+			kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+			Expect(kr.TaskType).To(Equal(clouddriver.TaskTypeDelete))
 		})
 	})
 })

--- a/pkg/http/core/task.go
+++ b/pkg/http/core/task.go
@@ -91,7 +91,9 @@ func GetTask(c *gin.Context) {
 				manifests = append(manifests, map[string]interface{}{})
 				continue
 			}
+
 			clouddriver.Error(c, http.StatusInternalServerError, err)
+
 			return
 		}
 

--- a/pkg/http/core/task.go
+++ b/pkg/http/core/task.go
@@ -73,13 +73,24 @@ func GetTask(c *gin.Context) {
 
 	for _, r := range resources {
 		// Ignore getting the manifest if task type is "cleanup".
-		if strings.EqualFold(r.TaskType, "cleanup") {
+		if strings.EqualFold(r.TaskType, clouddriver.TaskTypeCleanup) {
 			manifests = append(manifests, map[string]interface{}{})
 			continue
 		}
 
 		result, err := client.Get(r.Resource, r.Name, r.Namespace)
 		if err != nil {
+			// If the task type is "delete" and the resource was not found,
+			// append an empty manifest and continue.
+			// I tried to use `errors.IsNotFound(err)` here to check
+			// if the error was a not found error, but was unable to get the
+			// test to work in doing this, so for now we are just checking
+			// the string suffix.
+			if strings.EqualFold(r.TaskType, clouddriver.TaskTypeDelete) &&
+				strings.HasSuffix(err.Error(), "not found") {
+				manifests = append(manifests, map[string]interface{}{})
+				continue
+			}
 			clouddriver.Error(c, http.StatusInternalServerError, err)
 			return
 		}

--- a/pkg/task.go
+++ b/pkg/task.go
@@ -2,7 +2,11 @@ package clouddriver
 
 import "github.com/gin-gonic/gin"
 
-const TaskIDKey = `TaskID`
+const (
+	TaskIDKey       = `TaskID`
+	TaskTypeCleanup = `cleanup`
+	TaskTypeDelete  = `delete`
+)
 
 func NewDefaultTask(id string) Task {
 	return Task{


### PR DESCRIPTION
When a resource is deleted in Go Clouddriver it creates a task, which is then checked by Orca. Sometimes the resource is deleted before orca can grab the status of this task which is throwing an error 
```
<kind> "<name>" not found
```
Declare these tasks as kind `delete` and ignore these errors.