### PR TITLE
Add GET/PUT kubernetes providers paths

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -283,13 +283,59 @@ paths:
       responses:
         "200":
           description: "OK"
+          schema:
+            $ref: "#/definitions/KubernetesProvider"
         "400":
           description: "Bad Request"
         "409":
           description: "Conflict"
         "500":
           description: "Internal Server Error"
+    put:
+      tags:
+      - "kubernetes"
+      summary: "Create, or replace, a Kubernetes account (provider)"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Object that describes the kubernetes provider"
+        required: true
+        schema:
+          $ref: "#/definitions/KubernetesProvider"
+      responses:
+        "200":
+          description: "OK"
+          schema:
+            $ref: "#/definitions/KubernetesProvider"
+        "400":
+          description: "Bad Request"
+        "500":
+          description: "Internal Server Error"
   /v1/kubernetes/providers/{name}:
+    get:
+      tags:
+      - "kubernetes"
+      parameters:
+      - name: "name"
+        in: "path"
+        required: true
+        type: "string"
+      summary: "Retrieve a Kubernetes account (provider)"
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: "OK"
+          schema:
+            $ref: "#/definitions/KubernetesProvider"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
     delete:
       tags:
       - "kubernetes"


### PR DESCRIPTION
Defines remaining CRUD paths for Kubernetes Providers
- `GET /v1/kubernetes/providers/{name}` to retrieve an existing kubernetes provider
- `PUT /v1/kubernetes/providers` to create, or replace if existing, a kubernetes provider