### PR TITLE
Add support for traffic load balancers annotation

### DIFF
--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -231,7 +231,7 @@ func getListOptions(app string) (metav1.ListOptions, error) {
 	return lo, err
 }
 
-// mergeManifests merges manifests of kind List into the parent list of manifets.
+// mergeManifests merges manifests of kind List into the parent list of manifests.
 func mergeManifests(manifests []unstructured.Unstructured) ([]unstructured.Unstructured, error) {
 	mergedManifests := []unstructured.Unstructured{}
 


### PR DESCRIPTION
- adds support for annotation `traffic.spinnaker.io/load-balancers`

Notes:
- Some of the errors returned start with a capital letter, like `Service selector must have no label keys in common with target workload`. This is to align with the Java source code and provide a similar experience to OSS Clouddriver. It is not good practice for Go errors to begin with a capital letter, but I think we should do it in this case.