### PR TITLE
Add support for traffic load balancers annotation

### DIFF
--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -466,9 +466,6 @@ func disjoint(m1, m2 map[string]string) bool {
 	for k := range m1 {
 		if _, ok := m2[k]; ok {
 			disjoint = false
-		}
-
-		if !disjoint {
 			break
 		}
 	}

--- a/internal/kubernetes/traffic.go
+++ b/internal/kubernetes/traffic.go
@@ -1,0 +1,54 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+const (
+	AnnotationSpinnakerTrafficLoadBalancers = "traffic.spinnaker.io/load-balancers"
+)
+
+// LoadBalancers returns a slice of load balancers from the annotation
+// `traffic.spinnaker.io/load-balancers`. It errors if this annotation
+// is not a string slice, if it is formatted incorrectly, or if
+// the kind is not supported.
+//
+// See https://spinnaker.io/docs/reference/providers/kubernetes-v2/#traffic for more info.
+func LoadBalancers(u unstructured.Unstructured) ([]string, error) {
+	var lbs []string
+
+	annotations := u.GetAnnotations()
+	if annotations != nil {
+		if value, ok := annotations[AnnotationSpinnakerTrafficLoadBalancers]; ok {
+			err := json.Unmarshal([]byte(value), &lbs)
+			if err != nil {
+				return nil,
+					fmt.Errorf("error unmarshaling annotation 'traffic.spinnaker.io/load-balancers' for resource (kind: %s, name: %s, namespace: %s) into string slice: %v",
+						u.GetKind(),
+						u.GetName(),
+						u.GetNamespace(),
+						err)
+			}
+
+			for _, lb := range lbs {
+				a := strings.Split(lb, " ")
+				if len(a) != 2 {
+					return nil,
+						fmt.Errorf("Failed to attach load balancer '%s'. Load balancers must be specified in the form '{kind} {name}', e.g. 'service my-service'.", lb)
+				}
+
+				kind := a[0]
+				if !strings.EqualFold(kind, "service") {
+					return nil,
+						fmt.Errorf("No support for load balancing via %s exists in Spinnaker.", kind)
+				}
+			}
+		}
+	}
+
+	return lbs, nil
+}

--- a/internal/kubernetes/traffic.go
+++ b/internal/kubernetes/traffic.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
@@ -14,8 +13,7 @@ const (
 
 // LoadBalancers returns a slice of load balancers from the annotation
 // `traffic.spinnaker.io/load-balancers`. It errors if this annotation
-// is not a string slice, if it is formatted incorrectly, or if
-// the kind is not supported.
+// is not a string slice format like '["service my-service", "service my-service2"]'.
 //
 // See https://spinnaker.io/docs/reference/providers/kubernetes-v2/#traffic for more info.
 func LoadBalancers(u unstructured.Unstructured) ([]string, error) {
@@ -27,25 +25,12 @@ func LoadBalancers(u unstructured.Unstructured) ([]string, error) {
 			err := json.Unmarshal([]byte(value), &lbs)
 			if err != nil {
 				return nil,
-					fmt.Errorf("error unmarshaling annotation 'traffic.spinnaker.io/load-balancers' for resource (kind: %s, name: %s, namespace: %s) into string slice: %v",
+					fmt.Errorf("error unmarshaling annotation 'traffic.spinnaker.io/load-balancers' "+
+						"for resource (kind: %s, name: %s, namespace: %s) into string slice: %v",
 						u.GetKind(),
 						u.GetName(),
 						u.GetNamespace(),
 						err)
-			}
-
-			for _, lb := range lbs {
-				a := strings.Split(lb, " ")
-				if len(a) != 2 {
-					return nil,
-						fmt.Errorf("Failed to attach load balancer '%s'. Load balancers must be specified in the form '{kind} {name}', e.g. 'service my-service'.", lb)
-				}
-
-				kind := a[0]
-				if !strings.EqualFold(kind, "service") {
-					return nil,
-						fmt.Errorf("No support for load balancing via %s exists in Spinnaker.", kind)
-				}
 			}
 		}
 	}

--- a/internal/kubernetes/traffic_test.go
+++ b/internal/kubernetes/traffic_test.go
@@ -1,0 +1,127 @@
+package kubernetes_test
+
+import (
+	. "github.com/homedepot/go-clouddriver/internal/kubernetes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var _ = Describe("Traffic", func() {
+	var (
+		err          error
+		fakeResource unstructured.Unstructured
+		lbs          []string
+	)
+
+	Context("#LoadBalancers", func() {
+		JustBeforeEach(func() {
+			lbs, err = LoadBalancers(fakeResource)
+		})
+
+		When("annotation is missing", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "ReplicaSet",
+					},
+				}
+			})
+
+			It("returns no load balancers", func() {
+				Expect(err).To(BeNil())
+				Expect(lbs).To(HaveLen(0))
+			})
+		})
+
+		When("the annotation is not an array", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "ReplicaSet",
+						"metadata": map[string]interface{}{
+							"name":      "test-name",
+							"namespace": "test-namespace",
+							"annotations": map[string]interface{}{
+								"traffic.spinnaker.io/load-balancers": "string",
+							},
+						},
+					},
+				}
+			})
+
+			It("errors", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("error unmarshaling annotation 'traffic.spinnaker.io/load-balancers' for resource (kind: ReplicaSet, name: test-name, namespace: test-namespace) into string slice: invalid character 's' looking for beginning of value"))
+			})
+		})
+
+		When("the annotation is formatted incorrectly", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "ReplicaSet",
+						"metadata": map[string]interface{}{
+							"name":      "test-name",
+							"namespace": "test-namespace",
+							"annotations": map[string]interface{}{
+								"traffic.spinnaker.io/load-balancers": "[\"test-lb-service\"]",
+							},
+						},
+					},
+				}
+			})
+
+			It("errors", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("Failed to attach load balancer 'test-lb-service'. Load balancers must be specified in the form '{kind} {name}', e.g. 'service my-service'."))
+			})
+		})
+
+		When("the load balancer kind is not supported by spinnaker", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "ReplicaSet",
+						"metadata": map[string]interface{}{
+							"name":      "test-name",
+							"namespace": "test-namespace",
+							"annotations": map[string]interface{}{
+								"traffic.spinnaker.io/load-balancers": "[\"service test-lb-service\",\"ingress test-lb-service\"]",
+							},
+						},
+					},
+				}
+			})
+
+			It("errors", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("No support for load balancing via ingress exists in Spinnaker."))
+			})
+		})
+
+		When("it succeeds", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "ReplicaSet",
+						"metadata": map[string]interface{}{
+							"name":      "test-name",
+							"namespace": "test-namespace",
+							"annotations": map[string]interface{}{
+								"traffic.spinnaker.io/load-balancers": "[\"service test-lb-service\",\"service test-lb-service2\"]",
+							},
+						},
+					},
+				}
+			})
+
+			It("succeeds", func() {
+				Expect(err).To(BeNil())
+				Expect(lbs).To(HaveLen(2))
+				Expect(lbs[0]).To(Equal("service test-lb-service"))
+				Expect(lbs[1]).To(Equal("service test-lb-service2"))
+			})
+		})
+	})
+})

--- a/internal/kubernetes/traffic_test.go
+++ b/internal/kubernetes/traffic_test.go
@@ -56,50 +56,6 @@ var _ = Describe("Traffic", func() {
 			})
 		})
 
-		When("the annotation is formatted incorrectly", func() {
-			BeforeEach(func() {
-				fakeResource = unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"kind": "ReplicaSet",
-						"metadata": map[string]interface{}{
-							"name":      "test-name",
-							"namespace": "test-namespace",
-							"annotations": map[string]interface{}{
-								"traffic.spinnaker.io/load-balancers": "[\"test-lb-service\"]",
-							},
-						},
-					},
-				}
-			})
-
-			It("errors", func() {
-				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(Equal("Failed to attach load balancer 'test-lb-service'. Load balancers must be specified in the form '{kind} {name}', e.g. 'service my-service'."))
-			})
-		})
-
-		When("the load balancer kind is not supported by spinnaker", func() {
-			BeforeEach(func() {
-				fakeResource = unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"kind": "ReplicaSet",
-						"metadata": map[string]interface{}{
-							"name":      "test-name",
-							"namespace": "test-namespace",
-							"annotations": map[string]interface{}{
-								"traffic.spinnaker.io/load-balancers": "[\"service test-lb-service\",\"ingress test-lb-service\"]",
-							},
-						},
-					},
-				}
-			})
-
-			It("errors", func() {
-				Expect(err).ToNot(BeNil())
-				Expect(err.Error()).To(Equal("No support for load balancing via ingress exists in Spinnaker."))
-			})
-		})
-
 		When("it succeeds", func() {
 			BeforeEach(func() {
 				fakeResource = unstructured.Unstructured{


### PR DESCRIPTION
- adds support for annotation `traffic.spinnaker.io/load-balancers`

Notes:
- Some of the errors returned start with a capital letter, like `Service selector must have no label keys in common with target workload`. This is to align with the Java source code and provide a similar experience to OSS Clouddriver. It is not good practice for Go errors to begin with a capital letter, but I think we should do it in this case.