### PR TITLE
Helm repository basic auth

### DIFF
--- a/pkg/artifact/controller.go
+++ b/pkg/artifact/controller.go
@@ -49,13 +49,15 @@ type Credentials struct {
 	Types []Type `json:"types"`
 	// Helm repository config.
 	Repository string `json:"repository,omitempty"`
+	Username   string `json:"username,omitempty"`
+	Password   string `json:"password,omitempty"`
 	// Github config.
 	BaseURL    string `json:"baseURL,omitempty"`
 	Token      string `json:"token,omitempty"`
 	Enterprise bool   `json:"enterprise,omitempty"`
 }
 
-var (
+const (
 	defaultConfigDir = "/opt/spinnaker/artifacts/config"
 )
 
@@ -126,6 +128,11 @@ func NewCredentialsController(dir string) (CredentialsController, error) {
 					}
 
 					helmClient := helm.NewClient(ac.Repository)
+
+					if ac.Username != "" && ac.Password != "" {
+						helmClient.WithUsernameAndPassword(ac.Username, ac.Password)
+					}
+
 					cc.helmClients[ac.Name] = helmClient
 				case TypeGithubFile:
 					var tc *http.Client

--- a/pkg/artifact/controller_test.go
+++ b/pkg/artifact/controller_test.go
@@ -194,7 +194,7 @@ var _ = Describe("Controller", func() {
 
 		When("it succeeds", func() {
 			It("succeeds", func() {
-				Expect(artifactCredentials).To(HaveLen(12))
+				Expect(artifactCredentials).To(HaveLen(13))
 				for _, ac := range artifactCredentials {
 					Expect(ac.Repository).To(BeEmpty())
 					Expect(ac.Token).To(BeEmpty())

--- a/pkg/artifact/test/helm-chart-basic-auth.json
+++ b/pkg/artifact/test/helm-chart-basic-auth.json
@@ -1,0 +1,9 @@
+{
+  "name": "helm-basic-auth",
+  "types": [
+    "helm/chart"
+  ],
+  "repository": "https://kubernetes-charts.storage.googleapis.com",
+  "username": "fake-user",
+  "password": "fakk-password"
+}

--- a/pkg/helm/client_test.go
+++ b/pkg/helm/client_test.go
@@ -92,6 +92,21 @@ var _ = Describe("Client", func() {
 			})
 		})
 
+		When("with username/password", func() {
+			BeforeEach(func() {
+				client.WithUsernameAndPassword("fake-user", "fake-password")
+
+				server.AppendHandlers(ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/index.yaml"),
+					ghttp.VerifyBasicAuth("fake-user", "fake-password"),
+				))
+			})
+
+			It("it succeeds", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+
 		When("it succeeds", func() {
 			BeforeEach(func() {
 				server.AppendHandlers(ghttp.CombineHandlers(
@@ -263,6 +278,23 @@ entries:
 			BeforeEach(func() {
 				server.AppendHandlers(ghttp.CombineHandlers(
 					ghttp.VerifyRequest(http.MethodGet, "/artifactory/helm/hello-app-1.0.0.tgz"),
+					ghttp.RespondWith(http.StatusOK, `some-binary-data`),
+				))
+			})
+
+			It("succeeds", func() {
+				Expect(err).To(BeNil())
+				Expect(string(b)).To(Equal("some-binary-data"))
+			})
+		})
+
+		When("with username/password", func() {
+			BeforeEach(func() {
+				client.WithUsernameAndPassword("fake-user", "fake-password")
+
+				server.AppendHandlers(ghttp.CombineHandlers(
+					ghttp.VerifyRequest(http.MethodGet, "/artifactory/helm/hello-app-1.0.0.tgz"),
+					ghttp.VerifyBasicAuth("fake-user", "fake-password"),
 					ghttp.RespondWith(http.StatusOK, `some-binary-data`),
 				))
 			})

--- a/pkg/helm/helmfakes/fake_client.go
+++ b/pkg/helm/helmfakes/fake_client.go
@@ -34,6 +34,12 @@ type FakeClient struct {
 		result1 helm.Index
 		result2 error
 	}
+	WithUsernameAndPasswordStub        func(string, string)
+	withUsernameAndPasswordMutex       sync.RWMutex
+	withUsernameAndPasswordArgsForCall []struct {
+		arg1 string
+		arg2 string
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -45,16 +51,15 @@ func (fake *FakeClient) GetChart(arg1 string, arg2 string) ([]byte, error) {
 		arg1 string
 		arg2 string
 	}{arg1, arg2})
-	stub := fake.GetChartStub
-	fakeReturns := fake.getChartReturns
 	fake.recordInvocation("GetChart", []interface{}{arg1, arg2})
 	fake.getChartMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
+	if fake.GetChartStub != nil {
+		return fake.GetChartStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.getChartReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -108,16 +113,15 @@ func (fake *FakeClient) GetIndex() (helm.Index, error) {
 	ret, specificReturn := fake.getIndexReturnsOnCall[len(fake.getIndexArgsForCall)]
 	fake.getIndexArgsForCall = append(fake.getIndexArgsForCall, struct {
 	}{})
-	stub := fake.GetIndexStub
-	fakeReturns := fake.getIndexReturns
 	fake.recordInvocation("GetIndex", []interface{}{})
 	fake.getIndexMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.GetIndexStub != nil {
+		return fake.GetIndexStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.getIndexReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -159,6 +163,38 @@ func (fake *FakeClient) GetIndexReturnsOnCall(i int, result1 helm.Index, result2
 	}{result1, result2}
 }
 
+func (fake *FakeClient) WithUsernameAndPassword(arg1 string, arg2 string) {
+	fake.withUsernameAndPasswordMutex.Lock()
+	fake.withUsernameAndPasswordArgsForCall = append(fake.withUsernameAndPasswordArgsForCall, struct {
+		arg1 string
+		arg2 string
+	}{arg1, arg2})
+	fake.recordInvocation("WithUsernameAndPassword", []interface{}{arg1, arg2})
+	fake.withUsernameAndPasswordMutex.Unlock()
+	if fake.WithUsernameAndPasswordStub != nil {
+		fake.WithUsernameAndPasswordStub(arg1, arg2)
+	}
+}
+
+func (fake *FakeClient) WithUsernameAndPasswordCallCount() int {
+	fake.withUsernameAndPasswordMutex.RLock()
+	defer fake.withUsernameAndPasswordMutex.RUnlock()
+	return len(fake.withUsernameAndPasswordArgsForCall)
+}
+
+func (fake *FakeClient) WithUsernameAndPasswordCalls(stub func(string, string)) {
+	fake.withUsernameAndPasswordMutex.Lock()
+	defer fake.withUsernameAndPasswordMutex.Unlock()
+	fake.WithUsernameAndPasswordStub = stub
+}
+
+func (fake *FakeClient) WithUsernameAndPasswordArgsForCall(i int) (string, string) {
+	fake.withUsernameAndPasswordMutex.RLock()
+	defer fake.withUsernameAndPasswordMutex.RUnlock()
+	argsForCall := fake.withUsernameAndPasswordArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -166,6 +202,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.getChartMutex.RUnlock()
 	fake.getIndexMutex.RLock()
 	defer fake.getIndexMutex.RUnlock()
+	fake.withUsernameAndPasswordMutex.RLock()
+	defer fake.withUsernameAndPasswordMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
This PR adds support for
1. Basic auth (username/password) to Helm artifact credentials
2. Defining a custom directory for the artifact credentials configuration files, rather than using the default `/opt/spinnaker/artifacts/confg`.  
    - In our `go-clouddriver` deployment we maintain the credentials config in a Kubernetes ConfigMap which is mounted as a volume to the default directory location.  However, we want to store the credentials config in vault and use the [vault agent injector](https://www.vaultproject.io/docs/platform/k8s/injector) to make them available to `go-clouddriver`.  The vault agent injector writes to the `/vault` directory, so need the ability to use a directory different than the default.