### PR TITLE
add discover ability for kube client

### DIFF
--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -1154,6 +1154,8 @@ func listResources(c *gin.Context, wg *sync.WaitGroup, rs []string, rc chan reso
 	// requests appear to run serially. This is particularly bad if a cluster is not
 	// reachable - even with a timeout of 10 seconds, a request for 4 resources
 	// would take 40 seconds since the API cannot be discovered concurrently.
+	//
+	// See https://github.com/kubernetes/client-go/blob/f6ce18ae578c8cca64d14ab9687824d9e1305a67/restmapper/discovery.go#L194.
 	if err = client.Discover(); err != nil {
 		clouddriver.Log(err)
 		return

--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -1136,6 +1136,8 @@ func listApplicationResources(c *gin.Context, rs []string, application string) (
 	return resources, nil
 }
 
+// listResources initializes discovery for a given client then lists
+// the requested resources concurrently.
 func listResources(c *gin.Context, wg *sync.WaitGroup, rs []string, rc chan resource,
 	account, application string) {
 	// Increment the wait group counter when we're done here.
@@ -1143,6 +1145,16 @@ func listResources(c *gin.Context, wg *sync.WaitGroup, rs []string, rc chan reso
 	// Grab the kube client for the given account.
 	client, err := kubeConfigClient(c, account)
 	if err != nil {
+		clouddriver.Log(err)
+		return
+	}
+	// First, run discovery on this dynamic client before listing resources
+	// concurrently. This is necessary since the rest mapper for dynamic
+	// clients uses a mutex lock. Failure to do this will make concurrent
+	// requests appear to run serially. This is particularly bad if a cluster is not
+	// reachable - even with a timeout of 10 seconds, a request for 4 resources
+	// would take 40 seconds since the API cannot be discovered concurrently.
+	if err = client.Discover(); err != nil {
 		clouddriver.Log(err)
 		return
 	}
@@ -1210,12 +1222,14 @@ func kubeConfigClient(c *gin.Context, account string) (kubernetes.Client, error)
 		return nil, err
 	}
 	// Generate a new rest config using this information.
+	// Set the timeout to be the list timeout.
 	config := &rest.Config{
 		Host:        provider.Host,
 		BearerToken: token,
 		TLSClientConfig: rest.TLSClientConfig{
 			CAData: cd,
 		},
+		Timeout: time.Second * defaultListTimeoutSeconds,
 	}
 	// Create a new dynamic client for this config.
 	client, err := kc.NewClient(config)

--- a/pkg/http/core/applications_test.go
+++ b/pkg/http/core/applications_test.go
@@ -240,8 +240,8 @@ var _ = Describe("Application", func() {
 
 		When("listing deployments returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListResourceReturnsOnCall(0, nil, errors.New("error listing deployments"))
-				fakeKubeClient.ListResourceReturnsOnCall(2, nil, errors.New("error listing deployments"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(0, nil, errors.New("error listing deployments"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(2, nil, errors.New("error listing deployments"))
 			})
 
 			It("continues", func() {
@@ -251,8 +251,8 @@ var _ = Describe("Application", func() {
 
 		When("listing replicasets returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListResourceReturnsOnCall(1, nil, errors.New("error listing replicaSets"))
-				fakeKubeClient.ListResourceReturnsOnCall(3, nil, errors.New("error listing replicaSets"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(1, nil, errors.New("error listing replicaSets"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(3, nil, errors.New("error listing replicaSets"))
 			})
 
 			It("continues", func() {
@@ -551,8 +551,8 @@ var _ = Describe("Application", func() {
 
 		When("listing ingresses returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListResourceReturnsOnCall(0, nil, errors.New("error listing ingresses"))
-				fakeKubeClient.ListResourceReturnsOnCall(1, nil, errors.New("error listing ingresses"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(0, nil, errors.New("error listing ingresses"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(1, nil, errors.New("error listing ingresses"))
 			})
 
 			It("continues", func() {
@@ -562,8 +562,8 @@ var _ = Describe("Application", func() {
 
 		When("listing services returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListResourceReturnsOnCall(1, nil, errors.New("error listing services"))
-				fakeKubeClient.ListResourceReturnsOnCall(3, nil, errors.New("error listing services"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(1, nil, errors.New("error listing services"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(3, nil, errors.New("error listing services"))
 			})
 
 			It("continues", func() {
@@ -1033,10 +1033,20 @@ var _ = Describe("Application", func() {
 			})
 		})
 
+		When("discovering the API returns an error", func() {
+			BeforeEach(func() {
+				fakeKubeClient.DiscoverReturns(errors.New("error discovering"))
+			})
+
+			It("continues", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+			})
+		})
+
 		When("listing replicasets returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListResourceReturnsOnCall(0, nil, errors.New("error listing replicasets"))
-				fakeKubeClient.ListResourceReturnsOnCall(2, nil, errors.New("error listing replicasets"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(0, nil, errors.New("error listing replicasets"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(2, nil, errors.New("error listing replicasets"))
 			})
 
 			It("continues", func() {
@@ -1046,8 +1056,8 @@ var _ = Describe("Application", func() {
 
 		When("listing pods returns an error", func() {
 			BeforeEach(func() {
-				fakeKubeClient.ListResourceReturnsOnCall(1, nil, errors.New("error listing pods"))
-				fakeKubeClient.ListResourceReturnsOnCall(3, nil, errors.New("error listing pods"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(1, nil, errors.New("error listing pods"))
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(3, nil, errors.New("error listing pods"))
 			})
 
 			It("continues", func() {

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -209,7 +209,7 @@ func (c *client) Discover() error {
 	// Just use this function call to cache the API discovery.
 	_, err := c.mapper.ResourceSingularizer("pods")
 	if err != nil {
-		fmt.Errorf("error discovering API: %w", err)
+		return fmt.Errorf("error discovering API: %w", err)
 	}
 
 	return nil

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/homedepot/go-clouddriver/pkg/kubernetes/patcher"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,6 +37,7 @@ type Client interface {
 	Apply(*unstructured.Unstructured) (Metadata, error)
 	ApplyWithNamespaceOverride(*unstructured.Unstructured, string) (Metadata, error)
 	DeleteResourceByKindAndNameAndNamespace(string, string, string, metav1.DeleteOptions) error
+	Discover() error
 	GVRForKind(string) (schema.GroupVersionResource, error)
 	Get(string, string, string) (*unstructured.Unstructured, error)
 	ListByGVR(schema.GroupVersionResource, metav1.ListOptions) (*unstructured.UnstructuredList, error)
@@ -191,6 +193,24 @@ func (c *client) DeleteResourceByKindAndNameAndNamespace(kind, name, namespace s
 	}
 
 	return err
+}
+
+// Discover uses the resource singularize function of a client GVR mapping
+// to initialize the API discovery cache.
+//
+// This should be ran before running any client request operations concurrently.
+// First, it will initialize the cache making any future requests use the disk
+// cache for API discovery instead of making requests to the cluster. Second,
+// since the REST mapper has a mutex lock on API discovery, concurrent requests
+// to grab the GVR from the mapper will appear to run serially.
+func (c *client) Discover() error {
+	// Just use this function call to cache the API discovery.
+	_, err := c.mapper.ResourceSingularizer("pods")
+	if err != nil {
+		fmt.Errorf("error discovering API: %w", err)
+	}
+
+	return nil
 }
 
 // Get a manifest by resource/kind (example: 'pods' or 'pod'),

--- a/pkg/kubernetes/client.go
+++ b/pkg/kubernetes/client.go
@@ -203,6 +203,8 @@ func (c *client) DeleteResourceByKindAndNameAndNamespace(kind, name, namespace s
 // cache for API discovery instead of making requests to the cluster. Second,
 // since the REST mapper has a mutex lock on API discovery, concurrent requests
 // to grab the GVR from the mapper will appear to run serially.
+//
+// See https://github.com/kubernetes/client-go/blob/f6ce18ae578c8cca64d14ab9687824d9e1305a67/restmapper/discovery.go#L194.
 func (c *client) Discover() error {
 	// Just use this function call to cache the API discovery.
 	_, err := c.mapper.ResourceSingularizer("pods")

--- a/pkg/kubernetes/controller.go
+++ b/pkg/kubernetes/controller.go
@@ -42,14 +42,14 @@ const (
 	// Default cache directory.
 	cacheDir       = "/var/kube/cache"
 	defaultTimeout = 180 * time.Second
-)
-
-var (
-	ttl = 10 * time.Minute
+	ttl            = 10 * time.Minute
 )
 
 func newClientWithDefaultDiskCache(config *rest.Config) (Client, error) {
-	config.Timeout = defaultTimeout
+	// If the timeout is not set, set it to the default timeout.
+	if config.Timeout == 0 {
+		config.Timeout = defaultTimeout
+	}
 
 	dynamicClient, err := dynamic.NewForConfig(config)
 	if err != nil {

--- a/pkg/kubernetes/kubernetesfakes/fake_client.go
+++ b/pkg/kubernetes/kubernetesfakes/fake_client.go
@@ -54,6 +54,16 @@ type FakeClient struct {
 	deleteResourceByKindAndNameAndNamespaceReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DiscoverStub        func() error
+	discoverMutex       sync.RWMutex
+	discoverArgsForCall []struct {
+	}
+	discoverReturns struct {
+		result1 error
+	}
+	discoverReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GVRForKindStub        func(string) (schema.GroupVersionResource, error)
 	gVRForKindMutex       sync.RWMutex
 	gVRForKindArgsForCall []struct {
@@ -385,6 +395,59 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespaceReturnsOnCall(i i
 		})
 	}
 	fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) Discover() error {
+	fake.discoverMutex.Lock()
+	ret, specificReturn := fake.discoverReturnsOnCall[len(fake.discoverArgsForCall)]
+	fake.discoverArgsForCall = append(fake.discoverArgsForCall, struct {
+	}{})
+	stub := fake.DiscoverStub
+	fakeReturns := fake.discoverReturns
+	fake.recordInvocation("Discover", []interface{}{})
+	fake.discoverMutex.Unlock()
+	if stub != nil {
+		return stub()
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) DiscoverCallCount() int {
+	fake.discoverMutex.RLock()
+	defer fake.discoverMutex.RUnlock()
+	return len(fake.discoverArgsForCall)
+}
+
+func (fake *FakeClient) DiscoverCalls(stub func() error) {
+	fake.discoverMutex.Lock()
+	defer fake.discoverMutex.Unlock()
+	fake.DiscoverStub = stub
+}
+
+func (fake *FakeClient) DiscoverReturns(result1 error) {
+	fake.discoverMutex.Lock()
+	defer fake.discoverMutex.Unlock()
+	fake.DiscoverStub = nil
+	fake.discoverReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) DiscoverReturnsOnCall(i int, result1 error) {
+	fake.discoverMutex.Lock()
+	defer fake.discoverMutex.Unlock()
+	fake.DiscoverStub = nil
+	if fake.discoverReturnsOnCall == nil {
+		fake.discoverReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.discoverReturnsOnCall[i] = struct {
 		result1 error
 	}{result1}
 }
@@ -1007,6 +1070,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.applyWithNamespaceOverrideMutex.RUnlock()
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.RLock()
 	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.RUnlock()
+	fake.discoverMutex.RLock()
+	defer fake.discoverMutex.RUnlock()
 	fake.gVRForKindMutex.RLock()
 	defer fake.gVRForKindMutex.RUnlock()
 	fake.getMutex.RLock()


### PR DESCRIPTION
Listing resources concurrently was not working for clusters that were not available. We would get a timeout after 30 seconds (instead of the specified 10 in the request context) for *each* resource requested.

This was because for each resource requested in parallel we have to perform API discovery on the kubernetes dynamic client. This did not take into account the context timeout of 10 seconds and would therefore timeout after 30 seconds. Additionally, hidden in the client discovery code is a mutex lock around this discovery operation (see https://github.com/kubernetes/client-go/blob/f6ce18ae578c8cca64d14ab9687824d9e1305a67/restmapper/discovery.go#L194). So, concurrently requesting four resources would fail on the API discovery four times in a row, resulting in a 2 minute request!

This PR fixes this by:
- providing a `Discover` function for the client that should be run before any concurrent list operations
- setting the request timeout in the rest config instead of just the request context (this will force the API discovery to timeout at 10 seconds instead of 30)