### PR TITLE
Make associating pods to parent resource more efficient

### DIFF
--- a/pkg/http/core/applications_test.go
+++ b/pkg/http/core/applications_test.go
@@ -470,6 +470,52 @@ var _ = Describe("Application", func() {
 								"ownerReferences": []map[string]interface{}{
 									{
 										"name": "test-rs1",
+										"kind": "replicaSet",
+										"uid":  "test-uid1",
+									},
+								},
+								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"labels": map[string]interface{}{
+									"label1": "test-label1",
+								},
+								"ownerReferences": []map[string]interface{}{
+									{
+										"name": "test-rs1",
+										"kind": "replicaSet",
+										"uid":  "test-uid2",
+									},
+								},
+								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"labels": map[string]interface{}{
+									"label1": "test-label1",
+								},
+								"ownerReferences": []map[string]interface{}{
+									{
+										"name": "test-rs1",
+										"kind": "replicaSet",
+										"uid":  "test-uid3",
 									},
 								},
 								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
@@ -496,6 +542,7 @@ var _ = Describe("Application", func() {
 									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 									"deployment.kubernetes.io/revision": "19",
 								},
+								"uid": "test-uid1",
 							},
 							"spec": map[string]interface{}{
 								"replicas": 1,
@@ -538,6 +585,7 @@ var _ = Describe("Application", func() {
 									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 									"deployment.kubernetes.io/revision": "19",
 								},
+								"uid": "test-uid2",
 							},
 							"spec": map[string]interface{}{
 								"replicas": 1,
@@ -581,6 +629,7 @@ var _ = Describe("Application", func() {
 									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 									"deployment.kubernetes.io/revision": "19",
 								},
+								"uid": "test-uid3",
 							},
 							"spec": map[string]interface{}{
 								"replicas": 1,

--- a/pkg/http/core/payload_test.go
+++ b/pkg/http/core/payload_test.go
@@ -927,7 +927,36 @@ const payloadListServerGroups = `[
                 "unknown": 0,
                 "up": 1
               },
-              "instances": [],
+              "instances": [
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod1"
+                }
+              ],
               "isDisabled": false,
               "key": {
                 "account": "",


### PR DESCRIPTION
The `/applications/:application/serverGroups` endpoint was taking a long time to respond when there are several resources to retrieve. This PR makes this endpoint far more efficient.

Specifically, this endpoint is performing the following operations *serially* one by one:
- list pods with a label selector for the given app
- list replicaSets with a label selector for the given app
- list daemonSets with a label selector for the given app
- list statefulSets with a label selector for the given app
- build server group for each of these resources associated with each pod

It turns out that the culprit was the final bullet point to build the server group, specifically [this function here](https://github.com/homedepot/go-clouddriver/blob/48c110af700b4a37ee5e1bfae940d99e3ced1730/pkg/http/core/applications.go#L901).

Here's some time diff data regarding client calls to the cluster:
- list pods: ~ 500ms (~350 resources)
- list rs: ~50ms (~150 resources)
- list ds: ~30ms (1 resource)
- list sts: ~30ms (0 resources)

Here's the time data for building the server groups for the above resources *before* this PR.
- build server group: (**9 seconds**)

And after this PR
- build server group: ~90ms

We might want to consider making the calls for these resources (pods, rs, sts, ds) concurrently. Even for very large applications that have thousands of pods this optimization should decrease the time spent getting server groups to a few seconds tops (just guessing). Perhaps this should be a separate PR :).

Additionally, we were originally associating a pod with its owner *by name only*, which is incorrect as this would associate pods with an owner of the same name in a separate namespace! The fix is just to associate a pod with an owner's UID. Much better!