### PR TITLE
Spinnaker strategy use-source-capacity

### DIFF
--- a/pkg/kubernetes/strategy.go
+++ b/pkg/kubernetes/strategy.go
@@ -1,0 +1,85 @@
+package kubernetes
+
+import (
+	"strconv"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	AnnotationSpinnakerMaxVersionHistory = "strategy.spinnaker.io/max-version-history"
+	AnnotationSpinnakerRecreate          = "strategy.spinnaker.io/recreate"
+	AnnotationSpinnakerReplaced          = "strategy.spinnaker.io/replace"
+	AnnotationSpinnakerUseSourceCapacity = "strategy.spinnaker.io/use-source-capacity"
+)
+
+// GetMaxVersionHistory returns true if the value of the annotation
+// `strategy.spinnaker.io/max-version-history` of the given Kubernetes
+// unstructured resource, or 0 if annotation is not present.
+//
+// See https://spinnaker.io/docs/reference/providers/kubernetes-v2/#strategy for more info.
+func GetMaxVersionHistory(u unstructured.Unstructured) (maxVersionHistory int, err error) {
+	maxVersionHistory = 0
+
+	annotations := u.GetAnnotations()
+	if annotations != nil {
+		if value, ok := annotations[AnnotationSpinnakerMaxVersionHistory]; ok {
+			maxVersionHistory, err = strconv.Atoi(value)
+			if err != nil {
+				return
+			}
+		}
+	}
+
+	return
+}
+
+// Recreate returns true if the given Kubernetes unstructured resource
+// has the annotation `strategy.spinnaker.io/recreate` set to "true".
+//
+// See https://spinnaker.io/docs/reference/providers/kubernetes-v2/#strategy for more info.
+func Recreate(u unstructured.Unstructured) bool {
+	annotations := u.GetAnnotations()
+	if annotations != nil {
+		if value, ok := annotations[AnnotationSpinnakerRecreate]; ok {
+			return value == "true"
+		}
+	}
+
+	return false
+}
+
+// Replace returns true if the given Kubernetes unstructured resource
+// has the annotation `strategy.spinnaker.io/replace` set to "true".
+//
+// See https://spinnaker.io/docs/reference/providers/kubernetes-v2/#strategy for more info.
+func Replace(u unstructured.Unstructured) bool {
+	annotations := u.GetAnnotations()
+	if annotations != nil {
+		if value, ok := annotations[AnnotationSpinnakerReplaced]; ok {
+			return value == "true"
+		}
+	}
+
+	return false
+}
+
+// UseSourceCapacity returns true is a given Kubernetes unstructured resource
+// has the annotation `strategy.spinnaker.io/use-source-capacity` set to "true"
+// and it is of kind Deployment, ReplicaSet, or StatefulSet.
+//
+// See https://spinnaker.io/docs/reference/providers/kubernetes-v2/#strategy for more info.
+func UseSourceCapacity(u unstructured.Unstructured) bool {
+	switch strings.ToLower(u.GetKind()) {
+	case "deployment", "replicaset", "statefulset":
+		annotations := u.GetAnnotations()
+		if annotations != nil {
+			if value, ok := annotations[AnnotationSpinnakerUseSourceCapacity]; ok {
+				return value == "true"
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/kubernetes/strategy_test.go
+++ b/pkg/kubernetes/strategy_test.go
@@ -1,0 +1,314 @@
+package kubernetes_test
+
+import (
+	. "github.com/homedepot/go-clouddriver/pkg/kubernetes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("Strategy", func() {
+
+	var (
+		err               error
+		fakeResource      unstructured.Unstructured
+		maxVersionHistory int
+		recreate          bool
+		replace           bool
+		useSourceCapacity bool
+	)
+
+	Context("#GetMaxVersionHistory", func() {
+		JustBeforeEach(func() {
+			maxVersionHistory, err = GetMaxVersionHistory(fakeResource)
+		})
+
+		When("annotation is missing", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+					},
+				}
+			})
+
+			It("returns 0", func() {
+				Expect(maxVersionHistory).To(Equal(0))
+				Expect(err).To(BeNil())
+			})
+		})
+
+		When("annotation is set to a non-integer", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"strategy.spinnaker.io/max-version-history": "one",
+							},
+						},
+					},
+				}
+			})
+
+			It("errors", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(maxVersionHistory).To(Equal(0))
+			})
+		})
+
+		When("annotation is set to an integer", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"strategy.spinnaker.io/max-version-history": "5",
+							},
+						},
+					},
+				}
+			})
+
+			It("succeeds", func() {
+				Expect(maxVersionHistory).To(Equal(5))
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+
+	Context("#Recreate", func() {
+		JustBeforeEach(func() {
+			recreate = Recreate(fakeResource)
+		})
+
+		When("annotation is missing", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+					},
+				}
+			})
+
+			It("returns false", func() {
+				Expect(recreate).To(Equal(false))
+			})
+		})
+
+		When("annotation is set to false", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"strategy.spinnaker.io/recreate": "false",
+							},
+						},
+					},
+				}
+			})
+
+			It("returns false", func() {
+				Expect(recreate).To(Equal(false))
+			})
+		})
+
+		When("annotation is set to true", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"strategy.spinnaker.io/recreate": "true",
+							},
+						},
+					},
+				}
+			})
+
+			It("returns true", func() {
+				Expect(recreate).To(Equal(true))
+			})
+		})
+	})
+
+	Context("#Replace", func() {
+		JustBeforeEach(func() {
+			replace = Replace(fakeResource)
+		})
+
+		When("annotation is missing", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+					},
+				}
+			})
+
+			It("returns false", func() {
+				Expect(replace).To(Equal(false))
+			})
+		})
+
+		When("annotation is set to false", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"strategy.spinnaker.io/replace": "false",
+							},
+						},
+					},
+				}
+			})
+
+			It("returns false", func() {
+				Expect(replace).To(Equal(false))
+			})
+		})
+
+		When("annotation is set to true", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"strategy.spinnaker.io/replace": "true",
+							},
+						},
+					},
+				}
+			})
+
+			It("returns true", func() {
+				Expect(replace).To(Equal(true))
+			})
+		})
+	})
+
+	Context("#UseSourceCapacity", func() {
+		JustBeforeEach(func() {
+			useSourceCapacity = UseSourceCapacity(fakeResource)
+		})
+
+		When("annotation is missing", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+					},
+				}
+			})
+
+			It("returns false", func() {
+				Expect(useSourceCapacity).To(Equal(false))
+			})
+		})
+
+		When("annotation is false", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"strategy.spinnaker.io/use-source-capacity": "false",
+							},
+						},
+					},
+				}
+			})
+
+			It("returns false", func() {
+				Expect(useSourceCapacity).To(Equal(false))
+			})
+		})
+
+		When("annotation is true", func() {
+			When("kind is pod", func() {
+				BeforeEach(func() {
+					fakeResource = unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": "Pod",
+							"metadata": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"strategy.spinnaker.io/use-source-capacity": "true",
+								},
+							},
+						},
+					}
+				})
+
+				It("returns false", func() {
+					Expect(UseSourceCapacity(fakeResource)).To(Equal(false))
+				})
+			})
+
+			When("kind is deployment", func() {
+				BeforeEach(func() {
+					fakeResource = unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": "Deployment",
+							"metadata": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"strategy.spinnaker.io/use-source-capacity": "true",
+								},
+							},
+						},
+					}
+				})
+
+				It("returns true", func() {
+					Expect(UseSourceCapacity(fakeResource)).To(Equal(true))
+				})
+			})
+
+			When("kind is replicaSet", func() {
+				BeforeEach(func() {
+					fakeResource = unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": "ReplicaSet",
+							"metadata": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"strategy.spinnaker.io/use-source-capacity": "true",
+								},
+							},
+						},
+					}
+				})
+
+				It("returns true", func() {
+					Expect(UseSourceCapacity(fakeResource)).To(Equal(true))
+				})
+			})
+
+			When("kind is statefuleSet", func() {
+				BeforeEach(func() {
+					fakeResource = unstructured.Unstructured{
+						Object: map[string]interface{}{
+							"kind": "StatefulSet",
+							"metadata": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"strategy.spinnaker.io/use-source-capacity": "true",
+								},
+							},
+						},
+					}
+				})
+
+				It("returns true", func() {
+					Expect(UseSourceCapacity(fakeResource)).To(Equal(true))
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
This PR:
- Implements support of the `strategy.spinnaker.io/use-source-capacity` annotation as described in [Spinnaker docs](https://spinnaker.io/docs/reference/providers/kubernetes-v2/#strategy)
- Although `use-source-capacity` is the only strategy annotation implements, the `strategy.go` file contains functions for retrieving the remaining Spinnaker strategy annotations, which can be used in the future
   - max-version-history
   - release
   - replace
