### PR TITLE
sort resources by account, namespace, kind, and name

### DIFF
--- a/pkg/http/core/payload_test.go
+++ b/pkg/http/core/payload_test.go
@@ -498,6 +498,42 @@ const payloadApplications = `[
             }
           ]`
 
+const payloadApplicationsSorted = `[
+            {
+              "attributes": {
+                "name": "a"
+              },
+              "clusterNames": {
+                "test-account3": [
+                  "test-kind3 test-name3"
+                ]
+              },
+              "name": "a"
+            },
+            {
+              "attributes": {
+                "name": "b"
+              },
+              "clusterNames": {
+                "test-account2": [
+                  "test-kind2 test-name2"
+                ]
+              },
+              "name": "b"
+            },
+            {
+              "attributes": {
+                "name": "c"
+              },
+              "clusterNames": {
+                "test-account1": [
+                  "test-kind1 test-name1"
+                ]
+              },
+              "name": "c"
+            }
+          ]`
+
 const payloadGetAccountCredentials = `{
             "accountType": "test-account",
             "cacheThreads": 0,
@@ -850,6 +886,155 @@ const payloadServerGroupManagers = `[
             }
           ]`
 
+const payloadServerGroupManagersSorted = `[
+            {
+              "account": "account1",
+              "apiVersion": "apps/v1",
+              "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "kind": "deployment",
+              "labels": {
+                "label1": "test-label1"
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1"
+              },
+              "name": "deployment test-deployment1",
+              "displayName": "test-deployment1",
+              "namespace": "test-namespace1",
+              "region": "test-namespace1",
+              "serverGroups": [
+                {
+                  "account": "account1",
+                  "moniker": {
+                    "app": "test-application",
+                    "cluster": "deployment test-rs1",
+                    "sequence": 236
+                  },
+                  "name": "replicaSet test-rs1",
+                  "namespace": "test-namespace1",
+                  "region": "test-namespace1"
+                }
+              ]
+            },
+            {
+              "account": "account1",
+              "apiVersion": "apps/v1",
+              "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "kind": "deployment",
+              "labels": {
+                "label1": "test-label2"
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment2"
+              },
+              "name": "deployment test-deployment2",
+              "displayName": "test-deployment2",
+              "namespace": "test-namespace2",
+              "region": "test-namespace2",
+              "serverGroups": [
+                {
+                  "account": "account1",
+                  "moniker": {
+                    "app": "test-application",
+                    "cluster": "deployment test-rs2",
+                    "sequence": 236
+                  },
+                  "name": "replicaSet test-rs4",
+                  "namespace": "test-namespace2",
+                  "region": "test-namespace2"
+                },
+                {
+                  "account": "account1",
+                  "moniker": {
+                    "app": "test-application",
+                    "cluster": "deployment test-rs2",
+                    "sequence": 236
+                  },
+                  "name": "replicaSet test-rs2",
+                  "namespace": "test-namespace2",
+                  "region": "test-namespace2"
+                }
+              ]
+            },
+            {
+              "account": "account1",
+              "apiVersion": "apps/v1",
+              "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "kind": "deployment",
+              "labels": {
+                "label1": "test-label2"
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment4"
+              },
+              "name": "deployment test-deployment4",
+              "displayName": "test-deployment4",
+              "namespace": "test-namespace2",
+              "region": "test-namespace2",
+              "serverGroups": [
+                {
+                  "account": "account1",
+                  "moniker": {
+                    "app": "test-application",
+                    "cluster": "deployment test-rs2",
+                    "sequence": 236
+                  },
+                  "name": "replicaSet test-rs4",
+                  "namespace": "test-namespace2",
+                  "region": "test-namespace2"
+                },
+                {
+                  "account": "account1",
+                  "moniker": {
+                    "app": "test-application",
+                    "cluster": "deployment test-rs2",
+                    "sequence": 236
+                  },
+                  "name": "replicaSet test-rs2",
+                  "namespace": "test-namespace2",
+                  "region": "test-namespace2"
+                }
+              ]
+            },
+            {
+              "account": "account1",
+              "apiVersion": "apps/v1",
+              "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "kind": "deployment",
+              "labels": {
+                "label1": "test-label3"
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment3"
+              },
+              "name": "deployment test-deployment3",
+              "displayName": "test-deployment3",
+              "namespace": "test-namespace3",
+              "region": "test-namespace3",
+              "serverGroups": [
+                {
+                  "account": "account1",
+                  "moniker": {
+                    "app": "test-application",
+                    "cluster": "deployment test-rs3",
+                    "sequence": 236
+                  },
+                  "name": "replicaSet test-rs3",
+                  "namespace": "test-namespace3",
+                  "region": "test-namespace3"
+                }
+              ]
+            }
+          ]`
+
 const payloadListServerGroups = `[
             {
               "account": "account1",
@@ -916,7 +1101,7 @@ const payloadListServerGroups = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "",
+              "kind": "DaemonSet",
               "labels": null,
               "loadBalancers": null,
               "manifest": null,
@@ -1002,7 +1187,7 @@ const payloadListServerGroups = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "",
+              "kind": "ReplicaSet",
               "labels": null,
               "loadBalancers": null,
               "manifest": null,
@@ -1094,7 +1279,7 @@ const payloadListServerGroups = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "",
+              "kind": "StatefulSet",
               "labels": null,
               "loadBalancers": null,
               "manifest": null,
@@ -1107,6 +1292,557 @@ const payloadListServerGroups = `[
               "namespace": "test-namespace1",
               "providerType": "",
               "region": "test-namespace1",
+              "securityGroups": null,
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            }
+          ]`
+
+const payloadListServerGroupsSorted = `[
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 2,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-ds1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 2,
+                "unknown": 0,
+                "up": 1
+              },
+              "instances": [
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod2"
+                },
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod3"
+                },
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod4"
+                }
+              ],
+              "isDisabled": false,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "DaemonSet",
+              "labels": null,
+              "loadBalancers": null,
+              "manifest": null,
+              "moniker": {
+                "app": "test-deployment1",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "DaemonSet test-ds1",
+              "namespace": "test-namespace1",
+              "providerType": "",
+              "region": "test-namespace1",
+              "securityGroups": null,
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            },
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod3"
+                }
+              ],
+              "isDisabled": false,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "ReplicaSet",
+              "labels": null,
+              "loadBalancers": null,
+              "manifest": null,
+              "moniker": {
+                "app": "test-deployment1",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "ReplicaSet test-rs1",
+              "namespace": "test-namespace1",
+              "providerType": "",
+              "region": "test-namespace1",
+              "securityGroups": null,
+              "serverGroupManagers": [
+                {
+                  "account": "account1",
+                  "location": "test-namespace1",
+                  "name": "test-deployment1"
+                }
+              ],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            },
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod1"
+                }
+              ],
+              "isDisabled": false,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "StatefulSet",
+              "labels": null,
+              "loadBalancers": null,
+              "manifest": null,
+              "moniker": {
+                "app": "test-deployment1",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "StatefulSet test-rs1",
+              "namespace": "test-namespace1",
+              "providerType": "",
+              "region": "test-namespace1",
+              "securityGroups": null,
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            },
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 2,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-ds1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 2,
+                "unknown": 0,
+                "up": 1
+              },
+              "instances": [
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod2"
+                },
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod3"
+                },
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod4"
+                }
+              ],
+              "isDisabled": false,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "DaemonSet",
+              "labels": null,
+              "loadBalancers": null,
+              "manifest": null,
+              "moniker": {
+                "app": "test-deployment1",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "DaemonSet test-ds1",
+              "namespace": "test-namespace2",
+              "providerType": "",
+              "region": "test-namespace2",
+              "securityGroups": null,
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            },
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod1"
+                }
+              ],
+              "isDisabled": false,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "StatefulSet",
+              "labels": null,
+              "loadBalancers": null,
+              "manifest": null,
+              "moniker": {
+                "app": "test-deployment1",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "StatefulSet test-rs1",
+              "namespace": "test-namespace2",
+              "providerType": "",
+              "region": "test-namespace2",
               "securityGroups": null,
               "serverGroupManagers": [],
               "type": "kubernetes",
@@ -1190,6 +1926,240 @@ const payloadListLoadBalancers = `[
                 "metadata": {
                   "name": "test-service1",
                   "namespace": "test-namespace1"
+                }
+              },
+              "providerType": "kubernetes",
+              "zone": "test-application"
+            }
+          ]`
+
+const payloadListLoadBalancersSorted = `[
+            {
+              "account": "account1",
+              "cloudProvider": "kubernetes",
+              "labels": {
+                "label1": "test-label1"
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "ingress test-ingress1"
+              },
+              "name": "ingress test-ingress1",
+              "displayName": "test-ingress1",
+              "region": "test-namespace1",
+              "serverGroups": null,
+              "type": "kubernetes",
+              "accountName": "account1",
+              "createdTime": 1581603123000,
+              "key": {
+                "account": "account1",
+                "group": "networking.k8s.io",
+                "kubernetesKind": "ingress",
+                "name": "ingress test-ingress1",
+                "namespace": "test-namespace1",
+                "provider": "kubernetes"
+              },
+              "kind": "ingress",
+              "manifest": {
+                "apiVersion": "networking.k8s.io/v1beta1",
+                "kind": "Ingress",
+                "metadata": {
+                  "creationTimestamp": "2020-02-13T14:12:03Z",
+                  "labels": {
+                    "label1": "test-label1"
+                  },
+                  "name": "test-ingress1",
+                  "namespace": "test-namespace1",
+                  "uid": "cec15437-4e6a-11ea-9788-4201ac100006"
+                }
+              },
+              "providerType": "kubernetes",
+              "uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+              "zone": "test-application"
+            },
+            {
+              "account": "account1",
+              "cloudProvider": "kubernetes",
+              "moniker": {
+                "app": "test-application",
+                "cluster": "service test-service1"
+              },
+              "name": "service test-service1",
+              "displayName": "test-service1",
+              "region": "test-namespace1",
+              "serverGroups": null,
+              "type": "kubernetes",
+              "accountName": "account1",
+              "createdTime": -62135596800000,
+              "key": {
+                "account": "account1",
+                "group": "",
+                "kubernetesKind": "service",
+                "name": "service test-service1",
+                "namespace": "test-namespace1",
+                "provider": "kubernetes"
+              },
+              "kind": "service",
+              "manifest": {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                  "name": "test-service1",
+                  "namespace": "test-namespace1"
+                }
+              },
+              "providerType": "kubernetes",
+              "zone": "test-application"
+            },
+            {
+              "account": "account1",
+              "cloudProvider": "kubernetes",
+              "labels": {
+                "label1": "test-label1"
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "ingress test-ingress2"
+              },
+              "name": "ingress test-ingress2",
+              "displayName": "test-ingress2",
+              "region": "test-namespace2",
+              "serverGroups": null,
+              "type": "kubernetes",
+              "accountName": "account1",
+              "createdTime": 1581603123000,
+              "key": {
+                "account": "account1",
+                "group": "networking.k8s.io",
+                "kubernetesKind": "ingress",
+                "name": "ingress test-ingress2",
+                "namespace": "test-namespace2",
+                "provider": "kubernetes"
+              },
+              "kind": "ingress",
+              "manifest": {
+                "apiVersion": "networking.k8s.io/v1beta1",
+                "kind": "Ingress",
+                "metadata": {
+                  "creationTimestamp": "2020-02-13T14:12:03Z",
+                  "labels": {
+                    "label1": "test-label1"
+                  },
+                  "name": "test-ingress2",
+                  "namespace": "test-namespace2",
+                  "uid": "cec15437-4e6a-11ea-9788-4201ac100006"
+                }
+              },
+              "providerType": "kubernetes",
+              "uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+              "zone": "test-application"
+            },
+            {
+              "account": "account1",
+              "cloudProvider": "kubernetes",
+              "labels": {
+                "label1": "test-label1"
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "ingress test-ingress3"
+              },
+              "name": "ingress test-ingress3",
+              "displayName": "test-ingress3",
+              "region": "test-namespace2",
+              "serverGroups": null,
+              "type": "kubernetes",
+              "accountName": "account1",
+              "createdTime": 1581603123000,
+              "key": {
+                "account": "account1",
+                "group": "networking.k8s.io",
+                "kubernetesKind": "ingress",
+                "name": "ingress test-ingress3",
+                "namespace": "test-namespace2",
+                "provider": "kubernetes"
+              },
+              "kind": "ingress",
+              "manifest": {
+                "apiVersion": "networking.k8s.io/v1beta1",
+                "kind": "Ingress",
+                "metadata": {
+                  "creationTimestamp": "2020-02-13T14:12:03Z",
+                  "labels": {
+                    "label1": "test-label1"
+                  },
+                  "name": "test-ingress3",
+                  "namespace": "test-namespace2",
+                  "uid": "cec15437-4e6a-11ea-9788-4201ac100006"
+                }
+              },
+              "providerType": "kubernetes",
+              "uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+              "zone": "test-application"
+            },
+            {
+              "account": "account1",
+              "cloudProvider": "kubernetes",
+              "moniker": {
+                "app": "test-application",
+                "cluster": "service test-service2"
+              },
+              "name": "service test-service2",
+              "displayName": "test-service2",
+              "region": "test-namespace2",
+              "serverGroups": null,
+              "type": "kubernetes",
+              "accountName": "account1",
+              "createdTime": -62135596800000,
+              "key": {
+                "account": "account1",
+                "group": "",
+                "kubernetesKind": "service",
+                "name": "service test-service2",
+                "namespace": "test-namespace2",
+                "provider": "kubernetes"
+              },
+              "kind": "service",
+              "manifest": {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                  "name": "test-service2",
+                  "namespace": "test-namespace2"
+                }
+              },
+              "providerType": "kubernetes",
+              "zone": "test-application"
+            },
+            {
+              "account": "account1",
+              "cloudProvider": "kubernetes",
+              "moniker": {
+                "app": "test-application",
+                "cluster": "service test-service3"
+              },
+              "name": "service test-service3",
+              "displayName": "test-service3",
+              "region": "test-namespace2",
+              "serverGroups": null,
+              "type": "kubernetes",
+              "accountName": "account1",
+              "createdTime": -62135596800000,
+              "key": {
+                "account": "account1",
+                "group": "",
+                "kubernetesKind": "service",
+                "name": "service test-service3",
+                "namespace": "test-namespace2",
+                "provider": "kubernetes"
+              },
+              "kind": "service",
+              "manifest": {
+                "apiVersion": "v1",
+                "kind": "Service",
+                "metadata": {
+                  "name": "test-service3",
+                  "namespace": "test-namespace2"
                 }
               },
               "providerType": "kubernetes",


### PR DESCRIPTION
I've noticed some pretty wonky things happening in the clusters page in Spinnaker. It isn't "breaking" but it is rather annoying. Sometimes on auto-refresh (not page refresh), UI elements will move around in a different order, and occasionally this causes the UI to look a bit "broken". 

I'm pretty sure this is an issue with us not sorting the server groups and server groups managers before returning the list. Before, we were sorting by name only, but this PR sorts all of these elements by account name (cluster), namespace, kind, and name, giving us a more ordered list of clusters in the UI.

Most of this PR is just extensive tests that return unsorted resources. For a source on the logic behind sorting by multiple elements, see [this stackoverflow post](https://stackoverflow.com/a/52134016/3878752).