### PR TITLE
Task not found response

### DIFF
--- a/pkg/http/core/kubernetes/restart_test.go
+++ b/pkg/http/core/kubernetes/restart_test.go
@@ -85,6 +85,17 @@ var _ = Describe("RollingRestart", func() {
 		})
 	})
 
+	When("creating the resource returns an error", func() {
+		BeforeEach(func() {
+			fakeSQLClient.CreateKubernetesResourceReturns(errors.New("error creating resource"))
+		})
+
+		It("returns an error", func() {
+			Expect(c.Writer.Status()).To(Equal(http.StatusInternalServerError))
+			Expect(c.Errors.Last().Error()).To(Equal("error creating resource"))
+		})
+	})
+
 	When("the kind is not supported to restarted", func() {
 		BeforeEach(func() {
 			rollingRestartManifestRequest.ManifestName = "not-supported-kind test-name"

--- a/pkg/http/core/kubernetes/rollback_test.go
+++ b/pkg/http/core/kubernetes/rollback_test.go
@@ -131,6 +131,17 @@ var _ = Describe("Rollback", func() {
 		})
 	})
 
+	When("creating the resource returns an error", func() {
+		BeforeEach(func() {
+			fakeSQLClient.CreateKubernetesResourceReturns(errors.New("error creating resource"))
+		})
+
+		It("returns an error", func() {
+			Expect(c.Writer.Status()).To(Equal(http.StatusInternalServerError))
+			Expect(c.Errors.Last().Error()).To(Equal("error creating resource"))
+		})
+	})
+
 	Context("when the mode is static", func() {
 		BeforeEach(func() {
 			undoRolloutManifestRequest.Mode = "static"

--- a/pkg/http/core/kubernetes/scale_test.go
+++ b/pkg/http/core/kubernetes/scale_test.go
@@ -96,6 +96,17 @@ var _ = Describe("Scale", func() {
 		})
 	})
 
+	When("creating the resource returns an error", func() {
+		BeforeEach(func() {
+			fakeSQLClient.CreateKubernetesResourceReturns(errors.New("error creating resource"))
+		})
+
+		It("returns an error", func() {
+			Expect(c.Writer.Status()).To(Equal(http.StatusInternalServerError))
+			Expect(c.Errors.Last().Error()).To(Equal("error creating resource"))
+		})
+	})
+
 	When("the kind is not supported to scale", func() {
 		BeforeEach(func() {
 			scaleManifestRequest.ManifestName = "not-supported-kind test-name"

--- a/pkg/http/core/task.go
+++ b/pkg/http/core/task.go
@@ -31,15 +31,7 @@ func GetTask(c *gin.Context) {
 	}
 
 	if len(resources) == 0 {
-		// if strings.Contains(id, "-") {
-		// 	c.JSON(http.StatusOK, clouddriver.NewDefaultTask(id))
-		// } else {
-		c.JSON(http.StatusNotFound, clouddriver.NewError(
-			http.StatusText(http.StatusNotFound),
-			fmt.Sprintf("Task not found (id: %s)", id),
-			http.StatusNotFound,
-		))
-		// }
+		clouddriver.Error(c, http.StatusNotFound, fmt.Errorf("Task not found (id: %s)", id))
 		return
 	}
 

--- a/pkg/http/core/task.go
+++ b/pkg/http/core/task.go
@@ -30,10 +30,16 @@ func GetTask(c *gin.Context) {
 		return
 	}
 
-	// If there were no kubernetes resources associated with this task ID,
-	// return the default task.
 	if len(resources) == 0 {
-		c.JSON(http.StatusOK, clouddriver.NewDefaultTask(id))
+		// if strings.Contains(id, "-") {
+		// 	c.JSON(http.StatusOK, clouddriver.NewDefaultTask(id))
+		// } else {
+		c.JSON(http.StatusNotFound, clouddriver.NewError(
+			http.StatusText(http.StatusNotFound),
+			fmt.Sprintf("Task not found (id: %s)", id),
+			http.StatusNotFound,
+		))
+		// }
 		return
 	}
 

--- a/pkg/http/core/task_test.go
+++ b/pkg/http/core/task_test.go
@@ -45,8 +45,8 @@ var _ = Describe("Task", func() {
 				fakeSQLClient.ListKubernetesResourcesByTaskIDReturns([]kubernetes.Resource{}, nil)
 			})
 
-			It("returns status internal server error", func() {
-				Expect(res.StatusCode).To(Equal(http.StatusOK))
+			It("returns not found error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusNotFound))
 			})
 		})
 


### PR DESCRIPTION
Returns a `404 Not Found` for a `GET /task/:id` request when no kubernetes resources exist for the task ID.

Currently, when a task is not found, it returns a `200 OK` with a default response payload, which was masking the fact that not all `/kubernetes/ops` requests were creating kubernetes resource entries, so these were corrected.