### PR TITLE
Use application annotation to filter on Clusters page

### DIFF
--- a/internal/api/core/applications.go
+++ b/internal/api/core/applications.go
@@ -942,8 +942,8 @@ func newServerGroup(result unstructured.Unstructured, serverGroupMap map[string]
 		}
 	}
 
-	cluster := annotations["moniker.spinnaker.io/cluster"]
-	app := annotations["moniker.spinnaker.io/application"]
+	cluster := annotations[kubernetes.AnnotationSpinnakerMonikerCluster]
+	app := annotations[kubernetes.AnnotationSpinnakerMonikerApplication]
 	sequence := sequence(annotations)
 
 	return ServerGroup{
@@ -1128,10 +1128,6 @@ func (cc *Controller) GetServerGroup(c *gin.Context) {
 		return
 	}
 
-	lo := metav1.ListOptions{
-		LabelSelector: kubernetes.LabelKubernetesName + "=" + application,
-	}
-
 	result, err := provider.Client.Get(kind, name, location)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
@@ -1141,6 +1137,11 @@ func (cc *Controller) GetServerGroup(c *gin.Context) {
 	// Declare a context with timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*defaultListTimeoutSeconds)
 	defer cancel()
+	// Declare a label selector.
+	lo := metav1.ListOptions{
+		LabelSelector: kubernetes.DefaultLabelSelector(),
+		FieldSelector: "metadata.namespace=" + location,
+	}
 	// "Instances" in kubernetes are pods.
 	pods, err := provider.Client.ListResourceWithContext(ctx, "pods", lo)
 	if err != nil {
@@ -1426,7 +1427,7 @@ func list(wg *sync.WaitGroup, rc chan resource,
 	defer wg.Done()
 	// Declare server side filtering options.
 	lo := metav1.ListOptions{
-		LabelSelector: kubernetes.LabelKubernetesName + "=" + application,
+		LabelSelector: kubernetes.DefaultLabelSelector(),
 	}
 	// Declare a context with timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*defaultListTimeoutSeconds)
@@ -1438,6 +1439,9 @@ func list(wg *sync.WaitGroup, rc chan resource,
 		clouddriver.Log(err)
 		return
 	}
+	// Filter the results to only the application annotation requested.
+	ul.Items = kubernetes.FilterOnAnnotation(ul.Items,
+		kubernetes.AnnotationSpinnakerMonikerApplication, application)
 	// Send all unstructured objects to the channel.
 	for _, u := range ul.Items {
 		res := resource{

--- a/internal/api/core/applications.go
+++ b/internal/api/core/applications.go
@@ -1149,6 +1149,9 @@ func (cc *Controller) GetServerGroup(c *gin.Context) {
 		return
 	}
 
+	// Filter the results to only the application annotation requested.
+	pods.Items = kubernetes.FilterOnAnnotation(pods.Items,
+		kubernetes.AnnotationSpinnakerMonikerApplication, application)
 	instanceCounts := InstanceCounts{}
 	images := listImages(result)
 	desired := getDesiredReplicasCount(result)
@@ -1234,8 +1237,8 @@ func newPodInstance(p *kubernetes.Pod, application, account string) Instance {
 	}
 
 	annotations := p.Object().ObjectMeta.Annotations
-	cluster := annotations["moniker.spinnaker.io/cluster"]
-	app := annotations["moniker.spinnaker.io/application"]
+	cluster := annotations[kubernetes.AnnotationSpinnakerMonikerCluster]
+	app := annotations[kubernetes.AnnotationSpinnakerMonikerApplication]
 
 	if app == "" {
 		app = application

--- a/internal/api/core/applications_test.go
+++ b/internal/api/core/applications_test.go
@@ -1147,6 +1147,9 @@ var _ = Describe("Application", func() {
 								"name":              "test-pod1",
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
@@ -1169,6 +1172,9 @@ var _ = Describe("Application", func() {
 								"name":              "test-pod1",
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
@@ -1191,6 +1197,9 @@ var _ = Describe("Application", func() {
 								"name":              "test-pod1",
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
@@ -1221,7 +1230,7 @@ var _ = Describe("Application", func() {
 									"artifact.spinnaker.io/name":       "test-deployment1",
 									"artifact.spinnaker.io/type":       "kubernetes/deployment",
 									"artifact.spinnaker.io/location":   "test-namespace1",
-									"moniker.spinnaker.io/application": "test-deployment1",
+									"moniker.spinnaker.io/application": "test-application",
 									"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
 									"moniker.spinnaker.io/sequence":    "19",
 								},
@@ -1276,7 +1285,7 @@ var _ = Describe("Application", func() {
 									"artifact.spinnaker.io/name":        "test-deployment1",
 									"artifact.spinnaker.io/type":        "kubernetes/deployment",
 									"artifact.spinnaker.io/location":    "test-namespace1",
-									"moniker.spinnaker.io/application":  "test-deployment1",
+									"moniker.spinnaker.io/application":  "test-application",
 									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 									"deployment.kubernetes.io/revision": "19",
 								},
@@ -1320,7 +1329,7 @@ var _ = Describe("Application", func() {
 									"artifact.spinnaker.io/name":        "test-deployment1",
 									"artifact.spinnaker.io/type":        "kubernetes/deployment",
 									"artifact.spinnaker.io/location":    "test-namespace1",
-									"moniker.spinnaker.io/application":  "test-deployment1",
+									"moniker.spinnaker.io/application":  "test-application",
 									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 									"deployment.kubernetes.io/revision": "19",
 								},
@@ -1364,6 +1373,9 @@ var _ = Describe("Application", func() {
 								"name":      "test-svc1",
 								"namespace": "test-namespace1",
 								"uid":       "test-uid4",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 							},
 							"spec": map[string]interface{}{
 								"selector": map[string]interface{}{
@@ -1380,6 +1392,9 @@ var _ = Describe("Application", func() {
 								"name":      "test-svc2",
 								"namespace": "test-namespace1",
 								"uid":       "test-uid5",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 							},
 							"spec": map[string]interface{}{
 								"selector": map[string]interface{}{
@@ -1797,7 +1812,7 @@ var _ = Describe("Application", func() {
 			})
 		})
 
-		When("it succeeds", func() {
+		FWhen("it succeeds", func() {
 			It("succeeds", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusOK))
 				validateResponse(payloadListServerGroups)

--- a/internal/api/core/applications_test.go
+++ b/internal/api/core/applications_test.go
@@ -1,8 +1,6 @@
 package core_test
 
 import (
-	// . "github.com/homedepot/go-clouddriver/internal/api/v0"
-
 	"errors"
 	"io/ioutil"
 	"log"
@@ -121,6 +119,27 @@ var _ = Describe("Application", func() {
 								"name":              "test-deployment1",
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "wrong-application",
+								},
+								"labels": map[string]interface{}{
+									"label1": "test-label1",
+								},
+								"uid": "test-uid1",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Deployment",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-deployment1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
@@ -136,6 +155,9 @@ var _ = Describe("Application", func() {
 								"name":              "test-deployment2",
 								"namespace":         "test-namespace2",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label2",
 								},
@@ -155,6 +177,30 @@ var _ = Describe("Application", func() {
 								"name":      "test-rs1",
 								"namespace": "test-namespace1",
 								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application":  "wrong-application",
+									"artifact.spinnaker.io/name":        "test-deployment1",
+									"artifact.spinnaker.io/type":        "kubernetes/deployment",
+									"deployment.kubernetes.io/revision": "236",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-rs1",
+										"kind": "replicaSet",
+										"uid":  "test-uid1",
+									},
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-rs1",
+								"namespace": "test-namespace1",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application":  "test-application",
 									"artifact.spinnaker.io/name":        "test-deployment1",
 									"artifact.spinnaker.io/type":        "kubernetes/deployment",
 									"deployment.kubernetes.io/revision": "236",
@@ -246,6 +292,27 @@ var _ = Describe("Application", func() {
 									"name":              "test-deployment3",
 									"namespace":         "test-namespace3",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "wrong-application",
+									},
+									"labels": map[string]interface{}{
+										"label1": "test-label3",
+									},
+									"uid": "test-uid3",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "Deployment",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-deployment3",
+									"namespace":         "test-namespace3",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label3",
 									},
@@ -261,6 +328,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-deployment4",
 									"namespace":         "test-namespace2",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label2",
 									},
@@ -276,6 +346,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-deployment1",
 									"namespace":         "test-namespace1",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label1",
 									},
@@ -291,6 +364,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-deployment2",
 									"namespace":         "test-namespace2",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label2",
 									},
@@ -310,6 +386,30 @@ var _ = Describe("Application", func() {
 									"name":      "test-rs4",
 									"namespace": "test-namespace2",
 									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application":  "wrong-application",
+										"artifact.spinnaker.io/name":        "test-deployment2",
+										"artifact.spinnaker.io/type":        "kubernetes/deployment",
+										"deployment.kubernetes.io/revision": "236",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-rs2",
+											"kind": "Deployment",
+											"uid":  "test-uid2",
+										},
+									},
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "ReplicaSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":      "test-rs4",
+									"namespace": "test-namespace2",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application":  "test-application",
 										"artifact.spinnaker.io/name":        "test-deployment2",
 										"artifact.spinnaker.io/type":        "kubernetes/deployment",
 										"deployment.kubernetes.io/revision": "236",
@@ -332,6 +432,7 @@ var _ = Describe("Application", func() {
 									"name":      "test-rs3",
 									"namespace": "test-namespace3",
 									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application":  "test-application",
 										"artifact.spinnaker.io/name":        "test-deployment3",
 										"artifact.spinnaker.io/type":        "kubernetes/deployment",
 										"deployment.kubernetes.io/revision": "236",
@@ -354,6 +455,7 @@ var _ = Describe("Application", func() {
 									"name":      "test-rs2",
 									"namespace": "test-namespace2",
 									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application":  "test-application",
 										"artifact.spinnaker.io/name":        "test-deployment2",
 										"artifact.spinnaker.io/type":        "kubernetes/deployment",
 										"deployment.kubernetes.io/revision": "236",
@@ -376,6 +478,7 @@ var _ = Describe("Application", func() {
 									"name":      "test-rs1",
 									"namespace": "test-namespace1",
 									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application":  "test-application",
 										"artifact.spinnaker.io/name":        "test-deployment1",
 										"artifact.spinnaker.io/type":        "kubernetes/deployment",
 										"deployment.kubernetes.io/revision": "236",
@@ -427,6 +530,9 @@ var _ = Describe("Application", func() {
 								"name":              "test-pod1",
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "wrong-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
@@ -449,6 +555,34 @@ var _ = Describe("Application", func() {
 								"name":              "test-pod1",
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
+								"labels": map[string]interface{}{
+									"label1": "test-label1",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-rs1",
+										"kind": "replicaSet",
+										"uid":  "test-uid1",
+									},
+								},
+								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
@@ -471,6 +605,9 @@ var _ = Describe("Application", func() {
 								"name":              "test-pod1",
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
@@ -497,6 +634,27 @@ var _ = Describe("Application", func() {
 								"name":              "test-ingress1",
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "wrong-application",
+								},
+								"labels": map[string]interface{}{
+									"label1": "test-label1",
+								},
+								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Ingress",
+							"apiVersion": "networking.k8s.io/v1beta1",
+							"metadata": map[string]interface{}{
+								"name":              "test-ingress1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
@@ -513,6 +671,27 @@ var _ = Describe("Application", func() {
 							"kind":       "Service",
 							"apiVersion": "v1",
 							"metadata": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "wrong-application",
+								},
+								"name":      "test-service1",
+								"namespace": "test-namespace1",
+							},
+							"spec": map[string]interface{}{
+								"selector": map[string]interface{}{
+									"test": "label",
+								},
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Service",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"name":      "test-service1",
 								"namespace": "test-namespace1",
 							},
@@ -539,7 +718,58 @@ var _ = Describe("Application", func() {
 									"artifact.spinnaker.io/name":       "test-deployment1",
 									"artifact.spinnaker.io/type":       "kubernetes/deployment",
 									"artifact.spinnaker.io/location":   "test-namespace1",
-									"moniker.spinnaker.io/application": "test-deployment1",
+									"moniker.spinnaker.io/application": "wrong-application",
+									"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
+									"moniker.spinnaker.io/sequence":    "19",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-deployment1",
+										"kind": "Deployment",
+										"uid":  "test-uid3",
+									},
+								},
+								"uid": "test-uid1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"test": "label",
+										},
+									},
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-rs1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":       "test-deployment1",
+									"artifact.spinnaker.io/type":       "kubernetes/deployment",
+									"artifact.spinnaker.io/location":   "test-namespace1",
+									"moniker.spinnaker.io/application": "test-application",
 									"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
 									"moniker.spinnaker.io/sequence":    "19",
 								},
@@ -594,7 +824,46 @@ var _ = Describe("Application", func() {
 									"artifact.spinnaker.io/name":        "test-deployment1",
 									"artifact.spinnaker.io/type":        "kubernetes/deployment",
 									"artifact.spinnaker.io/location":    "test-namespace1",
-									"moniker.spinnaker.io/application":  "test-deployment1",
+									"moniker.spinnaker.io/application":  "wrong-application",
+									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
+									"deployment.kubernetes.io/revision": "19",
+								},
+								"uid": "test-uid3",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "StatefulSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-rs1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":        "test-deployment1",
+									"artifact.spinnaker.io/type":        "kubernetes/deployment",
+									"artifact.spinnaker.io/location":    "test-namespace1",
+									"moniker.spinnaker.io/application":  "test-application",
 									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 									"deployment.kubernetes.io/revision": "19",
 								},
@@ -633,7 +902,7 @@ var _ = Describe("Application", func() {
 									"artifact.spinnaker.io/name":        "test-deployment1",
 									"artifact.spinnaker.io/type":        "kubernetes/deployment",
 									"artifact.spinnaker.io/location":    "test-namespace1",
-									"moniker.spinnaker.io/application":  "test-deployment1",
+									"moniker.spinnaker.io/application":  "test-application",
 									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 									"deployment.kubernetes.io/revision": "19",
 								},
@@ -734,6 +1003,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-pod1",
 									"namespace":         "test-namespace1",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "wrong-application",
+									},
 									"labels": map[string]interface{}{
 										"test": "label3",
 									},
@@ -756,6 +1028,34 @@ var _ = Describe("Application", func() {
 									"name":              "test-pod1",
 									"namespace":         "test-namespace1",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
+									"labels": map[string]interface{}{
+										"test": "label3",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-rs1",
+											"kind": "replicaSet",
+											"uid":  "test-uid11",
+										},
+									},
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "Pod",
+								"apiVersion": "v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-pod1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"test": "label2",
 									},
@@ -778,6 +1078,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-pod1",
 									"namespace":         "test-namespace1",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"test": "label1",
 									},
@@ -804,6 +1107,27 @@ var _ = Describe("Application", func() {
 									"name":              "test-ingress3",
 									"namespace":         "test-namespace2",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "wrong-application",
+									},
+									"labels": map[string]interface{}{
+										"label1": "test-label1",
+									},
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "Ingress",
+								"apiVersion": "networking.k8s.io/v1beta1",
+								"metadata": map[string]interface{}{
+									"name":              "test-ingress3",
+									"namespace":         "test-namespace2",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label1",
 									},
@@ -819,6 +1143,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-ingress2",
 									"namespace":         "test-namespace2",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label1",
 									},
@@ -834,6 +1161,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-ingress1",
 									"namespace":         "test-namespace1",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label1",
 									},
@@ -850,6 +1180,9 @@ var _ = Describe("Application", func() {
 								"kind":       "Service",
 								"apiVersion": "v1",
 								"metadata": map[string]interface{}{
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "wrong-application",
+									},
 									"name":      "test-service3",
 									"namespace": "test-namespace2",
 									"uid":       "aec15437-4e6a-11ea-9788-4201ac100006",
@@ -866,6 +1199,28 @@ var _ = Describe("Application", func() {
 								"kind":       "Service",
 								"apiVersion": "v1",
 								"metadata": map[string]interface{}{
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
+									"name":      "test-service3",
+									"namespace": "test-namespace2",
+									"uid":       "aec15437-4e6a-11ea-9788-4201ac100006",
+								},
+								"spec": map[string]interface{}{
+									"selector": map[string]interface{}{
+										"test": "label",
+									},
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "Service",
+								"apiVersion": "v1",
+								"metadata": map[string]interface{}{
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"name":      "test-service2",
 									"namespace": "test-namespace2",
 									"uid":       "bec15437-4e6a-11ea-9788-4201ac100006",
@@ -882,6 +1237,9 @@ var _ = Describe("Application", func() {
 								"kind":       "Service",
 								"apiVersion": "v1",
 								"metadata": map[string]interface{}{
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"name":      "test-service1",
 									"namespace": "test-namespace1",
 									"uid":       "cec15437-4e6a-11ea-9788-4201ac100006",
@@ -909,7 +1267,58 @@ var _ = Describe("Application", func() {
 										"artifact.spinnaker.io/name":       "test-deployment1",
 										"artifact.spinnaker.io/type":       "kubernetes/deployment",
 										"artifact.spinnaker.io/location":   "test-namespace1",
-										"moniker.spinnaker.io/application": "test-deployment1",
+										"moniker.spinnaker.io/application": "wrong-application",
+										"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
+										"moniker.spinnaker.io/sequence":    "19",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-deployment1",
+											"kind": "Deployment",
+											"uid":  "test-uid3",
+										},
+									},
+									"uid": "test-uid11",
+								},
+								"spec": map[string]interface{}{
+									"replicas": 1,
+									"template": map[string]interface{}{
+										"metadata": map[string]interface{}{
+											"labels": map[string]interface{}{
+												"test": "label1",
+											},
+										},
+										"spec": map[string]interface{}{
+											"containers": []map[string]interface{}{
+												{
+													"image": "test-image1",
+												},
+												{
+													"image": "test-image2",
+												},
+											},
+										},
+									},
+								},
+								"status": map[string]interface{}{
+									"replicas":      1,
+									"readyReplicas": 0,
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "ReplicaSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-rs1",
+									"namespace":         "test-namespace2",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"artifact.spinnaker.io/name":       "test-deployment1",
+										"artifact.spinnaker.io/type":       "kubernetes/deployment",
+										"artifact.spinnaker.io/location":   "test-namespace1",
+										"moniker.spinnaker.io/application": "test-application",
 										"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
 										"moniker.spinnaker.io/sequence":    "19",
 									},
@@ -964,7 +1373,51 @@ var _ = Describe("Application", func() {
 										"artifact.spinnaker.io/name":        "test-deployment1",
 										"artifact.spinnaker.io/type":        "kubernetes/deployment",
 										"artifact.spinnaker.io/location":    "test-namespace1",
-										"moniker.spinnaker.io/application":  "test-deployment1",
+										"moniker.spinnaker.io/application":  "wrong-application",
+										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
+										"deployment.kubernetes.io/revision": "19",
+									},
+									"uid": "test-uid3",
+								},
+								"spec": map[string]interface{}{
+									"replicas": 1,
+									"template": map[string]interface{}{
+										"metadata": map[string]interface{}{
+											"labels": map[string]interface{}{
+												"test": "label2",
+											},
+										},
+										"spec": map[string]interface{}{
+											"containers": []map[string]interface{}{
+												{
+													"image": "test-image1",
+												},
+												{
+													"image": "test-image2",
+												},
+											},
+										},
+									},
+								},
+								"status": map[string]interface{}{
+									"replicas":      1,
+									"readyReplicas": 0,
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "StatefulSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-sts1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"artifact.spinnaker.io/name":        "test-deployment1",
+										"artifact.spinnaker.io/type":        "kubernetes/deployment",
+										"artifact.spinnaker.io/location":    "test-namespace1",
+										"moniker.spinnaker.io/application":  "test-application",
 										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 										"deployment.kubernetes.io/revision": "19",
 									},
@@ -1008,7 +1461,7 @@ var _ = Describe("Application", func() {
 										"artifact.spinnaker.io/name":        "test-deployment1",
 										"artifact.spinnaker.io/type":        "kubernetes/deployment",
 										"artifact.spinnaker.io/location":    "test-namespace1",
-										"moniker.spinnaker.io/application":  "test-deployment1",
+										"moniker.spinnaker.io/application":  "test-application",
 										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 										"deployment.kubernetes.io/revision": "19",
 									},
@@ -1148,6 +1601,31 @@ var _ = Describe("Application", func() {
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
 								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "wrong-application",
+								},
+								"labels": map[string]interface{}{
+									"label1": "test-label1",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-rs1",
+										"kind": "replicaSet",
+										"uid":  "test-uid1",
+									},
+								},
+								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
 									"moniker.spinnaker.io/application": "test-application",
 								},
 								"labels": map[string]interface{}{
@@ -1230,6 +1708,57 @@ var _ = Describe("Application", func() {
 									"artifact.spinnaker.io/name":       "test-deployment1",
 									"artifact.spinnaker.io/type":       "kubernetes/deployment",
 									"artifact.spinnaker.io/location":   "test-namespace1",
+									"moniker.spinnaker.io/application": "wrong-application",
+									"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
+									"moniker.spinnaker.io/sequence":    "19",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-deployment1",
+										"kind": "Deployment",
+										"uid":  "test-uid3",
+									},
+								},
+								"uid": "test-uid1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"test": "label",
+										},
+									},
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-rs1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":       "test-deployment1",
+									"artifact.spinnaker.io/type":       "kubernetes/deployment",
+									"artifact.spinnaker.io/location":   "test-namespace1",
 									"moniker.spinnaker.io/application": "test-application",
 									"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
 									"moniker.spinnaker.io/sequence":    "19",
@@ -1273,6 +1802,46 @@ var _ = Describe("Application", func() {
 			}, nil)
 			fakeKubeClient.ListResourceWithContextReturnsOnCall(2, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"kind":       "DaemonSet",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-ds1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":        "test-deployment1",
+									"artifact.spinnaker.io/type":        "kubernetes/deployment",
+									"artifact.spinnaker.io/location":    "test-namespace1",
+									"moniker.spinnaker.io/application":  "wrong-application",
+									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
+									"deployment.kubernetes.io/revision": "19",
+								},
+								"uid": "test-uid2",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"desiredNumberScheduled": 2,
+								"currentNumberScheduled": 1,
+								"numberReady":            1,
+							},
+						},
+					},
 					{
 						Object: map[string]interface{}{
 							"kind":       "DaemonSet",
@@ -1329,6 +1898,50 @@ var _ = Describe("Application", func() {
 									"artifact.spinnaker.io/name":        "test-deployment1",
 									"artifact.spinnaker.io/type":        "kubernetes/deployment",
 									"artifact.spinnaker.io/location":    "test-namespace1",
+									"moniker.spinnaker.io/application":  "wrong-application",
+									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
+									"deployment.kubernetes.io/revision": "19",
+								},
+								"uid": "test-uid3",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"test": "label2",
+										},
+									},
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "StatefulSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-sts1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":        "test-deployment1",
+									"artifact.spinnaker.io/type":        "kubernetes/deployment",
+									"artifact.spinnaker.io/location":    "test-namespace1",
 									"moniker.spinnaker.io/application":  "test-application",
 									"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 									"deployment.kubernetes.io/revision": "19",
@@ -1365,6 +1978,25 @@ var _ = Describe("Application", func() {
 			}, nil)
 			fakeKubeClient.ListResourceWithContextReturnsOnCall(4, &unstructured.UnstructuredList{
 				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"kind":       "Service",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-svc1",
+								"namespace": "test-namespace1",
+								"uid":       "test-uid4",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "wrong-application",
+								},
+							},
+							"spec": map[string]interface{}{
+								"selector": map[string]interface{}{
+									"test": "label",
+								},
+							},
+						},
+					},
 					{
 						Object: map[string]interface{}{
 							"kind":       "Service",
@@ -1484,6 +2116,34 @@ var _ = Describe("Application", func() {
 									"name":              "test-pod3",
 									"namespace":         "test-namespace1",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "wrong-application",
+									},
+									"labels": map[string]interface{}{
+										"label1": "test-label1",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-rs1",
+											"kind": "replicaSet",
+											"uid":  "test-uid1",
+										},
+									},
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "Pod",
+								"apiVersion": "v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-pod3",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label1",
 									},
@@ -1506,6 +2166,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-pod4",
 									"namespace":         "test-namespace1",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label1",
 									},
@@ -1528,6 +2191,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-pod3",
 									"namespace":         "test-namespace1",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label1",
 									},
@@ -1550,6 +2216,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-pod2",
 									"namespace":         "test-namespace1",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label1",
 									},
@@ -1572,6 +2241,9 @@ var _ = Describe("Application", func() {
 									"name":              "test-pod1",
 									"namespace":         "test-namespace1",
 									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
 									"labels": map[string]interface{}{
 										"label1": "test-label1",
 									},
@@ -1602,7 +2274,53 @@ var _ = Describe("Application", func() {
 										"artifact.spinnaker.io/name":       "test-deployment1",
 										"artifact.spinnaker.io/type":       "kubernetes/deployment",
 										"artifact.spinnaker.io/location":   "test-namespace1",
-										"moniker.spinnaker.io/application": "test-deployment1",
+										"moniker.spinnaker.io/application": "wrong-application",
+										"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
+										"moniker.spinnaker.io/sequence":    "19",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-deployment1",
+											"kind": "Deployment",
+											"uid":  "test-uid3",
+										},
+									},
+									"uid": "test-uid1",
+								},
+								"spec": map[string]interface{}{
+									"replicas": 1,
+									"template": map[string]interface{}{
+										"spec": map[string]interface{}{
+											"containers": []map[string]interface{}{
+												{
+													"image": "test-image1",
+												},
+												{
+													"image": "test-image2",
+												},
+											},
+										},
+									},
+								},
+								"status": map[string]interface{}{
+									"replicas":      1,
+									"readyReplicas": 0,
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "ReplicaSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-rs1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"artifact.spinnaker.io/name":       "test-deployment1",
+										"artifact.spinnaker.io/type":       "kubernetes/deployment",
+										"artifact.spinnaker.io/location":   "test-namespace1",
+										"moniker.spinnaker.io/application": "test-application",
 										"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
 										"moniker.spinnaker.io/sequence":    "19",
 									},
@@ -1652,7 +2370,47 @@ var _ = Describe("Application", func() {
 										"artifact.spinnaker.io/name":        "test-deployment1",
 										"artifact.spinnaker.io/type":        "kubernetes/deployment",
 										"artifact.spinnaker.io/location":    "test-namespace1",
-										"moniker.spinnaker.io/application":  "test-deployment1",
+										"moniker.spinnaker.io/application":  "wrong-application",
+										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
+										"deployment.kubernetes.io/revision": "19",
+									},
+									"uid": "test-uid2",
+								},
+								"spec": map[string]interface{}{
+									"replicas": 1,
+									"template": map[string]interface{}{
+										"spec": map[string]interface{}{
+											"containers": []map[string]interface{}{
+												{
+													"image": "test-image1",
+												},
+												{
+													"image": "test-image2",
+												},
+											},
+										},
+									},
+								},
+								"status": map[string]interface{}{
+									"desiredNumberScheduled": 2,
+									"currentNumberScheduled": 1,
+									"numberReady":            1,
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "DaemonSet",
+								"apiVersion": "v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-ds1",
+									"namespace":         "test-namespace2",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"artifact.spinnaker.io/name":        "test-deployment1",
+										"artifact.spinnaker.io/type":        "kubernetes/deployment",
+										"artifact.spinnaker.io/location":    "test-namespace1",
+										"moniker.spinnaker.io/application":  "test-application",
 										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 										"deployment.kubernetes.io/revision": "19",
 									},
@@ -1692,7 +2450,7 @@ var _ = Describe("Application", func() {
 										"artifact.spinnaker.io/name":        "test-deployment1",
 										"artifact.spinnaker.io/type":        "kubernetes/deployment",
 										"artifact.spinnaker.io/location":    "test-namespace1",
-										"moniker.spinnaker.io/application":  "test-deployment1",
+										"moniker.spinnaker.io/application":  "test-application",
 										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 										"deployment.kubernetes.io/revision": "19",
 									},
@@ -1736,7 +2494,46 @@ var _ = Describe("Application", func() {
 										"artifact.spinnaker.io/name":        "test-deployment1",
 										"artifact.spinnaker.io/type":        "kubernetes/deployment",
 										"artifact.spinnaker.io/location":    "test-namespace1",
-										"moniker.spinnaker.io/application":  "test-deployment1",
+										"moniker.spinnaker.io/application":  "wrong-application",
+										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
+										"deployment.kubernetes.io/revision": "19",
+									},
+									"uid": "test-uid3",
+								},
+								"spec": map[string]interface{}{
+									"replicas": 1,
+									"template": map[string]interface{}{
+										"spec": map[string]interface{}{
+											"containers": []map[string]interface{}{
+												{
+													"image": "test-image1",
+												},
+												{
+													"image": "test-image2",
+												},
+											},
+										},
+									},
+								},
+								"status": map[string]interface{}{
+									"replicas":      1,
+									"readyReplicas": 0,
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "StatefulSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-rs1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"artifact.spinnaker.io/name":        "test-deployment1",
+										"artifact.spinnaker.io/type":        "kubernetes/deployment",
+										"artifact.spinnaker.io/location":    "test-namespace1",
+										"moniker.spinnaker.io/application":  "test-application",
 										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 										"deployment.kubernetes.io/revision": "19",
 									},
@@ -1775,7 +2572,7 @@ var _ = Describe("Application", func() {
 										"artifact.spinnaker.io/name":        "test-deployment1",
 										"artifact.spinnaker.io/type":        "kubernetes/deployment",
 										"artifact.spinnaker.io/location":    "test-namespace1",
-										"moniker.spinnaker.io/application":  "test-deployment1",
+										"moniker.spinnaker.io/application":  "test-application",
 										"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 										"deployment.kubernetes.io/revision": "19",
 									},
@@ -1812,7 +2609,7 @@ var _ = Describe("Application", func() {
 			})
 		})
 
-		FWhen("it succeeds", func() {
+		When("it succeeds", func() {
 			It("succeeds", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusOK))
 				validateResponse(payloadListServerGroups)
@@ -1835,6 +2632,32 @@ var _ = Describe("Application", func() {
 								"name":              "test-pod1",
 								"namespace":         "test-namespace1",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "wrong-application",
+								},
+								"labels": map[string]interface{}{
+									"label1": "test-label1",
+								},
+								"ownerReferences": []map[string]interface{}{
+									{
+										"name": "test-rs1",
+									},
+								},
+								"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "Pod",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-pod1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
@@ -1855,6 +2678,9 @@ var _ = Describe("Application", func() {
 								"name":              "test-pod2",
 								"namespace":         "test-namespace2",
 								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"moniker.spinnaker.io/application": "test-application",
+								},
 								"labels": map[string]interface{}{
 									"label1": "test-label1",
 								},
@@ -1881,7 +2707,7 @@ var _ = Describe("Application", func() {
 							"artifact.spinnaker.io/name":        "test-deployment2",
 							"artifact.spinnaker.io/type":        "kubernetes/deployment",
 							"artifact.spinnaker.io/location":    "test-namespace2",
-							"moniker.spinnaker.io/application":  "test-deployment2",
+							"moniker.spinnaker.io/application":  "test-application",
 							"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 							"deployment.kubernetes.io/revision": "19",
 						},
@@ -1985,7 +2811,7 @@ var _ = Describe("Application", func() {
 							"artifact.spinnaker.io/name":        "test-deployment2",
 							"artifact.spinnaker.io/type":        "kubernetes/deployment",
 							"artifact.spinnaker.io/location":    "test-namespace2",
-							"moniker.spinnaker.io/application":  "test-deployment2",
+							"moniker.spinnaker.io/application":  "test-application",
 							"moniker.spinnaker.io/cluster":      "deployment test-deployment1",
 							"deployment.kubernetes.io/revision": "19",
 						},

--- a/internal/api/core/applications_test.go
+++ b/internal/api/core/applications_test.go
@@ -503,6 +503,125 @@ var _ = Describe("Application", func() {
 			})
 		})
 
+		When("the application annotation is wrapped in double quotes", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(0, &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"kind":       "Deployment",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-deployment1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "wrong-application",
+									},
+									"labels": map[string]interface{}{
+										"label1": "test-label1",
+									},
+									"uid": "test-uid1",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "Deployment",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-deployment1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "\"test-application\"",
+									},
+									"labels": map[string]interface{}{
+										"label1": "test-label1",
+									},
+									"uid": "test-uid1",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "Deployment",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-deployment2",
+									"namespace":         "test-namespace2",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "\"test-application\"",
+									},
+									"labels": map[string]interface{}{
+										"label1": "test-label2",
+									},
+									"uid": "test-uid2",
+								},
+							},
+						},
+					},
+				}, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(1, &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"kind":       "ReplicaSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":      "test-rs1",
+									"namespace": "test-namespace1",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application":  "wrong-application",
+										"artifact.spinnaker.io/name":        "test-deployment1",
+										"artifact.spinnaker.io/type":        "kubernetes/deployment",
+										"deployment.kubernetes.io/revision": "236",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-rs1",
+											"kind": "replicaSet",
+											"uid":  "test-uid1",
+										},
+									},
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "ReplicaSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":      "test-rs1",
+									"namespace": "test-namespace1",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application":  "\"test-application\"",
+										"artifact.spinnaker.io/name":        "test-deployment1",
+										"artifact.spinnaker.io/type":        "kubernetes/deployment",
+										"deployment.kubernetes.io/revision": "236",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-rs1",
+											"kind": "replicaSet",
+											"uid":  "test-uid1",
+										},
+									},
+								},
+							},
+						},
+					},
+				}, nil)
+				log.SetOutput(ioutil.Discard)
+			})
+
+			It("succeeds", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				validateResponse(payloadServerGroupManagers)
+			})
+		})
+
 		When("it succeeds", func() {
 			It("succeeds", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusOK))

--- a/internal/api/core/core_test.go
+++ b/internal/api/core/core_test.go
@@ -75,7 +75,8 @@ func setup() {
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"annotations": map[string]interface{}{
-							kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
+							kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
+							kubernetes.AnnotationSpinnakerMonikerApplication: "wrong-application",
 						},
 						"name":      "test-name",
 						"namespace": "test-namespace",
@@ -86,7 +87,20 @@ func setup() {
 				Object: map[string]interface{}{
 					"metadata": map[string]interface{}{
 						"annotations": map[string]interface{}{
-							kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
+							kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
+							kubernetes.AnnotationSpinnakerMonikerApplication: "test-application",
+						},
+						"name":      "test-name",
+						"namespace": "test-namespace",
+					},
+				},
+			},
+			{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
+							kubernetes.AnnotationSpinnakerMonikerApplication: "test-application",
 						},
 						"name":      "test-name",
 						"namespace": "test-namespace",
@@ -134,6 +148,22 @@ func setup() {
 						"annotations": map[string]interface{}{
 							kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
 						},
+					},
+				},
+			},
+		},
+	}, nil)
+	fakeKubeClient.ListResourcesByKindAndNamespaceReturns(&unstructured.UnstructuredList{
+		Items: []unstructured.Unstructured{
+			{
+				Object: map[string]interface{}{
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
+							kubernetes.AnnotationSpinnakerMonikerApplication: "test-application",
+						},
+						"name":      "test-name",
+						"namespace": "test-namespace",
 					},
 				},
 			},

--- a/internal/api/core/kubernetes/cleanup.go
+++ b/internal/api/core/kubernetes/cleanup.go
@@ -9,7 +9,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/homedepot/go-clouddriver/internal"
 	"github.com/homedepot/go-clouddriver/internal/kubernetes"
-	kube "github.com/homedepot/go-clouddriver/internal/kubernetes"
 	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -21,7 +20,7 @@ func (cc *Controller) CleanupArtifacts(c *gin.Context, ca CleanupArtifactsReques
 	taskID := clouddriver.TaskIDFromContext(c)
 
 	for _, manifest := range ca.Manifests {
-		u, err := kube.ToUnstructured(manifest)
+		u, err := kubernetes.ToUnstructured(manifest)
 		if err != nil {
 			clouddriver.Error(c, http.StatusBadRequest, err)
 			return
@@ -48,11 +47,11 @@ func (cc *Controller) CleanupArtifacts(c *gin.Context, ca CleanupArtifactsReques
 		cluster := clusterAnnotation(u)
 		// Handle max version history. Source code here:
 		// https://github.com/spinnaker/clouddriver/blob/master/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/op/artifact/KubernetesCleanupArtifactsOperation.java#L102
-		maxVersionHistory, err := kube.MaxVersionHistory(u)
+		maxVersionHistory, err := kubernetes.MaxVersionHistory(u)
 		if err == nil && maxVersionHistory > 0 && cluster != "" {
 			// Only list resources that are managed by Spinnaker.
 			lo := metav1.ListOptions{
-				LabelSelector: kubernetes.LabelKubernetesManagedBy + "=spinnaker",
+				LabelSelector: kubernetes.DefaultLabelSelector(),
 			}
 
 			ul, err := provider.Client.ListResourcesByKindAndNamespace(u.GetKind(), namespace, lo)
@@ -64,9 +63,8 @@ func (cc *Controller) CleanupArtifacts(c *gin.Context, ca CleanupArtifactsReques
 				return
 			}
 
-			f := kubernetes.NewManifestFilter(ul.Items)
-
-			artifacts := f.FilterOnClusterAnnotation(cluster)
+			artifacts := kubernetes.FilterOnAnnotation(ul.Items,
+				kubernetes.AnnotationSpinnakerMonikerCluster, cluster)
 			if maxVersionHistory < len(artifacts) {
 				// Sort on creation timestamp oldest to newest.
 				sort.Slice(artifacts, func(i, j int) bool {

--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -110,7 +110,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			}
 		}
 
-		if kube.Recreate(manifest) {
+		if kubernetes.Recreate(manifest) {
 			err = handleRecreate(provider.Client, &manifest, dm.NamespaceOverride)
 			if err != nil {
 				clouddriver.Error(c, http.StatusInternalServerError, err)
@@ -308,7 +308,7 @@ func handleUseSourceCapacity(client kubernetes.Client, u *unstructured.Unstructu
 	return nil
 }
 
-func handleRecreate(kubeClient kube.Client, u *unstructured.Unstructured, namespace string) error {
+func handleRecreate(kubeClient kubernetes.Client, u *unstructured.Unstructured, namespace string) error {
 	current, err := kubeClient.Get(u.GetKind(), u.GetName(), namespace)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -8,10 +8,10 @@ import (
 
 	"github.com/homedepot/go-clouddriver/internal"
 	"github.com/homedepot/go-clouddriver/internal/artifact"
+	"github.com/homedepot/go-clouddriver/internal/kubernetes"
 
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
-	kube "github.com/homedepot/go-clouddriver/internal/kubernetes"
 	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -57,7 +57,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 		return
 	}
 	// Sort the manifests by their kind's priority.
-	manifests = kube.SortManifests(manifests)
+	manifests = kubernetes.SortManifests(manifests)
 	application := dm.Moniker.App
 	// Consolidate all deploy manifest request artifacts.
 	artifacts := []clouddriver.Artifact{}
@@ -80,21 +80,21 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			manifest.SetName(generateName + rand.String(randNameNumber))
 		}
 
-		err = kube.AddSpinnakerAnnotations(&manifest, application)
+		err = kubernetes.AddSpinnakerAnnotations(&manifest, application)
 		if err != nil {
 			clouddriver.Error(c, http.StatusInternalServerError, err)
 			return
 		}
 
-		err = kube.AddSpinnakerLabels(&manifest, application)
+		err = kubernetes.AddSpinnakerLabels(&manifest, application)
 		if err != nil {
 			clouddriver.Error(c, http.StatusInternalServerError, err)
 			return
 		}
 
-		kube.BindArtifacts(&manifest, artifacts)
+		kubernetes.BindArtifacts(&manifest, artifacts)
 
-		if kube.IsVersioned(manifest) {
+		if kubernetes.IsVersioned(manifest) {
 			err := handleVersionedManifest(provider.Client, &manifest, application)
 			if err != nil {
 				clouddriver.Error(c, http.StatusInternalServerError, err)
@@ -102,7 +102,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			}
 		}
 
-		if kube.UseSourceCapacity(manifest) {
+		if kubernetes.UseSourceCapacity(manifest) {
 			err = handleUseSourceCapacity(provider.Client, &manifest, namespace)
 			if err != nil {
 				clouddriver.Error(c, http.StatusInternalServerError, err)
@@ -119,7 +119,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			return
 		}
 
-		kr := kube.Resource{
+		kr := kubernetes.Resource{
 			AccountName:  dm.Account,
 			ID:           uuid.New().String(),
 			TaskID:       taskID,
@@ -136,7 +136,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 		}
 
 		annotations := manifest.GetAnnotations()
-		artifactType := annotations[kube.AnnotationSpinnakerArtifactType]
+		artifactType := annotations[kubernetes.AnnotationSpinnakerArtifactType]
 		artifact := clouddriver.Artifact{
 			Name:      nameWithoutVersion,
 			Reference: meta.Name,
@@ -175,7 +175,7 @@ func toUnstructured(manifests []map[string]interface{}) ([]unstructured.Unstruct
 	m := []unstructured.Unstructured{}
 
 	for _, manifest := range manifests {
-		u, err := kube.ToUnstructured(manifest)
+		u, err := kubernetes.ToUnstructured(manifest)
 		if err != nil {
 			return nil, fmt.Errorf("kubernetes: unable to convert manifest to unstructured: %w", err)
 		}
@@ -196,12 +196,9 @@ func lowercaseFirst(str string) string {
 
 func getListOptions(app string) (metav1.ListOptions, error) {
 	labelSelector := metav1.LabelSelector{
-		MatchLabels: map[string]string{
-			kube.LabelKubernetesName: app,
-		},
 		MatchExpressions: []metav1.LabelSelectorRequirement{
 			{
-				Key:      kube.LabelSpinnakerMonikerSequence,
+				Key:      kubernetes.LabelSpinnakerMonikerSequence,
 				Operator: metav1.LabelSelectorOpExists,
 			},
 		},
@@ -240,7 +237,7 @@ func mergeManifests(manifests []unstructured.Unstructured) ([]unstructured.Unstr
 	return mergedManifests, nil
 }
 
-func handleVersionedManifest(client kube.Client, u *unstructured.Unstructured, application string) error {
+func handleVersionedManifest(client kubernetes.Client, u *unstructured.Unstructured, application string) error {
 	lo, err := getListOptions(application)
 	if err != nil {
 		return err
@@ -254,17 +251,20 @@ func handleVersionedManifest(client kube.Client, u *unstructured.Unstructured, a
 		return err
 	}
 
+	// Filter results to only those associated with this application.
+	results.Items = kubernetes.FilterOnAnnotation(results.Items,
+		kubernetes.AnnotationSpinnakerMonikerApplication, application)
 	nameWithoutVersion := u.GetName()
-	currentVersion := kube.GetCurrentVersion(results, kind, nameWithoutVersion)
-	latestVersion := kube.IncrementVersion(currentVersion)
+	currentVersion := kubernetes.GetCurrentVersion(results, kind, nameWithoutVersion)
+	latestVersion := kubernetes.IncrementVersion(currentVersion)
 	u.SetName(nameWithoutVersion + "-" + latestVersion.Long)
 
-	err = kube.AddSpinnakerVersionAnnotations(u, latestVersion)
+	err = kubernetes.AddSpinnakerVersionAnnotations(u, latestVersion)
 	if err != nil {
 		return err
 	}
 
-	err = kube.AddSpinnakerVersionLabels(u, latestVersion)
+	err = kubernetes.AddSpinnakerVersionLabels(u, latestVersion)
 	if err != nil {
 		return err
 	}
@@ -272,7 +272,7 @@ func handleVersionedManifest(client kube.Client, u *unstructured.Unstructured, a
 	return nil
 }
 
-func handleUseSourceCapacity(client kube.Client, u *unstructured.Unstructured, namespace string) error {
+func handleUseSourceCapacity(client kubernetes.Client, u *unstructured.Unstructured, namespace string) error {
 	current, err := client.Get(u.GetKind(), u.GetName(), namespace)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/internal/api/core/kubernetes/kubernetes_test.go
+++ b/internal/api/core/kubernetes/kubernetes_test.go
@@ -72,9 +72,10 @@ func setup() {
 			"apiVersion": "test-api-version",
 			"metadata": map[string]interface{}{
 				"annotations": map[string]interface{}{
-					kubernetes.AnnotationSpinnakerArtifactName: "test-deployment",
-					kubernetes.AnnotationSpinnakerArtifactType: "kubernetes/deployment",
-					"deployment.kubernetes.io/revision":        "100",
+					kubernetes.AnnotationSpinnakerMonikerApplication: "test-app",
+					kubernetes.AnnotationSpinnakerArtifactName:       "test-deployment",
+					kubernetes.AnnotationSpinnakerArtifactType:       "kubernetes/deployment",
+					"deployment.kubernetes.io/revision":              "100",
 				},
 				"name": "test-name",
 			},
@@ -89,6 +90,7 @@ func setup() {
 	fakeKubeClient = &kubernetesfakes.FakeClient{}
 	fakeKubeClient.GetReturns(&unstructured.Unstructured{Object: map[string]interface{}{}}, nil)
 	fakeKubeClient.ListByGVRReturns(fakeUnstructuredList, nil)
+	fakeKubeClient.ListResourcesByKindAndNamespaceReturns(fakeUnstructuredList, nil)
 
 	fakeKubeController = &kubernetesfakes.FakeController{}
 	fakeKubeController.NewClientReturns(fakeKubeClient, nil)

--- a/internal/api/core/kubernetes/rollback.go
+++ b/internal/api/core/kubernetes/rollback.go
@@ -85,7 +85,7 @@ func (cc *Controller) Rollback(c *gin.Context, ur UndoRolloutManifestRequest) {
 	}
 
 	lo := metav1.ListOptions{
-		LabelSelector: kubernetes.LabelKubernetesName + "=" + app,
+		LabelSelector: kubernetes.DefaultLabelSelector(),
 		FieldSelector: "metadata.namespace=" + namespace,
 	}
 
@@ -94,6 +94,9 @@ func (cc *Controller) Rollback(c *gin.Context, ur UndoRolloutManifestRequest) {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
 	}
+	// Filter results to only those associated with this application.
+	replicaSets.Items = kubernetes.FilterOnAnnotation(replicaSets.Items,
+		kubernetes.AnnotationSpinnakerMonikerApplication, app)
 
 	var tr *unstructured.Unstructured
 

--- a/internal/api/core/manifest_test.go
+++ b/internal/api/core/manifest_test.go
@@ -75,7 +75,7 @@ var _ = Describe("Manifest", func() {
 		})
 
 		JustBeforeEach(func() {
-			uri = svr.URL + "/manifests/test-account/test-namespace/test-kind/cluster/test-app/deployment test-deployment/dynamic/" + target
+			uri = svr.URL + "/manifests/test-account/test-namespace/test-kind/cluster/test-application/deployment test-deployment/dynamic/" + target
 			createRequest(http.MethodGet)
 			doRequest()
 		})
@@ -149,7 +149,18 @@ var _ = Describe("Manifest", func() {
 								Object: map[string]interface{}{
 									"metadata": map[string]interface{}{
 										"annotations": map[string]interface{}{
-											kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
+											kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
+											kubernetes.AnnotationSpinnakerMonikerApplication: "wrong-application",
+										},
+									},
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"annotations": map[string]interface{}{
+											kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
+											kubernetes.AnnotationSpinnakerMonikerApplication: "test-application",
 										},
 									},
 								},
@@ -188,7 +199,18 @@ var _ = Describe("Manifest", func() {
 								Object: map[string]interface{}{
 									"metadata": map[string]interface{}{
 										"annotations": map[string]interface{}{
-											kubernetes.AnnotationSpinnakerMonikerCluster: "deployment test-deployment",
+											kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
+											kubernetes.AnnotationSpinnakerMonikerApplication: "wrong-application",
+										},
+									},
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"annotations": map[string]interface{}{
+											kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
+											kubernetes.AnnotationSpinnakerMonikerApplication: "test-application",
 										},
 									},
 								},

--- a/internal/api/core/payload_test.go
+++ b/internal/api/core/payload_test.go
@@ -2243,6 +2243,9 @@ const payloadGetServerGroup = `{
                   "apiVersion": "v1",
                   "kind": "Pod",
                   "metadata": {
+										"annotations": {
+											"moniker.spinnaker.io/application": "test-application"
+										},
                     "creationTimestamp": "2020-02-13T14:12:03Z",
                     "labels": {
                       "label1": "test-label1"
@@ -2303,6 +2306,9 @@ const payloadGetServerGroup = `{
                   "apiVersion": "v1",
                   "kind": "Pod",
                   "metadata": {
+										"annotations": {
+											"moniker.spinnaker.io/application": "test-application"
+										},
                     "creationTimestamp": "2020-02-13T14:12:03Z",
                     "labels": {
                       "label1": "test-label1"
@@ -2350,7 +2356,7 @@ const payloadGetServerGroup = `{
                   "artifact.spinnaker.io/name": "test-deployment2",
                   "artifact.spinnaker.io/type": "kubernetes/deployment",
                   "deployment.kubernetes.io/revision": "19",
-                  "moniker.spinnaker.io/application": "test-deployment2",
+                  "moniker.spinnaker.io/application": "test-application",
                   "moniker.spinnaker.io/cluster": "deployment test-deployment1"
                 },
                 "creationTimestamp": "2020-02-13T14:12:03Z",
@@ -2378,7 +2384,7 @@ const payloadGetServerGroup = `{
               }
             },
             "moniker": {
-              "app": "test-deployment2",
+              "app": "test-application",
               "cluster": "deployment test-deployment1",
               "sequence": 19
             },

--- a/internal/api/core/payload_test.go
+++ b/internal/api/core/payload_test.go
@@ -1192,7 +1192,7 @@ const payloadListServerGroups = `[
               "loadBalancers": null,
               "manifest": null,
               "moniker": {
-                "app": "test-deployment1",
+                "app": "test-application",
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
@@ -1280,7 +1280,7 @@ const payloadListServerGroups = `[
 							],
               "manifest": null,
               "moniker": {
-                "app": "test-deployment1",
+                "app": "test-application",
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
@@ -1374,7 +1374,7 @@ const payloadListServerGroups = `[
 							],
               "manifest": null,
               "moniker": {
-                "app": "test-deployment1",
+                "app": "test-application",
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
@@ -1519,7 +1519,7 @@ const payloadListServerGroupsSorted = `[
               "loadBalancers": null,
               "manifest": null,
               "moniker": {
-                "app": "test-deployment1",
+                "app": "test-application",
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
@@ -1605,7 +1605,7 @@ const payloadListServerGroupsSorted = `[
               "loadBalancers": null,
               "manifest": null,
               "moniker": {
-                "app": "test-deployment1",
+                "app": "test-application",
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
@@ -1697,7 +1697,7 @@ const payloadListServerGroupsSorted = `[
               "loadBalancers": null,
               "manifest": null,
               "moniker": {
-                "app": "test-deployment1",
+                "app": "test-application",
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
@@ -1839,7 +1839,7 @@ const payloadListServerGroupsSorted = `[
               "loadBalancers": null,
               "manifest": null,
               "moniker": {
-                "app": "test-deployment1",
+                "app": "test-application",
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },
@@ -1925,7 +1925,7 @@ const payloadListServerGroupsSorted = `[
               "loadBalancers": null,
               "manifest": null,
               "moniker": {
-                "app": "test-deployment1",
+                "app": "test-application",
                 "cluster": "deployment test-deployment1",
                 "sequence": 19
               },

--- a/internal/kubernetes/filter.go
+++ b/internal/kubernetes/filter.go
@@ -6,33 +6,31 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func NewManifestFilter(items []unstructured.Unstructured) *ManifestFilter {
-	return &ManifestFilter{items: items}
-}
-
-type ManifestFilter struct {
-	items []unstructured.Unstructured
-}
-
-func (f *ManifestFilter) FilterOnClusterAnnotation(cluster string) []unstructured.Unstructured {
+// FilterOnAnnotations takes a slice of unstructured and returns
+// the filtered slice based on a given annotation key and value.
+func FilterOnAnnotation(items []unstructured.Unstructured,
+	annotationKey, annotationValue string) []unstructured.Unstructured {
 	filtered := []unstructured.Unstructured{}
 
-	for _, item := range f.items {
+	for _, item := range items {
 		annotations := item.GetAnnotations()
-		if annotations != nil {
-			if strings.EqualFold(annotations[AnnotationSpinnakerMonikerCluster], cluster) {
-				filtered = append(filtered, item)
-			}
+		if annotations != nil &&
+			strings.EqualFold(annotations[annotationKey], annotationValue) {
+			filtered = append(filtered, item)
 		}
 	}
 
 	return filtered
 }
 
-func (f *ManifestFilter) FilterOnLabel(label string) []unstructured.Unstructured {
+// FilterOnLabelExists takes a slice of unstructured and returns
+// a filtered slice where a given label exists in each
+// of the unstructured objects.
+func FilterOnLabelExists(items []unstructured.Unstructured,
+	label string) []unstructured.Unstructured {
 	filtered := []unstructured.Unstructured{}
 
-	for _, item := range f.items {
+	for _, item := range items {
 		labels := item.GetLabels()
 		if labels != nil {
 			if _, ok := labels[label]; ok {

--- a/internal/kubernetes/filter_test.go
+++ b/internal/kubernetes/filter_test.go
@@ -12,15 +12,15 @@ var (
 )
 
 var _ = Describe("ManifestFilter", func() {
-	Context("#FilterOnClusterAnnotation", func() {
+	Context("#FilterOnAnnotation", func() {
 		BeforeEach(func() {
 			fakeUnstructuredList = &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}}
 		})
 
 		When("called with empty list", func() {
 			BeforeEach(func() {
-				manifestFilter := kubernetes.NewManifestFilter([]unstructured.Unstructured{})
-				filteredResourcesArray = manifestFilter.FilterOnClusterAnnotation("test-cluster")
+				filteredResourcesArray = kubernetes.FilterOnAnnotation(fakeUnstructuredList.Items,
+					kubernetes.AnnotationSpinnakerMonikerCluster, "test-cluster")
 			})
 
 			It("returns an empty list", func() {
@@ -112,8 +112,8 @@ var _ = Describe("ManifestFilter", func() {
 						},
 					},
 				}
-				manifestFilter := kubernetes.NewManifestFilter(fakeResourcesArray)
-				filteredResourcesArray = manifestFilter.FilterOnClusterAnnotation("pod fakeName")
+				filteredResourcesArray = kubernetes.FilterOnAnnotation(fakeResourcesArray,
+					kubernetes.AnnotationSpinnakerMonikerCluster, "pod fakeName")
 			})
 
 			It("returns a of 2 items", func() {
@@ -122,15 +122,14 @@ var _ = Describe("ManifestFilter", func() {
 		})
 	})
 
-	Context("#FilterOnLabel", func() {
+	Context("#FilterOnLabelExists", func() {
 		BeforeEach(func() {
 			fakeUnstructuredList = &unstructured.UnstructuredList{Items: []unstructured.Unstructured{}}
 		})
 
 		When("called with empty list", func() {
 			BeforeEach(func() {
-				manifestFilter := kubernetes.NewManifestFilter([]unstructured.Unstructured{})
-				filteredResourcesArray = manifestFilter.FilterOnLabel("firstFakeLabel")
+				filteredResourcesArray = kubernetes.FilterOnLabelExists(fakeUnstructuredList.Items, "firstFakeLabel")
 			})
 
 			It("returns an empty list", func() {
@@ -210,8 +209,7 @@ var _ = Describe("ManifestFilter", func() {
 						},
 					},
 				}
-				manifestFilter := kubernetes.NewManifestFilter(fakeResourcesArray)
-				filteredResourcesArray = manifestFilter.FilterOnLabel("firstFakeLabel")
+				filteredResourcesArray = kubernetes.FilterOnLabelExists(fakeResourcesArray, "firstFakeLabel")
 			})
 
 			It("returns a list of 2 items", func() {

--- a/internal/kubernetes/label_selector.go
+++ b/internal/kubernetes/label_selector.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strings"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 )
@@ -25,4 +26,24 @@ func NewRequirement(op string, key string, values []string) (*labels.Requirement
 	default:
 		return nil, fmt.Errorf("operator '%v' is not recognized", op)
 	}
+}
+
+// DefaultLabelSelector returns the label selector
+// `app.kubernetes.io/managed-by in (spinnaker,spinnaker-operator)`,
+// which allows us to list all resources with a label selector
+// managed by Spinnaker or Spinnaker Operator.
+func DefaultLabelSelector() string {
+	labelSelector := metav1.LabelSelector{
+		MatchExpressions: []metav1.LabelSelectorRequirement{
+			{
+				Key:      LabelKubernetesManagedBy,
+				Operator: metav1.LabelSelectorOpIn,
+				Values:   []string{"spinnaker", "spinnaker-operator"},
+			},
+		},
+	}
+	// Since this is a defined label Selector we can ignore the error.
+	ls, _ := metav1.LabelSelectorAsSelector(&labelSelector)
+
+	return ls.String()
 }

--- a/internal/kubernetes/label_selector_test.go
+++ b/internal/kubernetes/label_selector_test.go
@@ -361,6 +361,17 @@ var _ = Describe("Label Selector", func() {
 				})
 			})
 		})
+	})
 
+	Context("#DefaultLabelSelector", func() {
+		var selector string
+
+		JustBeforeEach(func() {
+			selector = DefaultLabelSelector()
+		})
+
+		It("succeeds", func() {
+			Expect(selector).To(Equal("app.kubernetes.io/managed-by in (spinnaker,spinnaker-operator)"))
+		})
 	})
 })

--- a/internal/kubernetes/version.go
+++ b/internal/kubernetes/version.go
@@ -32,19 +32,12 @@ func GetCurrentVersion(ul *unstructured.UnstructuredList, kind, name string) str
 		return currentVersion
 	}
 
-	// Filter out all unassociated objects based on the moniker.spinnaker.io/cluster annotation.
-	manifestFilter := NewManifestFilter(ul.Items)
+	// Filter out all unassociated objects based on the
+	// moniker.spinnaker.io/cluster annotation.
 	cluster = kind + " " + name
-
-	results := manifestFilter.FilterOnClusterAnnotation(cluster)
-	if len(results) == 0 {
-		return currentVersion
-	}
-
+	results := FilterOnAnnotation(ul.Items, AnnotationSpinnakerMonikerCluster, cluster)
 	// Filter out empty moniker.spinnaker.io/sequence labels
-	manifestFilter2 := NewManifestFilter(results)
-	results = manifestFilter2.FilterOnLabel(LabelSpinnakerMonikerSequence)
-
+	results = FilterOnLabelExists(results, LabelSpinnakerMonikerSequence)
 	if len(results) == 0 {
 		return currentVersion
 	}


### PR DESCRIPTION
- adds exhaustive responses in tests that include the wrong application in the `moniker.spinnaker.io/application` to verify implementation is working correctly
- adds the func `kubernetes.DefaultLabelSelector()` which returns the label selector `app.kubernetes.io/managed-by in (spinnaker,spinnaker-operator)`
- filters all listed resources according to the `moniker.spinnaker.io/application=<APPLICATION_NAME>` after listing
- fixes issue where annotation `moniker.spinnaker.io/application` value was wrapped in double quotes
- removes any instance of using a label selector to select `app.kubernetes.io/name=<APPLICATION_NAME>`
- simplifies the manifest filter to two functions that are directly callable: `FilterOnAnnotation` and `FilterOnLabelExists`
