### PR TITLE
Adds GET/PUT operations for kubernetes providers

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -283,13 +283,59 @@ paths:
       responses:
         "200":
           description: "OK"
+          schema:
+            $ref: "#/definitions/KubernetesProvider"
         "400":
           description: "Bad Request"
         "409":
           description: "Conflict"
         "500":
           description: "Internal Server Error"
+    put:
+      tags:
+      - "kubernetes"
+      summary: "Create, or replace, a Kubernetes account (provider)"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Object that describes the kubernetes provider"
+        required: true
+        schema:
+          $ref: "#/definitions/KubernetesProvider"
+      responses:
+        "200":
+          description: "OK"
+          schema:
+            $ref: "#/definitions/KubernetesProvider"
+        "400":
+          description: "Bad Request"
+        "500":
+          description: "Internal Server Error"
   /v1/kubernetes/providers/{name}:
+    get:
+      tags:
+      - "kubernetes"
+      parameters:
+      - name: "name"
+        in: "path"
+        required: true
+        type: "string"
+      summary: "Retrieve a Kubernetes account (provider)"
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: "OK"
+          schema:
+            $ref: "#/definitions/KubernetesProvider"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
     delete:
       tags:
       - "kubernetes"

--- a/pkg/http/router.go
+++ b/pkg/http/router.go
@@ -95,7 +95,9 @@ func Initialize(r *gin.Engine) {
 	{
 		api := r.Group("/v1")
 		// Providers endpoint for kubernetes.
+		api.GET("/kubernetes/providers/:name", v1.GetKubernetesProvider)
 		api.POST("/kubernetes/providers", v1.CreateKubernetesProvider)
+		api.PUT("/kubernetes/providers", v1.CreateOrReplaceKubernetesProvider)
 		api.DELETE("/kubernetes/providers/:name", v1.DeleteKubernetesProvider)
 	}
 }

--- a/pkg/http/v1/provider.go
+++ b/pkg/http/v1/provider.go
@@ -77,14 +77,14 @@ func GetKubernetesProvider(c *gin.Context) {
 	name := c.Param("name")
 
 	p, err := sc.GetKubernetesProviderAndPermissions(name)
-	if err != nil || p.Name == "" {
-		if err == gorm.ErrRecordNotFound || p.Name == "" {
-			c.JSON(http.StatusNotFound, gin.H{"error": "provider not found"})
-			return
-		}
-
+	if err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 
+		return
+	}
+
+	if p.Name == "" {
+		c.JSON(http.StatusNotFound, gin.H{"error": "provider not found"})
 		return
 	}
 

--- a/pkg/http/v1/provider.go
+++ b/pkg/http/v1/provider.go
@@ -6,13 +6,12 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/google/uuid"
-	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 	"github.com/homedepot/go-clouddriver/pkg/kubernetes"
 	"github.com/homedepot/go-clouddriver/pkg/sql"
 	"github.com/jinzhu/gorm"
 )
 
+// CreateKubernetesProvider creates the kubernetes account (provider).
 func CreateKubernetesProvider(c *gin.Context) {
 	sc := sql.Instance(c)
 	p := kubernetes.Provider{}
@@ -41,37 +40,10 @@ func CreateKubernetesProvider(c *gin.Context) {
 		return
 	}
 
-	for _, group := range p.Permissions.Read {
-		rp := clouddriver.ReadPermission{
-			ID:          uuid.New().String(),
-			AccountName: p.Name,
-			ReadGroup:   group,
-		}
-
-		err = sc.CreateReadPermission(rp)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-	}
-
-	for _, group := range p.Permissions.Write {
-		wp := clouddriver.WritePermission{
-			ID:          uuid.New().String(),
-			AccountName: p.Name,
-			WriteGroup:  group,
-		}
-
-		err = sc.CreateWritePermission(wp)
-		if err != nil {
-			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-			return
-		}
-	}
-
 	c.JSON(http.StatusCreated, p)
 }
 
+// DeleteKubernetesProvider deletes the kubernetes account (provider).
 func DeleteKubernetesProvider(c *gin.Context) {
 	sc := sql.Instance(c)
 	name := c.Param("name")
@@ -95,4 +67,59 @@ func DeleteKubernetesProvider(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusNoContent, nil)
+}
+
+// GetKubernetesProvider retrieves the kubernetes account (provider).
+func GetKubernetesProvider(c *gin.Context) {
+	var p kubernetes.Provider
+
+	sc := sql.Instance(c)
+	name := c.Param("name")
+
+	p, err := sc.GetKubernetesProviderAndPermissions(name)
+	if err != nil || p.Name == "" {
+		if err == gorm.ErrRecordNotFound || p.Name == "" {
+			c.JSON(http.StatusNotFound, gin.H{"error": "provider not found"})
+			return
+		}
+
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+
+		return
+	}
+
+	c.JSON(http.StatusOK, p)
+}
+
+// CreateOrReplaceKubernetesProvider creates the kubernetes account (provider),
+// or if existing account, replaces it.
+func CreateOrReplaceKubernetesProvider(c *gin.Context) {
+	sc := sql.Instance(c)
+	p := kubernetes.Provider{}
+
+	err := c.ShouldBindJSON(&p)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+
+	_, err = base64.StdEncoding.DecodeString(p.CAData)
+	if err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("error decoding base64 CA data: %s", err.Error())})
+		return
+	}
+
+	err = sc.DeleteKubernetesProvider(p.Name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	err = sc.CreateKubernetesProvider(p)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, p)
 }

--- a/pkg/http/v1/provider_test.go
+++ b/pkg/http/v1/provider_test.go
@@ -79,28 +79,6 @@ var _ = Describe("Provider", func() {
 			})
 		})
 
-		When("creating a read group returns an error", func() {
-			BeforeEach(func() {
-				fakeSQLClient.CreateReadPermissionReturns(errors.New("error creating read permission"))
-			})
-
-			It("returns status internal server error", func() {
-				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
-				validateResponse(payloadErrorCreatingReadPermission)
-			})
-		})
-
-		When("creating a write group returns an error", func() {
-			BeforeEach(func() {
-				fakeSQLClient.CreateWritePermissionReturns(errors.New("error creating write permission"))
-			})
-
-			It("returns status internal server error", func() {
-				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
-				validateResponse(payloadErrorCreatingWritePermission)
-			})
-		})
-
 		When("it succeeds", func() {
 			It("returns status created", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusCreated))

--- a/pkg/http/v1/provider_test.go
+++ b/pkg/http/v1/provider_test.go
@@ -87,6 +87,136 @@ var _ = Describe("Provider", func() {
 		})
 	})
 
+	Describe("#CreateOrReplaceKubernetesProvider", func() {
+		BeforeEach(func() {
+			setup()
+			uri = svr.URL + "/v1/kubernetes/providers"
+			body.Write([]byte(payloadRequestKubernetesProviders))
+			createRequest(http.MethodPut)
+		})
+
+		AfterEach(func() {
+			teardown()
+		})
+
+		JustBeforeEach(func() {
+			doRequest()
+		})
+
+		When("the request body is bad data", func() {
+			BeforeEach(func() {
+				body = &bytes.Buffer{}
+				body.Write([]byte("dasdf[]dsf;;"))
+				createRequest(http.MethodPut)
+			})
+
+			It("returns status bad request", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+				validateResponse(payloadBadRequest)
+			})
+		})
+
+		When("the ca data in the request is bad", func() {
+			BeforeEach(func() {
+				body = &bytes.Buffer{}
+				body.Write([]byte(payloadRequestKubernetesProvidersBadCAData))
+				createRequest(http.MethodPut)
+			})
+
+			It("returns status bad request", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+				validateResponse(payloadErrorDecodingBase64)
+			})
+		})
+
+		When("creating the kubernetes provider returns an error", func() {
+			BeforeEach(func() {
+				fakeSQLClient.CreateKubernetesProviderReturns(errors.New("error creating provider"))
+			})
+
+			It("returns status internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				validateResponse(payloadErrorCreatingProvider)
+			})
+		})
+
+		When("it succeeds", func() {
+			When("the provider does not exist", func() {
+				It("returns ok and the provider is created", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					validateResponse(payloadKubernetesProviderCreated)
+				})
+			})
+
+			When("the provider already exists", func() {
+				BeforeEach(func() {
+					fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, nil)
+				})
+
+				It("returns ok and the provider is replaced", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					validateResponse(payloadKubernetesProviderCreated)
+				})
+			})
+		})
+	})
+
+	Describe("#GetKubernetesProvider", func() {
+		BeforeEach(func() {
+			setup()
+			testProvider := kubernetes.Provider{
+				Name:   "test-name",
+				Host:   "test-host",
+				CAData: "dGVzdC1jYS1kYXRhCg==",
+				Permissions: kubernetes.ProviderPermissions{
+					Read:  []string{"gg_test"},
+					Write: []string{"gg_test"},
+				},
+			}
+
+			fakeSQLClient.GetKubernetesProviderAndPermissionsReturns(testProvider, nil)
+			uri = svr.URL + "/v1/kubernetes/providers/test-name"
+			createRequest(http.MethodGet)
+		})
+
+		AfterEach(func() {
+			teardown()
+		})
+
+		JustBeforeEach(func() {
+			doRequest()
+		})
+
+		When("the record is not found", func() {
+			BeforeEach(func() {
+				fakeSQLClient.GetKubernetesProviderAndPermissionsReturns(kubernetes.Provider{}, nil)
+			})
+
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusNotFound))
+				validateResponse(payloadKubernetesProviderNotFound)
+			})
+		})
+
+		When("getting the provider returns a generic error", func() {
+			BeforeEach(func() {
+				fakeSQLClient.GetKubernetesProviderAndPermissionsReturns(kubernetes.Provider{}, errors.New("error getting provider"))
+			})
+
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				validateResponse(payloadKubernetesProviderGetGenericError)
+			})
+		})
+
+		When("it succeeds", func() {
+			It("returns ok and the provider", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				validateResponse(payloadKubernetesProviderCreated)
+			})
+		})
+	})
+
 	Describe("#DeleteKubernetesProvider", func() {
 		BeforeEach(func() {
 			setup()

--- a/pkg/sql/sql.go
+++ b/pkg/sql/sql.go
@@ -92,7 +92,7 @@ type Config struct {
 	Name     string
 }
 
-// Connaction returns the driver and connection string to the DB.
+// Connection returns the driver and connection string to the DB.
 func Connection(c Config) (string, string) {
 	if c.User == "" || c.Password == "" || c.Host == "" || c.Name == "" {
 		log.Println("[CLOUDDRIVER] SQL config missing field - defaulting to local sqlite DB.")

--- a/pkg/sql/sqlfakes/fake_client.go
+++ b/pkg/sql/sqlfakes/fake_client.go
@@ -4,7 +4,6 @@ package sqlfakes
 import (
 	"sync"
 
-	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 	"github.com/homedepot/go-clouddriver/pkg/kubernetes"
 	"github.com/homedepot/go-clouddriver/pkg/sql"
 )
@@ -32,28 +31,6 @@ type FakeClient struct {
 	createKubernetesResourceReturnsOnCall map[int]struct {
 		result1 error
 	}
-	CreateReadPermissionStub        func(clouddriver.ReadPermission) error
-	createReadPermissionMutex       sync.RWMutex
-	createReadPermissionArgsForCall []struct {
-		arg1 clouddriver.ReadPermission
-	}
-	createReadPermissionReturns struct {
-		result1 error
-	}
-	createReadPermissionReturnsOnCall map[int]struct {
-		result1 error
-	}
-	CreateWritePermissionStub        func(clouddriver.WritePermission) error
-	createWritePermissionMutex       sync.RWMutex
-	createWritePermissionArgsForCall []struct {
-		arg1 clouddriver.WritePermission
-	}
-	createWritePermissionReturns struct {
-		result1 error
-	}
-	createWritePermissionReturnsOnCall map[int]struct {
-		result1 error
-	}
 	DeleteKubernetesProviderStub        func(string) error
 	deleteKubernetesProviderMutex       sync.RWMutex
 	deleteKubernetesProviderArgsForCall []struct {
@@ -75,6 +52,19 @@ type FakeClient struct {
 		result2 error
 	}
 	getKubernetesProviderReturnsOnCall map[int]struct {
+		result1 kubernetes.Provider
+		result2 error
+	}
+	GetKubernetesProviderAndPermissionsStub        func(string) (kubernetes.Provider, error)
+	getKubernetesProviderAndPermissionsMutex       sync.RWMutex
+	getKubernetesProviderAndPermissionsArgsForCall []struct {
+		arg1 string
+	}
+	getKubernetesProviderAndPermissionsReturns struct {
+		result1 kubernetes.Provider
+		result2 error
+	}
+	getKubernetesProviderAndPermissionsReturnsOnCall map[int]struct {
 		result1 kubernetes.Provider
 		result2 error
 	}
@@ -332,126 +322,6 @@ func (fake *FakeClient) CreateKubernetesResourceReturnsOnCall(i int, result1 err
 	}{result1}
 }
 
-func (fake *FakeClient) CreateReadPermission(arg1 clouddriver.ReadPermission) error {
-	fake.createReadPermissionMutex.Lock()
-	ret, specificReturn := fake.createReadPermissionReturnsOnCall[len(fake.createReadPermissionArgsForCall)]
-	fake.createReadPermissionArgsForCall = append(fake.createReadPermissionArgsForCall, struct {
-		arg1 clouddriver.ReadPermission
-	}{arg1})
-	fake.recordInvocation("CreateReadPermission", []interface{}{arg1})
-	fake.createReadPermissionMutex.Unlock()
-	if fake.CreateReadPermissionStub != nil {
-		return fake.CreateReadPermissionStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.createReadPermissionReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeClient) CreateReadPermissionCallCount() int {
-	fake.createReadPermissionMutex.RLock()
-	defer fake.createReadPermissionMutex.RUnlock()
-	return len(fake.createReadPermissionArgsForCall)
-}
-
-func (fake *FakeClient) CreateReadPermissionCalls(stub func(clouddriver.ReadPermission) error) {
-	fake.createReadPermissionMutex.Lock()
-	defer fake.createReadPermissionMutex.Unlock()
-	fake.CreateReadPermissionStub = stub
-}
-
-func (fake *FakeClient) CreateReadPermissionArgsForCall(i int) clouddriver.ReadPermission {
-	fake.createReadPermissionMutex.RLock()
-	defer fake.createReadPermissionMutex.RUnlock()
-	argsForCall := fake.createReadPermissionArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeClient) CreateReadPermissionReturns(result1 error) {
-	fake.createReadPermissionMutex.Lock()
-	defer fake.createReadPermissionMutex.Unlock()
-	fake.CreateReadPermissionStub = nil
-	fake.createReadPermissionReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) CreateReadPermissionReturnsOnCall(i int, result1 error) {
-	fake.createReadPermissionMutex.Lock()
-	defer fake.createReadPermissionMutex.Unlock()
-	fake.CreateReadPermissionStub = nil
-	if fake.createReadPermissionReturnsOnCall == nil {
-		fake.createReadPermissionReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.createReadPermissionReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) CreateWritePermission(arg1 clouddriver.WritePermission) error {
-	fake.createWritePermissionMutex.Lock()
-	ret, specificReturn := fake.createWritePermissionReturnsOnCall[len(fake.createWritePermissionArgsForCall)]
-	fake.createWritePermissionArgsForCall = append(fake.createWritePermissionArgsForCall, struct {
-		arg1 clouddriver.WritePermission
-	}{arg1})
-	fake.recordInvocation("CreateWritePermission", []interface{}{arg1})
-	fake.createWritePermissionMutex.Unlock()
-	if fake.CreateWritePermissionStub != nil {
-		return fake.CreateWritePermissionStub(arg1)
-	}
-	if specificReturn {
-		return ret.result1
-	}
-	fakeReturns := fake.createWritePermissionReturns
-	return fakeReturns.result1
-}
-
-func (fake *FakeClient) CreateWritePermissionCallCount() int {
-	fake.createWritePermissionMutex.RLock()
-	defer fake.createWritePermissionMutex.RUnlock()
-	return len(fake.createWritePermissionArgsForCall)
-}
-
-func (fake *FakeClient) CreateWritePermissionCalls(stub func(clouddriver.WritePermission) error) {
-	fake.createWritePermissionMutex.Lock()
-	defer fake.createWritePermissionMutex.Unlock()
-	fake.CreateWritePermissionStub = stub
-}
-
-func (fake *FakeClient) CreateWritePermissionArgsForCall(i int) clouddriver.WritePermission {
-	fake.createWritePermissionMutex.RLock()
-	defer fake.createWritePermissionMutex.RUnlock()
-	argsForCall := fake.createWritePermissionArgsForCall[i]
-	return argsForCall.arg1
-}
-
-func (fake *FakeClient) CreateWritePermissionReturns(result1 error) {
-	fake.createWritePermissionMutex.Lock()
-	defer fake.createWritePermissionMutex.Unlock()
-	fake.CreateWritePermissionStub = nil
-	fake.createWritePermissionReturns = struct {
-		result1 error
-	}{result1}
-}
-
-func (fake *FakeClient) CreateWritePermissionReturnsOnCall(i int, result1 error) {
-	fake.createWritePermissionMutex.Lock()
-	defer fake.createWritePermissionMutex.Unlock()
-	fake.CreateWritePermissionStub = nil
-	if fake.createWritePermissionReturnsOnCall == nil {
-		fake.createWritePermissionReturnsOnCall = make(map[int]struct {
-			result1 error
-		})
-	}
-	fake.createWritePermissionReturnsOnCall[i] = struct {
-		result1 error
-	}{result1}
-}
-
 func (fake *FakeClient) DeleteKubernetesProvider(arg1 string) error {
 	fake.deleteKubernetesProviderMutex.Lock()
 	ret, specificReturn := fake.deleteKubernetesProviderReturnsOnCall[len(fake.deleteKubernetesProviderArgsForCall)]
@@ -570,6 +440,69 @@ func (fake *FakeClient) GetKubernetesProviderReturnsOnCall(i int, result1 kubern
 		})
 	}
 	fake.getKubernetesProviderReturnsOnCall[i] = struct {
+		result1 kubernetes.Provider
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetKubernetesProviderAndPermissions(arg1 string) (kubernetes.Provider, error) {
+	fake.getKubernetesProviderAndPermissionsMutex.Lock()
+	ret, specificReturn := fake.getKubernetesProviderAndPermissionsReturnsOnCall[len(fake.getKubernetesProviderAndPermissionsArgsForCall)]
+	fake.getKubernetesProviderAndPermissionsArgsForCall = append(fake.getKubernetesProviderAndPermissionsArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("GetKubernetesProviderAndPermissions", []interface{}{arg1})
+	fake.getKubernetesProviderAndPermissionsMutex.Unlock()
+	if fake.GetKubernetesProviderAndPermissionsStub != nil {
+		return fake.GetKubernetesProviderAndPermissionsStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	fakeReturns := fake.getKubernetesProviderAndPermissionsReturns
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) GetKubernetesProviderAndPermissionsCallCount() int {
+	fake.getKubernetesProviderAndPermissionsMutex.RLock()
+	defer fake.getKubernetesProviderAndPermissionsMutex.RUnlock()
+	return len(fake.getKubernetesProviderAndPermissionsArgsForCall)
+}
+
+func (fake *FakeClient) GetKubernetesProviderAndPermissionsCalls(stub func(string) (kubernetes.Provider, error)) {
+	fake.getKubernetesProviderAndPermissionsMutex.Lock()
+	defer fake.getKubernetesProviderAndPermissionsMutex.Unlock()
+	fake.GetKubernetesProviderAndPermissionsStub = stub
+}
+
+func (fake *FakeClient) GetKubernetesProviderAndPermissionsArgsForCall(i int) string {
+	fake.getKubernetesProviderAndPermissionsMutex.RLock()
+	defer fake.getKubernetesProviderAndPermissionsMutex.RUnlock()
+	argsForCall := fake.getKubernetesProviderAndPermissionsArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) GetKubernetesProviderAndPermissionsReturns(result1 kubernetes.Provider, result2 error) {
+	fake.getKubernetesProviderAndPermissionsMutex.Lock()
+	defer fake.getKubernetesProviderAndPermissionsMutex.Unlock()
+	fake.GetKubernetesProviderAndPermissionsStub = nil
+	fake.getKubernetesProviderAndPermissionsReturns = struct {
+		result1 kubernetes.Provider
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) GetKubernetesProviderAndPermissionsReturnsOnCall(i int, result1 kubernetes.Provider, result2 error) {
+	fake.getKubernetesProviderAndPermissionsMutex.Lock()
+	defer fake.getKubernetesProviderAndPermissionsMutex.Unlock()
+	fake.GetKubernetesProviderAndPermissionsStub = nil
+	if fake.getKubernetesProviderAndPermissionsReturnsOnCall == nil {
+		fake.getKubernetesProviderAndPermissionsReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.Provider
+			result2 error
+		})
+	}
+	fake.getKubernetesProviderAndPermissionsReturnsOnCall[i] = struct {
 		result1 kubernetes.Provider
 		result2 error
 	}{result1, result2}
@@ -1198,14 +1131,12 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.createKubernetesProviderMutex.RUnlock()
 	fake.createKubernetesResourceMutex.RLock()
 	defer fake.createKubernetesResourceMutex.RUnlock()
-	fake.createReadPermissionMutex.RLock()
-	defer fake.createReadPermissionMutex.RUnlock()
-	fake.createWritePermissionMutex.RLock()
-	defer fake.createWritePermissionMutex.RUnlock()
 	fake.deleteKubernetesProviderMutex.RLock()
 	defer fake.deleteKubernetesProviderMutex.RUnlock()
 	fake.getKubernetesProviderMutex.RLock()
 	defer fake.getKubernetesProviderMutex.RUnlock()
+	fake.getKubernetesProviderAndPermissionsMutex.RLock()
+	defer fake.getKubernetesProviderAndPermissionsMutex.RUnlock()
 	fake.listKubernetesAccountsBySpinnakerAppMutex.RLock()
 	defer fake.listKubernetesAccountsBySpinnakerAppMutex.RUnlock()
 	fake.listKubernetesClustersByApplicationMutex.RLock()


### PR DESCRIPTION
This implements two new paths for kubernetes providers
- `GET /v1/kubernetes/providers/:name` which returns the kubernetes provider, with read/write permissions
- `PUT /vi/kubernetes/providers` which
   - creates the provider and permissions when the provider does not already exist
   - replaces the provider and permissions when the provider already exists
   
This also refactors the create read/write permissions functions, moving them out of `providers.go` and encapsulating them inside the create kubernetes provider function in `sql.go`, which follows the pattern done with delete permissions.