### PR TITLE
fix delete cascade

### DIFF
--- a/pkg/http/core/kubernetes/delete.go
+++ b/pkg/http/core/kubernetes/delete.go
@@ -62,9 +62,15 @@ func Delete(c *gin.Context, dm DeleteManifestRequest) {
 	if dm.Options.GracePeriodSeconds != nil {
 		do.GracePeriodSeconds = dm.Options.GracePeriodSeconds
 	}
-
+	// There are two options that will set the deletion to cascade. Originally this was set when
+	// `options.cascading = true`, however in later APIs they have this set in
+	// `options.orphanDependants = false`.
+	//
+	// Using a pointer should prevent the older API versions from falsly cascading
+	// when they don't intend to.
 	propagationPolicy := v1.DeletePropagationOrphan
-	if dm.Options.Cascading {
+	if dm.Options.Cascading ||
+		(dm.Options.OrphanDependants != nil && !*dm.Options.OrphanDependants) {
 		propagationPolicy = v1.DeletePropagationForeground
 	}
 

--- a/pkg/http/core/kubernetes/delete_test.go
+++ b/pkg/http/core/kubernetes/delete_test.go
@@ -100,6 +100,47 @@ var _ = Describe("Delete", func() {
 		})
 	})
 
+	When("the cascading option is set", func() {
+		BeforeEach(func() {
+			deleteManifestRequest.Options.Cascading = true
+		})
+
+		It("sets the delete propagation to forground", func() {
+			Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+			kind, name, namespace, deleteOptions := fakeKubeClient.DeleteResourceByKindAndNameAndNamespaceArgsForCall(0)
+			Expect(kind).To(Equal("deployment"))
+			Expect(name).To(Equal("test-deployment"))
+			Expect(namespace).To(Equal("test-namespace"))
+			Expect(deleteOptions.GracePeriodSeconds).ToNot(BeNil())
+			Expect(*deleteOptions.GracePeriodSeconds).To(Equal(int64(10)))
+			Expect(deleteOptions.PropagationPolicy).ToNot(BeNil())
+			Expect(*deleteOptions.PropagationPolicy).To(Equal(v1.DeletePropagationForeground))
+			kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+			Expect(kr.TaskType).To(Equal(clouddriver.TaskTypeDelete))
+		})
+	})
+
+	When("orphan dependants is set to false", func() {
+		BeforeEach(func() {
+			f := false
+			deleteManifestRequest.Options.OrphanDependants = &f
+		})
+
+		It("sets the delete propagation to forground", func() {
+			Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+			kind, name, namespace, deleteOptions := fakeKubeClient.DeleteResourceByKindAndNameAndNamespaceArgsForCall(0)
+			Expect(kind).To(Equal("deployment"))
+			Expect(name).To(Equal("test-deployment"))
+			Expect(namespace).To(Equal("test-namespace"))
+			Expect(deleteOptions.GracePeriodSeconds).ToNot(BeNil())
+			Expect(*deleteOptions.GracePeriodSeconds).To(Equal(int64(10)))
+			Expect(deleteOptions.PropagationPolicy).ToNot(BeNil())
+			Expect(*deleteOptions.PropagationPolicy).To(Equal(v1.DeletePropagationForeground))
+			kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+			Expect(kr.TaskType).To(Equal(clouddriver.TaskTypeDelete))
+		})
+	})
+
 	When("the mode is label", func() {
 		BeforeEach(func() {
 			deleteManifestRequest.Mode = "label"
@@ -132,7 +173,7 @@ var _ = Describe("Delete", func() {
 			Expect(deleteOptions.GracePeriodSeconds).ToNot(BeNil())
 			Expect(*deleteOptions.GracePeriodSeconds).To(Equal(int64(10)))
 			Expect(deleteOptions.PropagationPolicy).ToNot(BeNil())
-			Expect(*deleteOptions.PropagationPolicy).To(Equal(v1.DeletePropagationForeground))
+			Expect(*deleteOptions.PropagationPolicy).To(Equal(v1.DeletePropagationOrphan))
 			kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
 			Expect(kr.TaskType).To(Equal(clouddriver.TaskTypeDelete))
 		})

--- a/pkg/http/core/kubernetes/kubernetes_test.go
+++ b/pkg/http/core/kubernetes/kubernetes_test.go
@@ -155,7 +155,7 @@ func newDeleteManifestRequest() DeleteManifestRequest {
 		Mode:         "static",
 		ManifestName: "deployment test-deployment",
 		Options: DeleteManifestRequestOptions{
-			Cascading:          true,
+			Cascading:          false,
 			GracePeriodSeconds: &gps,
 		},
 	}

--- a/pkg/http/core/kubernetes/ops.go
+++ b/pkg/http/core/kubernetes/ops.go
@@ -150,6 +150,7 @@ type DeleteManifestRequestLabelSelector struct {
 
 type DeleteManifestRequestOptions struct {
 	Cascading          bool   `json:"cascading"`
+	OrphanDependants   *bool  `json:"orphanDependants"`
 	GracePeriodSeconds *int64 `json:"gracePeriodSeconds"`
 }
 


### PR DESCRIPTION
There are two options that will set the deletion to cascade. Originally this was set when `options.cascading = true`, however in later APIs they have this set in `options.orphanDependants = false`. This PR fixes this problem by providing an `options.orphanDependants` pointer. It must be a pointer for backwards compatibility, so that older APIs which do not send this option are always set to cascade delete. For newer APIs which send this option, we check the option is `false` before setting the delete propagation. 