### PR TITLE
fix sequence for versioned resources

### DIFF
--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -812,6 +812,7 @@ func getSequence(annotations map[string]string) int {
 	}
 
 	sequence, _ := strconv.Atoi(annotations["deployment.kubernetes.io/revision"])
+
 	return sequence
 }
 

--- a/pkg/http/core/applications_test.go
+++ b/pkg/http/core/applications_test.go
@@ -489,12 +489,12 @@ var _ = Describe("Application", func() {
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
 								"annotations": map[string]interface{}{
-									"artifact.spinnaker.io/name":        "test-deployment1",
-									"artifact.spinnaker.io/type":        "kubernetes/deployment",
-									"artifact.spinnaker.io/location":    "test-namespace1",
-									"moniker.spinnaker.io/application":  "test-deployment1",
-									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
-									"deployment.kubernetes.io/revision": "19",
+									"artifact.spinnaker.io/name":       "test-deployment1",
+									"artifact.spinnaker.io/type":       "kubernetes/deployment",
+									"artifact.spinnaker.io/location":   "test-namespace1",
+									"moniker.spinnaker.io/application": "test-deployment1",
+									"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
+									"moniker.spinnaker.io/sequence":    "19",
 								},
 							},
 							"spec": map[string]interface{}{


### PR DESCRIPTION
A versioned resource contains its sequence in the `moniker.spinnaker.io/sequence` annotation. A resource which is owned by some deployment defines its sequence in the `deployment.kubernetes.io/revision` annotation.

This PR just gathers the sequence for resources from the `moniker.spinnaker.io/sequence`, otherwise it returns the sequence stored in the `deployment.kubernetes.io/revision` annotation.