### PR TITLE
add support for service info

### DIFF
--- a/pkg/http/core/applications.go
+++ b/pkg/http/core/applications.go
@@ -488,6 +488,24 @@ func makeLoadBalancerServerGroupsMap(serverGroups, services []resource,
 	loadBalancerServerGroups := map[string][]LoadBalancerServerGroup{}
 	// Loop through the resources and find the matching labels.
 	for _, serverGroup := range serverGroups {
+		// Define the resource and get the pod template labels.
+		var labels map[string]string
+		// Only certain kinds of resources can be fronted by
+		// a service.
+		kind := serverGroup.u.GetKind()
+		if strings.EqualFold(kind, "replicaSet") {
+			rs := kubernetes.NewReplicaSet(serverGroup.u.Object)
+			spec := rs.GetReplicaSetSpec()
+			labels = spec.Template.ObjectMeta.Labels
+		} else if strings.EqualFold(kind, "statefulSet") {
+			sts := kubernetes.NewStatefulSet(serverGroup.u.Object)
+			spec := sts.GetStatefulSetSpec()
+			labels = spec.Template.ObjectMeta.Labels
+		} else {
+			continue
+		}
+		// Loop through the services and check if a service
+		// is fronting this server group.
 		for _, service := range services {
 			// If the resource and Service are not in the same
 			// namespace then skip.
@@ -499,22 +517,6 @@ func makeLoadBalancerServerGroupsMap(serverGroups, services []resource,
 			selector := s.Selector()
 			// If there are no selectors, continue.
 			if len(selector) == 0 {
-				continue
-			}
-			// Define the resource and get the pod template labels.
-			var labels map[string]string
-			// Only certain kinds of resources can be fronted by
-			// a service.
-			kind := serverGroup.u.GetKind()
-			if strings.EqualFold(kind, "replicaSet") {
-				rs := kubernetes.NewReplicaSet(serverGroup.u.Object)
-				spec := rs.GetReplicaSetSpec()
-				labels = spec.Template.ObjectMeta.Labels
-			} else if strings.EqualFold(kind, "statefulSet") {
-				sts := kubernetes.NewStatefulSet(serverGroup.u.Object)
-				spec := sts.GetStatefulSetSpec()
-				labels = spec.Template.ObjectMeta.Labels
-			} else {
 				continue
 			}
 			// Define if the current resource is "fronted" by the service.
@@ -793,6 +795,24 @@ func makeServerGroupLoadBalancersMap(serverGroups, services []resource) map[stri
 	serverGroupLoadBalancers := map[string][]string{}
 	// Loop through the resources and find the matching labels.
 	for _, serverGroup := range serverGroups {
+		// Define the resource and get the pod template labels.
+		var labels map[string]string
+		// Only certain kinds of resources can be fronted by
+		// a service.
+		kind := serverGroup.u.GetKind()
+		if strings.EqualFold(kind, "replicaSet") {
+			rs := kubernetes.NewReplicaSet(serverGroup.u.Object)
+			spec := rs.GetReplicaSetSpec()
+			labels = spec.Template.ObjectMeta.Labels
+		} else if strings.EqualFold(kind, "statefulSet") {
+			sts := kubernetes.NewStatefulSet(serverGroup.u.Object)
+			spec := sts.GetStatefulSetSpec()
+			labels = spec.Template.ObjectMeta.Labels
+		} else {
+			continue
+		}
+		// Loop through the services and check if a service
+		// is fronting this server group.
 		for _, service := range services {
 			// If the resource and Service are not in the same
 			// namespace then skip.
@@ -804,22 +824,6 @@ func makeServerGroupLoadBalancersMap(serverGroups, services []resource) map[stri
 			selector := s.Selector()
 			// If there are no selectors, continue.
 			if len(selector) == 0 {
-				continue
-			}
-			// Define the resource and get the pod template labels.
-			var labels map[string]string
-			// Only certain kinds of resources can be fronted by
-			// a service.
-			kind := serverGroup.u.GetKind()
-			if strings.EqualFold(kind, "replicaSet") {
-				rs := kubernetes.NewReplicaSet(serverGroup.u.Object)
-				spec := rs.GetReplicaSetSpec()
-				labels = spec.Template.ObjectMeta.Labels
-			} else if strings.EqualFold(kind, "statefulSet") {
-				sts := kubernetes.NewStatefulSet(serverGroup.u.Object)
-				spec := sts.GetStatefulSetSpec()
-				labels = spec.Template.ObjectMeta.Labels
-			} else {
 				continue
 			}
 			// Define if the current resource is "fronted" by the service.

--- a/pkg/http/core/applications_test.go
+++ b/pkg/http/core/applications_test.go
@@ -453,6 +453,76 @@ var _ = Describe("Application", func() {
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"labels": map[string]interface{}{
+									"label1": "test-label1",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-rs1",
+										"kind": "replicaSet",
+										"uid":  "test-uid1",
+									},
+								},
+								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"labels": map[string]interface{}{
+									"label1": "test-label1",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-rs2",
+										"kind": "replicaSet",
+										"uid":  "test-uid2",
+									},
+								},
+								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"labels": map[string]interface{}{
+									"label1": "test-label1",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-rs3",
+										"kind": "replicaSet",
+										"uid":  "test-uid3",
+									},
+								},
+								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+							},
+						},
+					},
+				},
+			}, nil)
+			fakeKubeClient.ListResourceWithContextReturnsOnCall(1, &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
 							"kind":       "Ingress",
 							"apiVersion": "networking.k8s.io/v1beta1",
 							"metadata": map[string]interface{}{
@@ -468,7 +538,7 @@ var _ = Describe("Application", func() {
 					},
 				},
 			}, nil)
-			fakeKubeClient.ListResourceWithContextReturnsOnCall(1, &unstructured.UnstructuredList{
+			fakeKubeClient.ListResourceWithContextReturnsOnCall(2, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
 					{
 						Object: map[string]interface{}{
@@ -477,6 +547,148 @@ var _ = Describe("Application", func() {
 							"metadata": map[string]interface{}{
 								"name":      "test-service1",
 								"namespace": "test-namespace1",
+							},
+							"spec": map[string]interface{}{
+								"selector": map[string]string{
+									"test": "label",
+								},
+							},
+						},
+					},
+				},
+			}, nil)
+			fakeKubeClient.ListResourceWithContextReturnsOnCall(3, &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-rs1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":       "test-deployment1",
+									"artifact.spinnaker.io/type":       "kubernetes/deployment",
+									"artifact.spinnaker.io/location":   "test-namespace1",
+									"moniker.spinnaker.io/application": "test-deployment1",
+									"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
+									"moniker.spinnaker.io/sequence":    "19",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-deployment1",
+										"kind": "Deployment",
+										"uid":  "test-uid3",
+									},
+								},
+								"uid": "test-uid1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"test": "label",
+										},
+									},
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
+							},
+						},
+					},
+				},
+			}, nil)
+			fakeKubeClient.ListResourceWithContextReturnsOnCall(4, &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"kind":       "StatefulSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-rs1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":        "test-deployment1",
+									"artifact.spinnaker.io/type":        "kubernetes/deployment",
+									"artifact.spinnaker.io/location":    "test-namespace1",
+									"moniker.spinnaker.io/application":  "test-deployment1",
+									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
+									"deployment.kubernetes.io/revision": "19",
+								},
+								"uid": "test-uid3",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "StatefulSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-rs1",
+								"namespace":         "test-namespace2",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":        "test-deployment1",
+									"artifact.spinnaker.io/type":        "kubernetes/deployment",
+									"artifact.spinnaker.io/location":    "test-namespace1",
+									"moniker.spinnaker.io/application":  "test-deployment1",
+									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
+									"deployment.kubernetes.io/revision": "19",
+								},
+								"uid": "test-uid3",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
 							},
 						},
 					},
@@ -580,6 +792,76 @@ var _ = Describe("Application", func() {
 					Items: []unstructured.Unstructured{
 						{
 							Object: map[string]interface{}{
+								"kind":       "Pod",
+								"apiVersion": "v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-pod1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"labels": map[string]interface{}{
+										"test": "label3",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-rs1",
+											"kind": "replicaSet",
+											"uid":  "test-uid11",
+										},
+									},
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "Pod",
+								"apiVersion": "v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-pod1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"labels": map[string]interface{}{
+										"test": "label2",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-rs2",
+											"kind": "replicaSet",
+											"uid":  "test-uid2",
+										},
+									},
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "Pod",
+								"apiVersion": "v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-pod1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"labels": map[string]interface{}{
+										"test": "label1",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-rs3",
+											"kind": "statefulSet",
+											"uid":  "test-uid3",
+										},
+									},
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+								},
+							},
+						},
+					},
+				}, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(1, &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
 								"kind":       "Ingress",
 								"apiVersion": "networking.k8s.io/v1beta1",
 								"metadata": map[string]interface{}{
@@ -625,7 +907,7 @@ var _ = Describe("Application", func() {
 						},
 					},
 				}, nil)
-				fakeKubeClient.ListResourceWithContextReturnsOnCall(1, &unstructured.UnstructuredList{
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(2, &unstructured.UnstructuredList{
 					Items: []unstructured.Unstructured{
 						{
 							Object: map[string]interface{}{
@@ -634,6 +916,12 @@ var _ = Describe("Application", func() {
 								"metadata": map[string]interface{}{
 									"name":      "test-service3",
 									"namespace": "test-namespace2",
+									"uid":       "aec15437-4e6a-11ea-9788-4201ac100006",
+								},
+								"spec": map[string]interface{}{
+									"selector": map[string]string{
+										"test": "label",
+									},
 								},
 							},
 						},
@@ -644,6 +932,12 @@ var _ = Describe("Application", func() {
 								"metadata": map[string]interface{}{
 									"name":      "test-service2",
 									"namespace": "test-namespace2",
+									"uid":       "bec15437-4e6a-11ea-9788-4201ac100006",
+								},
+								"spec": map[string]interface{}{
+									"selector": map[string]string{
+										"test": "label1",
+									},
 								},
 							},
 						},
@@ -654,6 +948,154 @@ var _ = Describe("Application", func() {
 								"metadata": map[string]interface{}{
 									"name":      "test-service1",
 									"namespace": "test-namespace1",
+									"uid":       "cec15437-4e6a-11ea-9788-4201ac100006",
+								},
+								"spec": map[string]interface{}{
+									"selector": map[string]string{
+										"test": "label2",
+									},
+								},
+							},
+						},
+					},
+				}, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(3, &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"kind":       "ReplicaSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-rs1",
+									"namespace":         "test-namespace2",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"artifact.spinnaker.io/name":       "test-deployment1",
+										"artifact.spinnaker.io/type":       "kubernetes/deployment",
+										"artifact.spinnaker.io/location":   "test-namespace1",
+										"moniker.spinnaker.io/application": "test-deployment1",
+										"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
+										"moniker.spinnaker.io/sequence":    "19",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-deployment1",
+											"kind": "Deployment",
+											"uid":  "test-uid3",
+										},
+									},
+									"uid": "test-uid11",
+								},
+								"spec": map[string]interface{}{
+									"replicas": 1,
+									"template": map[string]interface{}{
+										"metadata": map[string]interface{}{
+											"labels": map[string]interface{}{
+												"test": "label1",
+											},
+										},
+										"spec": map[string]interface{}{
+											"containers": []map[string]interface{}{
+												{
+													"image": "test-image1",
+												},
+												{
+													"image": "test-image2",
+												},
+											},
+										},
+									},
+								},
+								"status": map[string]interface{}{
+									"replicas":      1,
+									"readyReplicas": 0,
+								},
+							},
+						},
+					},
+				}, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(4, &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"kind":       "StatefulSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-sts1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"artifact.spinnaker.io/name":        "test-deployment1",
+										"artifact.spinnaker.io/type":        "kubernetes/deployment",
+										"artifact.spinnaker.io/location":    "test-namespace1",
+										"moniker.spinnaker.io/application":  "test-deployment1",
+										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
+										"deployment.kubernetes.io/revision": "19",
+									},
+									"uid": "test-uid3",
+								},
+								"spec": map[string]interface{}{
+									"replicas": 1,
+									"template": map[string]interface{}{
+										"metadata": map[string]interface{}{
+											"labels": map[string]interface{}{
+												"test": "label2",
+											},
+										},
+										"spec": map[string]interface{}{
+											"containers": []map[string]interface{}{
+												{
+													"image": "test-image1",
+												},
+												{
+													"image": "test-image2",
+												},
+											},
+										},
+									},
+								},
+								"status": map[string]interface{}{
+									"replicas":      1,
+									"readyReplicas": 0,
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "StatefulSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-sts2",
+									"namespace":         "test-namespace2",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"artifact.spinnaker.io/name":        "test-deployment1",
+										"artifact.spinnaker.io/type":        "kubernetes/deployment",
+										"artifact.spinnaker.io/location":    "test-namespace1",
+										"moniker.spinnaker.io/application":  "test-deployment1",
+										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
+										"deployment.kubernetes.io/revision": "19",
+									},
+									"uid": "test-uid34",
+								},
+								"spec": map[string]interface{}{
+									"replicas": 1,
+									"template": map[string]interface{}{
+										"spec": map[string]interface{}{
+											"containers": []map[string]interface{}{
+												{
+													"image": "test-image1",
+												},
+												{
+													"image": "test-image2",
+												},
+											},
+										},
+									},
+								},
+								"status": map[string]interface{}{
+									"replicas":      1,
+									"readyReplicas": 0,
 								},
 							},
 						},
@@ -859,6 +1301,11 @@ var _ = Describe("Application", func() {
 							"spec": map[string]interface{}{
 								"replicas": 1,
 								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"test": "label",
+										},
+									},
 									"spec": map[string]interface{}{
 										"containers": []map[string]interface{}{
 											{
@@ -930,7 +1377,7 @@ var _ = Describe("Application", func() {
 							"kind":       "StatefulSet",
 							"apiVersion": "apps/v1",
 							"metadata": map[string]interface{}{
-								"name":              "test-rs1",
+								"name":              "test-sts1",
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
 								"annotations": map[string]interface{}{
@@ -946,6 +1393,11 @@ var _ = Describe("Application", func() {
 							"spec": map[string]interface{}{
 								"replicas": 1,
 								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"test": "label2",
+										},
+									},
 									"spec": map[string]interface{}{
 										"containers": []map[string]interface{}{
 											{
@@ -961,6 +1413,42 @@ var _ = Describe("Application", func() {
 							"status": map[string]interface{}{
 								"replicas":      1,
 								"readyReplicas": 0,
+							},
+						},
+					},
+				},
+			}, nil)
+			fakeKubeClient.ListResourceWithContextReturnsOnCall(4, &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"kind":       "Service",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-svc1",
+								"namespace": "test-namespace1",
+								"uid":       "test-uid4",
+							},
+							"spec": map[string]interface{}{
+								"selector": map[string]string{
+									"test": "label",
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Service",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-svc2",
+								"namespace": "test-namespace1",
+								"uid":       "test-uid5",
+							},
+							"spec": map[string]interface{}{
+								"selector": map[string]string{
+									"test": "label2",
+								},
 							},
 						},
 					},

--- a/pkg/http/core/payload_test.go
+++ b/pkg/http/core/payload_test.go
@@ -1099,7 +1099,7 @@ const payloadListServerGroups = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "DaemonSet",
+              "kind": "daemonSet",
               "labels": null,
               "loadBalancers": null,
               "manifest": null,
@@ -1108,7 +1108,7 @@ const payloadListServerGroups = `[
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
-              "name": "DaemonSet test-ds1",
+              "name": "daemonSet test-ds1",
               "namespace": "test-namespace1",
               "providerType": "",
               "region": "test-namespace1",
@@ -1185,16 +1185,18 @@ const payloadListServerGroups = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "ReplicaSet",
+              "kind": "replicaSet",
               "labels": null,
-              "loadBalancers": null,
+              "loadBalancers": [
+							  "service test-svc1"
+							],
               "manifest": null,
               "moniker": {
                 "app": "test-deployment1",
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
-              "name": "ReplicaSet test-rs1",
+              "name": "replicaSet test-rs1",
               "namespace": "test-namespace1",
               "providerType": "",
               "region": "test-namespace1",
@@ -1229,7 +1231,7 @@ const payloadListServerGroups = `[
               "cluster": "deployment test-deployment1",
               "createdTime": 1581603123000,
               "disabled": false,
-              "displayName": "test-rs1",
+              "displayName": "test-sts1",
               "instanceCounts": {
                 "down": 0,
                 "outOfService": 0,
@@ -1277,16 +1279,18 @@ const payloadListServerGroups = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "StatefulSet",
+              "kind": "statefulSet",
               "labels": null,
-              "loadBalancers": null,
+              "loadBalancers": [
+							  "service test-svc2"
+							],
               "manifest": null,
               "moniker": {
                 "app": "test-deployment1",
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
-              "name": "StatefulSet test-rs1",
+              "name": "statefulSet test-sts1",
               "namespace": "test-namespace1",
               "providerType": "",
               "region": "test-namespace1",
@@ -1422,7 +1426,7 @@ const payloadListServerGroupsSorted = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "DaemonSet",
+              "kind": "daemonSet",
               "labels": null,
               "loadBalancers": null,
               "manifest": null,
@@ -1431,7 +1435,7 @@ const payloadListServerGroupsSorted = `[
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
-              "name": "DaemonSet test-ds1",
+              "name": "daemonSet test-ds1",
               "namespace": "test-namespace1",
               "providerType": "",
               "region": "test-namespace1",
@@ -1508,7 +1512,7 @@ const payloadListServerGroupsSorted = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "ReplicaSet",
+              "kind": "replicaSet",
               "labels": null,
               "loadBalancers": null,
               "manifest": null,
@@ -1517,7 +1521,7 @@ const payloadListServerGroupsSorted = `[
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
-              "name": "ReplicaSet test-rs1",
+              "name": "replicaSet test-rs1",
               "namespace": "test-namespace1",
               "providerType": "",
               "region": "test-namespace1",
@@ -1600,7 +1604,7 @@ const payloadListServerGroupsSorted = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "StatefulSet",
+              "kind": "statefulSet",
               "labels": null,
               "loadBalancers": null,
               "manifest": null,
@@ -1609,7 +1613,7 @@ const payloadListServerGroupsSorted = `[
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
-              "name": "StatefulSet test-rs1",
+              "name": "statefulSet test-rs1",
               "namespace": "test-namespace1",
               "providerType": "",
               "region": "test-namespace1",
@@ -1742,7 +1746,7 @@ const payloadListServerGroupsSorted = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "DaemonSet",
+              "kind": "daemonSet",
               "labels": null,
               "loadBalancers": null,
               "manifest": null,
@@ -1751,7 +1755,7 @@ const payloadListServerGroupsSorted = `[
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
-              "name": "DaemonSet test-ds1",
+              "name": "daemonSet test-ds1",
               "namespace": "test-namespace2",
               "providerType": "",
               "region": "test-namespace2",
@@ -1828,7 +1832,7 @@ const payloadListServerGroupsSorted = `[
                 "namespace": "",
                 "provider": ""
               },
-              "kind": "StatefulSet",
+              "kind": "statefulSet",
               "labels": null,
               "loadBalancers": null,
               "manifest": null,
@@ -1837,7 +1841,7 @@ const payloadListServerGroupsSorted = `[
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
-              "name": "StatefulSet test-rs1",
+              "name": "statefulSet test-rs1",
               "namespace": "test-namespace2",
               "providerType": "",
               "region": "test-namespace2",
@@ -1854,7 +1858,11 @@ const payloadListServerGroupsSorted = `[
 const payloadListLoadBalancers = `[
             {
               "account": "account1",
+              "apiVersion": "networking.k8s.io/v1beta1",
               "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "displayName": "test-ingress1",
+              "kind": "ingress",
               "labels": {
                 "label1": "test-label1"
               },
@@ -1863,307 +1871,209 @@ const payloadListLoadBalancers = `[
                 "cluster": "ingress test-ingress1"
               },
               "name": "ingress test-ingress1",
-              "displayName": "test-ingress1",
+              "namespace": "test-namespace1",
               "region": "test-namespace1",
-              "serverGroups": null,
-              "type": "kubernetes",
-              "accountName": "account1",
-              "createdTime": 1581603123000,
-              "key": {
-                "account": "account1",
-                "group": "networking.k8s.io",
-                "kubernetesKind": "ingress",
-                "name": "ingress test-ingress1",
-                "namespace": "test-namespace1",
-                "provider": "kubernetes"
-              },
-              "kind": "ingress",
-              "manifest": {
-                "apiVersion": "networking.k8s.io/v1beta1",
-                "kind": "Ingress",
-                "metadata": {
-                  "creationTimestamp": "2020-02-13T14:12:03Z",
-                  "labels": {
-                    "label1": "test-label1"
-                  },
-                  "name": "test-ingress1",
-                  "namespace": "test-namespace1",
-                  "uid": "cec15437-4e6a-11ea-9788-4201ac100006"
-                }
-              },
-              "providerType": "kubernetes",
-              "uid": "cec15437-4e6a-11ea-9788-4201ac100006",
-              "zone": "test-application"
+              "serverGroups": [],
+              "type": "kubernetes"
             },
             {
               "account": "account1",
+              "apiVersion": "v1",
               "cloudProvider": "kubernetes",
+              "createdTime": -62135596800000,
+              "displayName": "test-service1",
+              "kind": "service",
               "moniker": {
                 "app": "test-application",
                 "cluster": "service test-service1"
               },
               "name": "service test-service1",
-              "displayName": "test-service1",
+              "namespace": "test-namespace1",
               "region": "test-namespace1",
-              "serverGroups": null,
-              "type": "kubernetes",
-              "accountName": "account1",
-              "createdTime": -62135596800000,
-              "key": {
-                "account": "account1",
-                "group": "",
-                "kubernetesKind": "service",
-                "name": "service test-service1",
-                "namespace": "test-namespace1",
-                "provider": "kubernetes"
-              },
-              "kind": "service",
-              "manifest": {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                  "name": "test-service1",
-                  "namespace": "test-namespace1"
+              "serverGroups": [
+                {
+                  "account": "account1",
+                  "cloudProvider": "kubernetes",
+                  "detachedInstances": [],
+                  "instances": [
+                    {
+                      "health": {
+                        "platform": "platform",
+                        "source": "Container TODO",
+                        "state": "Down",
+                        "type": "kubernetes/container"
+                      },
+                      "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                      "name": "pod test-pod1",
+                      "zone": "test-namespace1"
+                    }
+                  ],
+                  "isDisabled": false,
+                  "name": "replicaSet test-rs1",
+                  "region": "test-namespace1"
                 }
-              },
-              "providerType": "kubernetes",
-              "zone": "test-application"
+              ],
+              "type": "kubernetes"
             }
           ]`
 
 const payloadListLoadBalancersSorted = `[
-            {
-              "account": "account1",
-              "cloudProvider": "kubernetes",
-              "labels": {
-                "label1": "test-label1"
-              },
-              "moniker": {
-                "app": "test-application",
-                "cluster": "ingress test-ingress1"
-              },
-              "name": "ingress test-ingress1",
-              "displayName": "test-ingress1",
-              "region": "test-namespace1",
-              "serverGroups": null,
-              "type": "kubernetes",
-              "accountName": "account1",
-              "createdTime": 1581603123000,
-              "key": {
-                "account": "account1",
-                "group": "networking.k8s.io",
-                "kubernetesKind": "ingress",
-                "name": "ingress test-ingress1",
-                "namespace": "test-namespace1",
-                "provider": "kubernetes"
-              },
-              "kind": "ingress",
-              "manifest": {
-                "apiVersion": "networking.k8s.io/v1beta1",
-                "kind": "Ingress",
-                "metadata": {
-                  "creationTimestamp": "2020-02-13T14:12:03Z",
-                  "labels": {
-                    "label1": "test-label1"
-                  },
-                  "name": "test-ingress1",
-                  "namespace": "test-namespace1",
-                  "uid": "cec15437-4e6a-11ea-9788-4201ac100006"
-                }
-              },
-              "providerType": "kubernetes",
-              "uid": "cec15437-4e6a-11ea-9788-4201ac100006",
-              "zone": "test-application"
-            },
-            {
-              "account": "account1",
-              "cloudProvider": "kubernetes",
-              "moniker": {
-                "app": "test-application",
-                "cluster": "service test-service1"
-              },
-              "name": "service test-service1",
-              "displayName": "test-service1",
-              "region": "test-namespace1",
-              "serverGroups": null,
-              "type": "kubernetes",
-              "accountName": "account1",
-              "createdTime": -62135596800000,
-              "key": {
-                "account": "account1",
-                "group": "",
-                "kubernetesKind": "service",
-                "name": "service test-service1",
-                "namespace": "test-namespace1",
-                "provider": "kubernetes"
-              },
-              "kind": "service",
-              "manifest": {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                  "name": "test-service1",
-                  "namespace": "test-namespace1"
-                }
-              },
-              "providerType": "kubernetes",
-              "zone": "test-application"
-            },
-            {
-              "account": "account1",
-              "cloudProvider": "kubernetes",
-              "labels": {
-                "label1": "test-label1"
-              },
-              "moniker": {
-                "app": "test-application",
-                "cluster": "ingress test-ingress2"
-              },
-              "name": "ingress test-ingress2",
-              "displayName": "test-ingress2",
-              "region": "test-namespace2",
-              "serverGroups": null,
-              "type": "kubernetes",
-              "accountName": "account1",
-              "createdTime": 1581603123000,
-              "key": {
-                "account": "account1",
-                "group": "networking.k8s.io",
-                "kubernetesKind": "ingress",
-                "name": "ingress test-ingress2",
-                "namespace": "test-namespace2",
-                "provider": "kubernetes"
-              },
-              "kind": "ingress",
-              "manifest": {
-                "apiVersion": "networking.k8s.io/v1beta1",
-                "kind": "Ingress",
-                "metadata": {
-                  "creationTimestamp": "2020-02-13T14:12:03Z",
-                  "labels": {
-                    "label1": "test-label1"
-                  },
-                  "name": "test-ingress2",
-                  "namespace": "test-namespace2",
-                  "uid": "cec15437-4e6a-11ea-9788-4201ac100006"
-                }
-              },
-              "providerType": "kubernetes",
-              "uid": "cec15437-4e6a-11ea-9788-4201ac100006",
-              "zone": "test-application"
-            },
-            {
-              "account": "account1",
-              "cloudProvider": "kubernetes",
-              "labels": {
-                "label1": "test-label1"
-              },
-              "moniker": {
-                "app": "test-application",
-                "cluster": "ingress test-ingress3"
-              },
-              "name": "ingress test-ingress3",
-              "displayName": "test-ingress3",
-              "region": "test-namespace2",
-              "serverGroups": null,
-              "type": "kubernetes",
-              "accountName": "account1",
-              "createdTime": 1581603123000,
-              "key": {
-                "account": "account1",
-                "group": "networking.k8s.io",
-                "kubernetesKind": "ingress",
-                "name": "ingress test-ingress3",
-                "namespace": "test-namespace2",
-                "provider": "kubernetes"
-              },
-              "kind": "ingress",
-              "manifest": {
-                "apiVersion": "networking.k8s.io/v1beta1",
-                "kind": "Ingress",
-                "metadata": {
-                  "creationTimestamp": "2020-02-13T14:12:03Z",
-                  "labels": {
-                    "label1": "test-label1"
-                  },
-                  "name": "test-ingress3",
-                  "namespace": "test-namespace2",
-                  "uid": "cec15437-4e6a-11ea-9788-4201ac100006"
-                }
-              },
-              "providerType": "kubernetes",
-              "uid": "cec15437-4e6a-11ea-9788-4201ac100006",
-              "zone": "test-application"
-            },
-            {
-              "account": "account1",
-              "cloudProvider": "kubernetes",
-              "moniker": {
-                "app": "test-application",
-                "cluster": "service test-service2"
-              },
-              "name": "service test-service2",
-              "displayName": "test-service2",
-              "region": "test-namespace2",
-              "serverGroups": null,
-              "type": "kubernetes",
-              "accountName": "account1",
-              "createdTime": -62135596800000,
-              "key": {
-                "account": "account1",
-                "group": "",
-                "kubernetesKind": "service",
-                "name": "service test-service2",
-                "namespace": "test-namespace2",
-                "provider": "kubernetes"
-              },
-              "kind": "service",
-              "manifest": {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                  "name": "test-service2",
-                  "namespace": "test-namespace2"
-                }
-              },
-              "providerType": "kubernetes",
-              "zone": "test-application"
-            },
-            {
-              "account": "account1",
-              "cloudProvider": "kubernetes",
-              "moniker": {
-                "app": "test-application",
-                "cluster": "service test-service3"
-              },
-              "name": "service test-service3",
-              "displayName": "test-service3",
-              "region": "test-namespace2",
-              "serverGroups": null,
-              "type": "kubernetes",
-              "accountName": "account1",
-              "createdTime": -62135596800000,
-              "key": {
-                "account": "account1",
-                "group": "",
-                "kubernetesKind": "service",
-                "name": "service test-service3",
-                "namespace": "test-namespace2",
-                "provider": "kubernetes"
-              },
-              "kind": "service",
-              "manifest": {
-                "apiVersion": "v1",
-                "kind": "Service",
-                "metadata": {
-                  "name": "test-service3",
-                  "namespace": "test-namespace2"
-                }
-              },
-              "providerType": "kubernetes",
-              "zone": "test-application"
-            }
-          ]`
+						{
+							"account": "account1",
+							"apiVersion": "networking.k8s.io/v1beta1",
+							"cloudProvider": "kubernetes",
+							"createdTime": 1581603123000,
+							"displayName": "test-ingress1",
+							"kind": "ingress",
+							"labels": {
+								"label1": "test-label1"
+							},
+							"moniker": {
+								"app": "test-application",
+								"cluster": "ingress test-ingress1"
+							},
+							"name": "ingress test-ingress1",
+							"namespace": "test-namespace1",
+							"region": "test-namespace1",
+							"serverGroups": [],
+							"type": "kubernetes"
+						},
+						{
+							"account": "account1",
+							"apiVersion": "v1",
+							"cloudProvider": "kubernetes",
+							"createdTime": -62135596800000,
+							"displayName": "test-service1",
+							"kind": "service",
+							"moniker": {
+								"app": "test-application",
+								"cluster": "service test-service1"
+							},
+							"name": "service test-service1",
+							"namespace": "test-namespace1",
+							"region": "test-namespace1",
+							"serverGroups": [
+								{
+									"account": "account1",
+									"cloudProvider": "kubernetes",
+									"detachedInstances": [],
+									"instances": [
+										{
+											"health": {
+												"platform": "platform",
+												"source": "Container TODO",
+												"state": "Down",
+												"type": "kubernetes/container"
+											},
+											"id": "cec15437-4e6a-11ea-9788-4201ac100006",
+											"name": "pod test-pod1",
+											"zone": "test-namespace1"
+										}
+									],
+									"isDisabled": false,
+									"name": "statefulSet test-sts1",
+									"region": "test-namespace1"
+								}
+							],
+							"type": "kubernetes"
+						},
+						{
+							"account": "account1",
+							"apiVersion": "networking.k8s.io/v1beta1",
+							"cloudProvider": "kubernetes",
+							"createdTime": 1581603123000,
+							"displayName": "test-ingress2",
+							"kind": "ingress",
+							"labels": {
+								"label1": "test-label1"
+							},
+							"moniker": {
+								"app": "test-application",
+								"cluster": "ingress test-ingress2"
+							},
+							"name": "ingress test-ingress2",
+							"namespace": "test-namespace2",
+							"region": "test-namespace2",
+							"serverGroups": [],
+							"type": "kubernetes"
+						},
+						{
+							"account": "account1",
+							"apiVersion": "networking.k8s.io/v1beta1",
+							"cloudProvider": "kubernetes",
+							"createdTime": 1581603123000,
+							"displayName": "test-ingress3",
+							"kind": "ingress",
+							"labels": {
+								"label1": "test-label1"
+							},
+							"moniker": {
+								"app": "test-application",
+								"cluster": "ingress test-ingress3"
+							},
+							"name": "ingress test-ingress3",
+							"namespace": "test-namespace2",
+							"region": "test-namespace2",
+							"serverGroups": [],
+							"type": "kubernetes"
+						},
+						{
+							"account": "account1",
+							"apiVersion": "v1",
+							"cloudProvider": "kubernetes",
+							"createdTime": -62135596800000,
+							"displayName": "test-service2",
+							"kind": "service",
+							"moniker": {
+								"app": "test-application",
+								"cluster": "service test-service2"
+							},
+							"name": "service test-service2",
+							"namespace": "test-namespace2",
+							"region": "test-namespace2",
+							"serverGroups": [
+								{
+									"account": "account1",
+									"cloudProvider": "kubernetes",
+									"detachedInstances": [],
+									"instances": [
+										{
+											"health": {
+												"platform": "platform",
+												"source": "Container TODO",
+												"state": "Down",
+												"type": "kubernetes/container"
+											},
+											"id": "cec15437-4e6a-11ea-9788-4201ac100006",
+											"name": "pod test-pod1",
+											"zone": "test-namespace1"
+										}
+									],
+									"isDisabled": false,
+									"name": "replicaSet test-rs1",
+									"region": "test-namespace2"
+								}
+							],
+							"type": "kubernetes"
+						},
+						{
+							"account": "account1",
+							"apiVersion": "v1",
+							"cloudProvider": "kubernetes",
+							"createdTime": -62135596800000,
+							"displayName": "test-service3",
+							"kind": "service",
+							"moniker": {
+								"app": "test-application",
+								"cluster": "service test-service3"
+							},
+							"name": "service test-service3",
+							"namespace": "test-namespace2",
+							"region": "test-namespace2",
+							"serverGroups": [],
+							"type": "kubernetes"
+						}
+					]`
 
 const payloadListClusters = `{
             "test-account1": [
@@ -2334,13 +2244,13 @@ const payloadGetServerGroup = `{
 						"isDisabled": false,
             "key": {
               "account": "test-account",
-              "group": "ReplicaSet",
-              "kubernetesKind": "ReplicaSet",
+              "group": "replicaSet",
+              "kubernetesKind": "replicaSet",
               "name": "test-rs1",
               "namespace": "test-namespace1",
               "provider": "kubernetes"
             },
-            "kind": "ReplicaSet",
+            "kind": "replicaSet",
             "labels": null,
             "loadBalancers": [],
             "manifest": {
@@ -2384,7 +2294,7 @@ const payloadGetServerGroup = `{
               "cluster": "deployment test-deployment1",
               "sequence": 19
             },
-            "name": "ReplicaSet test-rs1",
+            "name": "replicaSet test-rs1",
             "namespace": "test-namespace1",
             "providerType": "kubernetes",
             "region": "test-namespace1",

--- a/pkg/kubernetes/service.go
+++ b/pkg/kubernetes/service.go
@@ -1,0 +1,27 @@
+package kubernetes
+
+import (
+	"encoding/json"
+
+	v1 "k8s.io/api/core/v1"
+)
+
+type Service interface {
+	Selector() map[string]string
+}
+
+type service struct {
+	s *v1.Service
+}
+
+func NewService(m map[string]interface{}) Service {
+	s := &v1.Service{}
+	b, _ := json.Marshal(m)
+	_ = json.Unmarshal(b, &s)
+
+	return &service{s: s}
+}
+
+func (s *service) Selector() map[string]string {
+	return s.s.Spec.Selector
+}

--- a/pkg/kubernetes/service_test.go
+++ b/pkg/kubernetes/service_test.go
@@ -1,0 +1,26 @@
+package kubernetes_test
+
+import (
+	. "github.com/homedepot/go-clouddriver/pkg/kubernetes"
+	. "github.com/onsi/ginkgo"
+)
+
+var _ = Describe("Service", func() {
+	var (
+		s Service
+	)
+
+	BeforeEach(func() {
+		m := map[string]interface{}{}
+		s = NewService(m)
+	})
+
+	Describe("#Selector", func() {
+		BeforeEach(func() {
+			_ = s.Selector()
+		})
+
+		It("succeeds", func() {
+		})
+	})
+})

--- a/pkg/kubernetes/statefulset.go
+++ b/pkg/kubernetes/statefulset.go
@@ -11,6 +11,7 @@ import (
 )
 
 type StatefulSet interface {
+	GetStatefulSetSpec() v1.StatefulSetSpec
 	Object() *v1.StatefulSet
 	SetReplicas(*int32)
 	Status() manifest.Status
@@ -29,6 +30,10 @@ func NewStatefulSet(m map[string]interface{}) StatefulSet {
 	_ = json.Unmarshal(b, &s)
 
 	return &statefulSet{ss: s}
+}
+
+func (ss *statefulSet) GetStatefulSetSpec() v1.StatefulSetSpec {
+	return ss.ss.Spec
 }
 
 func (ss *statefulSet) Object() *v1.StatefulSet {

--- a/pkg/kubernetes/statefulset_test.go
+++ b/pkg/kubernetes/statefulset_test.go
@@ -32,6 +32,15 @@ var _ = Describe("Statefulset", func() {
 		})
 	})
 
+	Describe("#GetStatefulSetSpec", func() {
+		BeforeEach(func() {
+			_ = ss.GetStatefulSetSpec()
+		})
+
+		It("succeeds", func() {
+		})
+	})
+
 	Describe("#Status", func() {
 		var s manifest.Status
 


### PR DESCRIPTION
Since this is a larger PR (most of it is just payload differences), I would recommend reviewing the `applications.go` file, in particular the functions `makeLoadBalancerServerGroupsMap` and `makeServerGroupLoadBalancersMap`. It should be noted that the `/applications/*/serverGroups` endpoint is now retrieving Kubernetes kind Services in addition to its other four resources. The `/applications/*/loadBalancers` endpoint is now retrieving 5 Kinds: Pods, ReplicaSets, StatefulSets, Services,		and Ingresses. Retrieval of pods seems necessary to build the expected response for the pages.

In summary, this PR:
- Fixes load balancers not being able to be deleted (API change was not setting namespace field correctly)
- Adds service info for ReplicaSets and StatefulSets that are fronted by a service
- Adds the neat load balancer icon to resources in the clusters page
- Shows all resources fronted by a service in the load balancers page

From the Clusters page:
![image](https://user-images.githubusercontent.com/7597848/120723812-74e66600-c4a0-11eb-9174-8e0c35aee223.png)

From the Load Balancers page:
![image](https://user-images.githubusercontent.com/7597848/120723894-a7905e80-c4a0-11eb-8126-10af5e44d515.png)
