### PR TITLE
Support scaling replicaSets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,8 @@ lint:
 		--enable misspell \
 		--enable wsl \
 		--print-issued-lines=false \
+		--skip-files .*_test.go \
+		--timeout=3m0s \
 		--out-format=colored-line-number \
 		--issues-exit-code=1 ./...
 
@@ -30,4 +32,4 @@ tools:
 vendor:
 	go mod vendor
 
-.PHONEY: all clean build lint run test tools
+.PHONY: all clean build lint run test tools

--- a/pkg/http/core/kubernetes/scale.go
+++ b/pkg/http/core/kubernetes/scale.go
@@ -69,9 +69,8 @@ func Scale(c *gin.Context, sm ScaleManifestRequest) {
 
 	var meta kube.Metadata
 
-	// TODO need to allow scaling for additional kinds.
 	switch strings.ToLower(kind) {
-	case "deployment", "statefulset":
+	case "deployment", "replicaset", "statefulset":
 		r, err := strconv.Atoi(sm.Replicas)
 		if err != nil {
 			clouddriver.Error(c, http.StatusBadRequest, err)

--- a/pkg/http/core/kubernetes/scale_test.go
+++ b/pkg/http/core/kubernetes/scale_test.go
@@ -118,6 +118,17 @@ var _ = Describe("Scale", func() {
 			Expect(c.Errors.Last().Error()).To(Equal("scaling kind not-supported-kind not currently supported"))
 		})
 	})
+
+	When("The kind is ReplicaSet", func() {
+		BeforeEach(func() {
+			scaleManifestRequest.ManifestName = "replicaset someReplicaSet"
+		})
+
+		It("succeeds", func() {
+			Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+		})
+	})
+
 	When("The kind is StatefulSet", func() {
 		BeforeEach(func() {
 			scaleManifestRequest.ManifestName = "statefulset someStatefulSet"


### PR DESCRIPTION
This PR:
- Adds support for scaling replicaSets
- Updates Makefile linter
   - Skip tests
   - Extends timeout
