### PR TITLE
associate server groups and managers using UID

### DIFF
--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -262,6 +262,7 @@ func listServerGroupManagers(c *gin.Context, wg *sync.WaitGroup, sgms chan Serve
 	for _, deployment := range deployments.Items {
 		sgm := newServerGroupManager(deployment, account, application)
 		sgm.ServerGroups = []ServerGroupManagerServerGroup{}
+
 		uid := string(deployment.GetUID())
 		if v, ok := serverGroupManagerMap[uid]; ok {
 			sgm.ServerGroups = v

--- a/pkg/http/core/applications_test.go
+++ b/pkg/http/core/applications_test.go
@@ -94,7 +94,7 @@ var _ = Describe("Application", func() {
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
-								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+								"uid": "test-uid1",
 							},
 						},
 					},
@@ -109,7 +109,7 @@ var _ = Describe("Application", func() {
 								"labels": map[string]interface{}{
 									"label1": "test-label2",
 								},
-								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+								"uid": "test-uid2",
 							},
 						},
 					},
@@ -128,6 +128,13 @@ var _ = Describe("Application", func() {
 									"artifact.spinnaker.io/name":        "test-deployment1",
 									"artifact.spinnaker.io/type":        "kubernetes/deployment",
 									"deployment.kubernetes.io/revision": "236",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-rs1",
+										"kind": "replicaSet",
+										"uid":  "test-uid1",
+									},
 								},
 							},
 						},
@@ -467,8 +474,8 @@ var _ = Describe("Application", func() {
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
-								"ownerReferences": []map[string]interface{}{
-									{
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
 										"name": "test-rs1",
 										"kind": "replicaSet",
 										"uid":  "test-uid1",
@@ -489,9 +496,9 @@ var _ = Describe("Application", func() {
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
-								"ownerReferences": []map[string]interface{}{
-									{
-										"name": "test-rs1",
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-rs2",
 										"kind": "replicaSet",
 										"uid":  "test-uid2",
 									},
@@ -511,9 +518,9 @@ var _ = Describe("Application", func() {
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
-								"ownerReferences": []map[string]interface{}{
-									{
-										"name": "test-rs1",
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-rs3",
 										"kind": "replicaSet",
 										"uid":  "test-uid3",
 									},
@@ -541,6 +548,13 @@ var _ = Describe("Application", func() {
 									"moniker.spinnaker.io/application": "test-deployment1",
 									"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
 									"moniker.spinnaker.io/sequence":    "19",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-deployment1",
+										"kind": "Deployment",
+										"uid":  "test-uid3",
+									},
 								},
 								"uid": "test-uid1",
 							},

--- a/pkg/http/core/payload_test.go
+++ b/pkg/http/core/payload_test.go
@@ -800,33 +800,12 @@ const payloadCredentialsExpandTrueNoNamespaces = `[
 const payloadServerGroupManagers = `[
             {
               "account": "account1",
-              "accountName": "account1",
+              "apiVersion": "apps/v1",
               "cloudProvider": "kubernetes",
               "createdTime": 1581603123000,
-              "key": {
-                "account": "account1",
-                "group": "deployment",
-                "kubernetesKind": "deployment",
-                "name": "test-deployment1",
-                "namespace": "test-namespace1",
-                "provider": "kubernetes"
-              },
               "kind": "deployment",
               "labels": {
                 "label1": "test-label1"
-              },
-              "manifest": {
-                "apiVersion": "apps/v1",
-                "kind": "Deployment",
-                "metadata": {
-                  "creationTimestamp": "2020-02-13T14:12:03Z",
-                  "labels": {
-                    "label1": "test-label1"
-                  },
-                  "name": "test-deployment1",
-                  "namespace": "test-namespace1",
-                  "uid": "cec15437-4e6a-11ea-9788-4201ac100006"
-                }
               },
               "moniker": {
                 "app": "test-application",
@@ -835,54 +814,29 @@ const payloadServerGroupManagers = `[
               "name": "deployment test-deployment1",
               "displayName": "test-deployment1",
               "namespace": "test-namespace1",
-              "providerType": "kubernetes",
               "region": "test-namespace1",
               "serverGroups": [
                 {
                   "account": "account1",
                   "moniker": {
                     "app": "test-application",
-                    "cluster": "deployment test-deployment1",
+                    "cluster": "deployment test-rs1",
                     "sequence": 236
                   },
                   "name": "replicaSet test-rs1",
                   "namespace": "test-namespace1",
                   "region": "test-namespace1"
                 }
-              ],
-              "type": "kubernetes",
-              "uid": "cec15437-4e6a-11ea-9788-4201ac100006",
-              "zone": "test-application"
+              ]
             },
             {
               "account": "account1",
-              "accountName": "account1",
+              "apiVersion": "apps/v1",
               "cloudProvider": "kubernetes",
               "createdTime": 1581603123000,
-              "key": {
-                "account": "account1",
-                "group": "deployment",
-                "kubernetesKind": "deployment",
-                "name": "test-deployment2",
-                "namespace": "test-namespace2",
-                "provider": "kubernetes"
-              },
               "kind": "deployment",
               "labels": {
                 "label1": "test-label2"
-              },
-              "manifest": {
-                "apiVersion": "apps/v1",
-                "kind": "Deployment",
-                "metadata": {
-                  "creationTimestamp": "2020-02-13T14:12:03Z",
-                  "labels": {
-                    "label1": "test-label2"
-                  },
-                  "name": "test-deployment2",
-                  "namespace": "test-namespace2",
-                  "uid": "cec15437-4e6a-11ea-9788-4201ac100006"
-                }
               },
               "moniker": {
                 "app": "test-application",
@@ -891,12 +845,8 @@ const payloadServerGroupManagers = `[
               "name": "deployment test-deployment2",
               "displayName": "test-deployment2",
               "namespace": "test-namespace2",
-              "providerType": "kubernetes",
               "region": "test-namespace2",
-              "serverGroups": [],
-              "type": "kubernetes",
-              "uid": "cec15437-4e6a-11ea-9788-4201ac100006",
-              "zone": "test-application"
+              "serverGroups": []
             }
           ]`
 
@@ -980,13 +930,7 @@ const payloadListServerGroups = `[
               "providerType": "",
               "region": "test-namespace1",
               "securityGroups": null,
-              "serverGroupManagers": [
-                {
-                  "account": "account1",
-                  "location": "test-namespace1",
-                  "name": "test-deployment1"
-                }
-              ],
+              "serverGroupManagers": [],
               "type": "kubernetes",
               "uid": "",
               "zone": "",
@@ -1164,13 +1108,7 @@ const payloadListServerGroups = `[
               "providerType": "",
               "region": "test-namespace1",
               "securityGroups": null,
-              "serverGroupManagers": [
-                {
-                  "account": "account1",
-                  "location": "test-namespace1",
-                  "name": "test-deployment1"
-                }
-              ],
+              "serverGroupManagers": [],
               "type": "kubernetes",
               "uid": "",
               "zone": "",


### PR DESCRIPTION
This PR fixes a few bugs where resources were not being associated with their correct Server Group Manager. We were originally relying on annotations provided by previous Spinnaker deployments. This changes that logic by relying solely on a resources `.metadata.ownerReference.UID` field in Kubernetes. Not only is this more efficient and reliable, it is far more accurate and ovoids the error of having resources associated with other resources of the same name in different namespaces.

Additionally I have added comments to this file to hopefully make it a bit easier to understand what's going on.

- add comments for the `/applications/*` endpoints in correct Go patterns
- associate pods with their owner by using owner UID
- associate replica sets with their deployment by using deployment UID
- use maps to generate these associations to increase efficiency