### PR TITLE
Adds PUT/DELETE Kubernetes Resources API Endpoints

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -421,6 +421,45 @@ paths:
           description: "Not Found"
         "500":
           description: "Internal Server Error"
+  /v1/kubernetes/providers/{name}/resources:
+    put:
+      tags:
+      - "kubernetes"
+      parameters:
+      - name: "name"
+        in: "path"
+        required: true
+        type: "string"
+      summary: "Updates resources, read from the cluster, for the Kubernetes account (provider)"
+      produces:
+      - "application/json"
+      responses:
+        "200":
+          description: "OK"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/KubernetesResource"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
+    delete:
+      tags:
+      - "kubernetes"
+      parameters:
+      - name: "name"
+        in: "path"
+        required: true
+        type: "string"
+      summary: "Deletes the database entries for all resources for the Kubernetes account (provider)"
+      responses:
+        "204":
+          description: "No Content"
+        "404":
+          description: "Not Found"
+        "500":
+          description: "Internal Server Error"
 definitions:
   KubernetesProvider:
     type: "object"
@@ -443,7 +482,6 @@ definitions:
       tokenProvider:
         type: "string"
         description: "The provider of the kubernetes auth token, defaults to google"
-        enum: ["google", "rancher"]
         example: "google"
       namespace:
         type: "string"
@@ -451,6 +489,56 @@ definitions:
         example: "example-namespace"
       permissions:
         $ref: "#/definitions/Permissions"
+  KubernetesResource:
+    type: "object"
+    required:
+    - accountName
+    - id
+    properties:
+      acccountName:
+        type: "string"
+        description: "The Spinnaker account that deployed this resource"
+        example: "gke_gcp-project-id_us-east1_cluster-name"
+      id:
+        type: "string"
+        description: "The unique ID for identifying this row in the database"
+        example: "f0500ae7-5db3-4c09-be11-c6c4d8016402"
+      timestamp:
+        type: "string"
+        description: "The time this resource row was added to the database"
+        example: "2021-10-16T19:48:47.923Z"
+      taskId:
+        type: "string"
+        description: "An identifier of the task responsible for creating this resource row in the database"
+        example: "f0500ae7-5db3-4c09-be11-c6c4d8016402"
+      apiGroup:
+        type: "string"
+        description: "The kubernetes API group for this resource"
+        example: "apps"
+      name:
+        type: "string"
+        description: "The name of this resource"
+        example: "example-name"
+      namespace:
+        type: "string"
+        description: "The kubernetes namespace of this resource"
+        example: "example-namespace"
+      resource:
+        type: "string"
+        description: "The Kubernetes API resource name for this resource"
+        example: "deployments"
+      version:
+        type: "string"
+        description: "The kubernetes API version for this resource"
+        example: "v1"
+      kind:
+        type: "string"
+        description: "The kubernetes kind of this resource"
+        example: "Deployment"
+      spinnakerApp:
+        type: "string"
+        description: "The name of the Spinnaker application which deployed this resource"
+        example: "example-application"
   Permissions:
     type: "object"
     required:

--- a/internal/api/core/applications.go
+++ b/internal/api/core/applications.go
@@ -16,17 +16,16 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 
 	"github.com/gin-gonic/gin"
+	"github.com/homedepot/go-clouddriver/internal"
 	"github.com/homedepot/go-clouddriver/internal/kubernetes"
 	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 )
 
 const (
-	defaultChanSize           = 100000
-	defaultListTimeoutSeconds = 10
-	stateUp                   = "Up"
-	stateDown                 = "Down"
-	statusRunning             = "Running"
-	typeKubernetes            = "kubernetes"
+	stateUp        = "Up"
+	stateDown      = "Down"
+	statusRunning  = "Running"
+	typeKubernetes = "kubernetes"
 )
 
 var (
@@ -1122,7 +1121,7 @@ func (cc *Controller) GetServerGroup(c *gin.Context) {
 	kind := nameArray[0]
 	name := nameArray[1]
 
-	provider, err := cc.KubernetesProviderWithTimeout(account, time.Second*defaultListTimeoutSeconds)
+	provider, err := cc.KubernetesProviderWithTimeout(account, time.Second*internal.DefaultListTimeoutSeconds)
 	if err != nil {
 		clouddriver.Error(c, http.StatusBadRequest, err)
 		return
@@ -1135,7 +1134,7 @@ func (cc *Controller) GetServerGroup(c *gin.Context) {
 	}
 
 	// Declare a context with timeout.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*defaultListTimeoutSeconds)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*internal.DefaultListTimeoutSeconds)
 	defer cancel()
 	// Declare a label selector.
 	lo := metav1.ListOptions{
@@ -1316,7 +1315,7 @@ func (cc *Controller) GetJob(c *gin.Context) {
 	kind := nameArray[0]
 	name := nameArray[1]
 
-	provider, err := cc.KubernetesProviderWithTimeout(account, time.Second*defaultListTimeoutSeconds)
+	provider, err := cc.KubernetesProviderWithTimeout(account, time.Second*internal.DefaultListTimeoutSeconds)
 	if err != nil {
 		clouddriver.Error(c, http.StatusBadRequest, err)
 		return
@@ -1361,7 +1360,7 @@ func DeleteJob(c *gin.Context) {
 func (cc *Controller) listApplicationResources(c *gin.Context, rs []string, application string) ([]resource, error) {
 	wg := &sync.WaitGroup{}
 	// Create channel of resouces to send to.
-	rc := make(chan resource, defaultChanSize)
+	rc := make(chan resource, internal.DefaultChanSize)
 	// List all accounts associated with the given Spinnaker app.
 	accounts, err := cc.SQLClient.ListKubernetesAccountsBySpinnakerApp(application)
 	if err != nil {
@@ -1393,7 +1392,7 @@ func (cc *Controller) listResources(wg *sync.WaitGroup, rs []string, rc chan res
 	// Increment the wait group counter when we're done here.
 	defer wg.Done()
 	// Grab the kube provider for the given account.
-	provider, err := cc.KubernetesProviderWithTimeout(account, time.Second*defaultListTimeoutSeconds)
+	provider, err := cc.KubernetesProviderWithTimeout(account, time.Second*internal.DefaultListTimeoutSeconds)
 	if err != nil {
 		clouddriver.Log(err)
 		return
@@ -1433,7 +1432,7 @@ func list(wg *sync.WaitGroup, rc chan resource,
 		LabelSelector: kubernetes.DefaultLabelSelector(),
 	}
 	// Declare a context with timeout.
-	ctx, cancel := context.WithTimeout(context.Background(), time.Second*defaultListTimeoutSeconds)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*internal.DefaultListTimeoutSeconds)
 	defer cancel()
 	// List resources with the context.
 	ul, err := client.ListResourceWithContext(ctx, r, lo)

--- a/internal/api/core/kubernetes/delete.go
+++ b/internal/api/core/kubernetes/delete.go
@@ -93,7 +93,7 @@ func (cc *Controller) Delete(c *gin.Context, dm DeleteManifestRequest) {
 			Version:      gvr.Version,
 			Kind:         kind,
 			SpinnakerApp: dm.App,
-			Cluster:      cluster(kind, name),
+			Cluster:      kubernetes.Cluster(kind, name),
 		}
 
 		err = cc.SQLClient.CreateKubernetesResource(kr)
@@ -184,7 +184,7 @@ func (cc *Controller) Delete(c *gin.Context, dm DeleteManifestRequest) {
 					Version:      gvr.Version,
 					Kind:         kind,
 					SpinnakerApp: dm.App,
-					Cluster:      cluster(kind, item.GetName()),
+					Cluster:      kubernetes.Cluster(kind, item.GetName()),
 				}
 
 				err = cc.SQLClient.CreateKubernetesResource(kr)

--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
-	"unicode"
 
 	"github.com/homedepot/go-clouddriver/internal"
 	"github.com/homedepot/go-clouddriver/internal/artifact"
@@ -146,7 +145,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			Version:      meta.Version,
 			Kind:         meta.Kind,
 			SpinnakerApp: dm.Moniker.App,
-			Cluster:      cluster(meta.Kind, nameWithoutVersion),
+			Cluster:      kubernetes.Cluster(meta.Kind, nameWithoutVersion),
 		}
 
 		annotations := manifest.GetAnnotations()
@@ -166,24 +165,6 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 	}
 }
 
-// Generate the cluster that a kind is a part of.
-// A Kubernetes cluster is of kind deployment, statefulSet, replicaSet, ingress, service, and daemonSet
-// so only generate a cluster for these kinds.
-func cluster(kind, name string) string {
-	cluster := ""
-
-	if strings.EqualFold(kind, "deployment") ||
-		strings.EqualFold(kind, "statefulSet") ||
-		strings.EqualFold(kind, "replicaSet") ||
-		strings.EqualFold(kind, "ingress") ||
-		strings.EqualFold(kind, "service") ||
-		strings.EqualFold(kind, "daemonSet") {
-		cluster = fmt.Sprintf("%s %s", lowercaseFirst(kind), name)
-	}
-
-	return cluster
-}
-
 // toUnstructured converts a slice of map[string]interface{} to unstructured.Unstructured.
 func toUnstructured(manifests []map[string]interface{}) ([]unstructured.Unstructured, error) {
 	m := []unstructured.Unstructured{}
@@ -198,14 +179,6 @@ func toUnstructured(manifests []map[string]interface{}) ([]unstructured.Unstruct
 	}
 
 	return m, nil
-}
-
-func lowercaseFirst(str string) string {
-	for i, v := range str {
-		return string(unicode.ToLower(v)) + str[i+1:]
-	}
-
-	return ""
 }
 
 func getListOptions(app string) (metav1.ListOptions, error) {

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -149,5 +149,9 @@ func (s *Server) Setup() {
 		api.POST("/kubernetes/providers", c.CreateKubernetesProvider)
 		api.PUT("/kubernetes/providers", c.CreateOrReplaceKubernetesProvider)
 		api.DELETE("/kubernetes/providers/:name", c.DeleteKubernetesProvider)
+		// Resources endpoint for kubernetes.
+		api.PUT("/kubernetes/providers/:name/resources", c.LoadKubernetesResources)
+		api.DELETE("/kubernetes/providers/:name/resources", c.DeleteKubernetesResources)
+
 	}
 }

--- a/internal/api/v1/payload_test.go
+++ b/internal/api/v1/payload_test.go
@@ -144,3 +144,7 @@ const payloadKubernetesProviderGetGenericError = `{
 const payloadKubernetesProviderDeleteGenericError = `{
             "error": "error deleting provider"
           }`
+
+const payloadKubernetesResourcesDeleteGenericError = `{
+            "error": "error deleting resources"
+          }`

--- a/internal/api/v1/resource.go
+++ b/internal/api/v1/resource.go
@@ -1,0 +1,187 @@
+package v1
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/gin-gonic/gin"
+	"github.com/google/uuid"
+	"github.com/homedepot/go-clouddriver/internal"
+	"github.com/homedepot/go-clouddriver/internal/kubernetes"
+	clouddriver "github.com/homedepot/go-clouddriver/pkg"
+	"github.com/jinzhu/gorm"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+var (
+	// Only need the kinds that show in the infrastructure pages.
+	infrastructureKinds = []string{
+		"daemonSets",
+		"deployments",
+		"ingresses",
+		"pods",
+		"replicaSets",
+		"services",
+		"statefulSets",
+	}
+)
+
+// LoadKubernetesResources populates the Kubernetes resources table
+// by querying the cluster for resources deployed by Spinnaker.
+//
+// The only resources populated are Kubernetes kinds that show in
+// the infrastructure pages (clusters, load balancers, firewalls).
+//   - daemonSets
+//   - deployments
+//   - ingresses
+//   - pods
+//   - replicaSets
+//   - statefulSets
+//   - services
+func (cc *Controller) LoadKubernetesResources(c *gin.Context) {
+	account := c.Param("name")
+
+	// Grab the kube provider for the given account.
+	provider, err := cc.KubernetesProviderWithTimeout(account, time.Second*internal.DefaultListTimeoutSeconds)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	// First, run discovery on this dynamic client before listing resources
+	// concurrently. This is necessary since the rest mapper for dynamic
+	// clients uses a mutex lock. Failure to do this will make concurrent
+	// requests appear to run serially. This is particularly bad if a cluster is not
+	// reachable - even with a timeout of 10 seconds, a request for 4 resources
+	// would take 40 seconds since the API cannot be discovered concurrently.
+	//
+	// See https://github.com/kubernetes/client-go/blob/f6ce18ae578c8cca64d14ab9687824d9e1305a67/restmapper/discovery.go#L194.
+	if err = provider.Client.Discover(); err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Declare a waitgroup to wait on concurrent resource listing.
+	wg := &sync.WaitGroup{}
+	// Add the number of kinds we will be listing concurrently.
+	wg.Add(len(infrastructureKinds))
+	// Create channel of unstructured objects (manifests) to send to.
+	uc := make(chan unstructured.Unstructured, internal.DefaultChanSize)
+	// List all required kinds concurrently.
+	for _, kind := range infrastructureKinds {
+		go listKinds(wg, uc, provider, kind, account)
+	}
+	// Wait for the calls to finish.
+	wg.Wait()
+	// Close the channel.
+	close(uc)
+
+	// Remove existing entries from the DB.
+	err = cc.SQLClient.DeleteKubernetesResourcesByAccountName(account)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	// Use the same task ID for all entries.
+	taskID := uuid.New().String()
+	resources := []kubernetes.Resource{}
+
+	// Create a resource entry in the DB for each unstructured object (manifest).
+	for u := range uc {
+		gvr, err := provider.Client.GVRForKind(u.GetKind())
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+		// Map values to kubernetes.Resource.
+		nameWithoutVersion := kubernetes.NameWithoutVersion(u.GetName())
+		kr := kubernetes.Resource{
+			AccountName:  account,
+			ID:           uuid.New().String(),
+			TaskID:       taskID,
+			Timestamp:    internal.CurrentTimeUTC(),
+			APIGroup:     gvr.Group,
+			Name:         u.GetName(),
+			ArtifactName: nameWithoutVersion,
+			Namespace:    u.GetNamespace(),
+			Resource:     gvr.Resource,
+			Version:      gvr.Version,
+			Kind:         u.GetKind(),
+			SpinnakerApp: kubernetes.SpinnakerMonikerApplication(u),
+			Cluster:      kubernetes.Cluster(u.GetKind(), nameWithoutVersion),
+		}
+		// Insert row into kubernetes_resources table.
+		err = cc.SQLClient.CreateKubernetesResource(kr)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+			return
+		}
+
+		resources = append(resources, kr)
+	}
+
+	c.JSON(http.StatusOK, resources)
+}
+
+// DeleteKubernetesResources deletes the resources from the database
+// for the given provider (account).
+func (cc *Controller) DeleteKubernetesResources(c *gin.Context) {
+	name := c.Param("name")
+
+	_, err := cc.SQLClient.GetKubernetesProvider(name)
+	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "provider not found"})
+			return
+		}
+
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+
+		return
+	}
+
+	err = cc.SQLClient.DeleteKubernetesResourcesByAccountName(name)
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusNoContent, nil)
+}
+
+// listKinds lists a given kind and sends to a channel of unstructured.Unstructured.
+// It uses a context with a timeout of 10 seconds.
+func listKinds(wg *sync.WaitGroup, uc chan unstructured.Unstructured,
+	provider *kubernetes.Provider, kind, account string) {
+	// Finish the wait group when we're done here.
+	defer wg.Done()
+
+	// Declare server side filtering options.
+	lo := metav1.ListOptions{
+		LabelSelector: kubernetes.DefaultLabelSelector(),
+	}
+	// If namespace-scoped account, then only get resources in the namespace.
+	if provider.Namespace != nil {
+		lo.FieldSelector = "metadata.namespace=" + *provider.Namespace
+	}
+
+	// Declare a context with timeout.
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second*internal.DefaultListTimeoutSeconds)
+	defer cancel()
+	// List resources with the context.
+	ul, err := provider.Client.ListResourceWithContext(ctx, kind, lo)
+	if err != nil {
+		// If there was an error, log and return.
+		clouddriver.Log(err)
+		return
+	}
+
+	// Send all unstructured objects to the channel.
+	for _, u := range ul.Items {
+		uc <- u
+	}
+}

--- a/internal/api/v1/resource_test.go
+++ b/internal/api/v1/resource_test.go
@@ -1,0 +1,461 @@
+package v1_test
+
+import (
+	"errors"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	// . "github.com/homedepot/go-clouddriver/internal/api/v1"
+
+	"github.com/homedepot/go-clouddriver/internal/kubernetes"
+	"github.com/jinzhu/gorm"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+var _ = Describe("Resource", func() {
+	Describe("#LoadKubernetesResources", func() {
+		BeforeEach(func() {
+			setup()
+			fakeSQLClient.DeleteKubernetesResourcesByAccountNameReturns(nil)
+			fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{}, nil)
+			log.SetOutput(ioutil.Discard)
+
+			uri = svr.URL + "/v1/kubernetes/providers/test-account/resources"
+			body.Write([]byte(payloadRequestKubernetesProviders))
+			createRequest(http.MethodPut)
+		})
+
+		AfterEach(func() {
+			teardown()
+		})
+
+		JustBeforeEach(func() {
+			doRequest()
+		})
+
+		When("getting the kubernetes provider for an account errors", func() {
+			BeforeEach(func() {
+				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, errors.New("error getting provider"))
+			})
+
+			It("returns internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("discovering API errors", func() {
+			BeforeEach(func() {
+				fakeKubeClient.DiscoverReturns(errors.New("error discovering API"))
+			})
+
+			It("returns internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("listing deployments returns an error", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(0, nil, errors.New("error listing deployments"))
+			})
+
+			It("continues", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+			})
+		})
+
+		When("deleting kubernetes resources errors", func() {
+			BeforeEach(func() {
+				fakeSQLClient.DeleteKubernetesResourcesByAccountNameReturns(errors.New("error deleting resources"))
+			})
+
+			It("returns internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("there are no previously deployed resources", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{}, nil)
+			})
+
+			It("deletes existing resources and returns status OK", func() {
+				Expect(fakeSQLClient.DeleteKubernetesResourcesByAccountNameCallCount()).To(Equal(1))
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+			})
+		})
+
+		When("using a namespace-scoped provider", func() {
+			BeforeEach(func() {
+				namespace := "test-namespace"
+				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{
+					Name:      "test-account",
+					Host:      "http://localhost",
+					CAData:    "",
+					Namespace: &namespace,
+				}, nil)
+			})
+
+			It("sets field selector in list options", func() {
+				_, _, lo := fakeKubeClient.ListResourceWithContextArgsForCall(0)
+				Expect(lo.FieldSelector).To(Equal("metadata.namespace=test-namespace"))
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+			})
+		})
+
+		When("creating kubernetes resource errors", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(0, fakeDaemonSets, nil)
+				fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{}, nil)
+				fakeSQLClient.CreateKubernetesResourceReturns(errors.New("error creating resource"))
+			})
+
+			It("returns internal server error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("list resources returns a daemonset", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(0, fakeDaemonSets, nil)
+				fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{}, nil)
+				fakeKubeClient.GVRForKindReturns(schema.GroupVersionResource{
+					Group:    "apps",
+					Version:  "v1",
+					Resource: "replicasets",
+				}, nil)
+			})
+
+			It("returns status OK", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.ListResourceWithContextCallCount()).To(Equal(7))
+				Expect(fakeSQLClient.DeleteKubernetesResourcesByAccountNameCallCount()).To(Equal(1))
+				Expect(fakeSQLClient.CreateKubernetesResourceCallCount()).To(Equal(1))
+
+				kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+				Expect(kr.AccountName).To(Equal("test-account"))
+				Expect(kr.APIGroup).To(Equal("apps"))
+				Expect(kr.ArtifactName).To(Equal("test-daemonset"))
+				Expect(kr.Cluster).To(Equal("daemonSet test-daemonset"))
+				Expect(kr.ID).ToNot(BeEmpty())
+				Expect(kr.Kind).To(Equal("DaemonSet"))
+				Expect(kr.Name).To(Equal("test-daemonset"))
+				Expect(kr.Namespace).To(Equal("test-namespace"))
+				Expect(kr.Resource).To(Equal("replicasets"))
+				Expect(kr.SpinnakerApp).To(Equal("test-application"))
+				Expect(kr.TaskID).ToNot(BeEmpty())
+				Expect(kr.TaskType).To(BeEmpty())
+				Expect(kr.Timestamp).ToNot(BeNil())
+				Expect(kr.Version).To(Equal("v1"))
+			})
+		})
+
+		When("list resources returns multiple deployments", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(1, fakeDeployments, nil)
+				fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{}, nil)
+				fakeKubeClient.GVRForKindReturns(schema.GroupVersionResource{
+					Group:    "apps",
+					Version:  "v1",
+					Resource: "deployments",
+				}, nil)
+			})
+
+			It("returns status OK", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.ListResourceWithContextCallCount()).To(Equal(7))
+				Expect(fakeSQLClient.DeleteKubernetesResourcesByAccountNameCallCount()).To(Equal(1))
+				Expect(fakeSQLClient.CreateKubernetesResourceCallCount()).To(Equal(2))
+
+				kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+				Expect(kr.AccountName).To(Equal("test-account"))
+				Expect(kr.APIGroup).To(Equal("apps"))
+				Expect(kr.ArtifactName).To(Equal("test-deployment1"))
+				Expect(kr.Cluster).To(Equal("deployment test-deployment1"))
+				Expect(kr.ID).ToNot(BeEmpty())
+				Expect(kr.Kind).To(Equal("Deployment"))
+				Expect(kr.Name).To(Equal("test-deployment1"))
+				Expect(kr.Namespace).To(Equal("test-namespace1"))
+				Expect(kr.Resource).To(Equal("deployments"))
+				Expect(kr.SpinnakerApp).To(Equal("test-application1"))
+				Expect(kr.TaskID).ToNot(BeEmpty())
+				Expect(kr.TaskType).To(BeEmpty())
+				Expect(kr.Timestamp).ToNot(BeNil())
+				Expect(kr.Version).To(Equal("v1"))
+
+				kr = fakeSQLClient.CreateKubernetesResourceArgsForCall(1)
+				Expect(kr.AccountName).To(Equal("test-account"))
+				Expect(kr.APIGroup).To(Equal("apps"))
+				Expect(kr.ArtifactName).To(Equal("test-deployment2"))
+				Expect(kr.Cluster).To(Equal("deployment test-deployment2"))
+				Expect(kr.ID).ToNot(BeEmpty())
+				Expect(kr.Kind).To(Equal("Deployment"))
+				Expect(kr.Name).To(Equal("test-deployment2"))
+				Expect(kr.Namespace).To(Equal("test-namespace2"))
+				Expect(kr.Resource).To(Equal("deployments"))
+				Expect(kr.SpinnakerApp).To(Equal("test-application2"))
+				Expect(kr.TaskID).ToNot(BeEmpty())
+				Expect(kr.TaskType).To(BeEmpty())
+				Expect(kr.Timestamp).ToNot(BeNil())
+				Expect(kr.Version).To(Equal("v1"))
+			})
+		})
+
+		When("list resources returns a ingress", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(2, fakeIngresses, nil)
+				fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{}, nil)
+				fakeKubeClient.GVRForKindReturns(schema.GroupVersionResource{
+					Group:    "",
+					Version:  "v1beta1",
+					Resource: "ingresses",
+				}, nil)
+			})
+
+			It("returns status OK", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.ListResourceWithContextCallCount()).To(Equal(7))
+				Expect(fakeSQLClient.DeleteKubernetesResourcesByAccountNameCallCount()).To(Equal(1))
+				Expect(fakeSQLClient.CreateKubernetesResourceCallCount()).To(Equal(1))
+
+				kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+				Expect(kr.AccountName).To(Equal("test-account"))
+				Expect(kr.APIGroup).To(BeEmpty())
+				Expect(kr.ArtifactName).To(Equal("test-ingress"))
+				Expect(kr.Cluster).To(Equal("ingress test-ingress"))
+				Expect(kr.ID).ToNot(BeEmpty())
+				Expect(kr.Kind).To(Equal("Ingress"))
+				Expect(kr.Name).To(Equal("test-ingress"))
+				Expect(kr.Namespace).To(Equal("test-namespace"))
+				Expect(kr.Resource).To(Equal("ingresses"))
+				Expect(kr.SpinnakerApp).To(Equal("test-application"))
+				Expect(kr.TaskID).ToNot(BeEmpty())
+				Expect(kr.TaskType).To(BeEmpty())
+				Expect(kr.Timestamp).ToNot(BeNil())
+				Expect(kr.Version).To(Equal("v1beta1"))
+			})
+		})
+
+		When("list resources returns a pod", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(3, fakePods, nil)
+				fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{}, nil)
+				fakeKubeClient.GVRForKindReturns(schema.GroupVersionResource{
+					Group:    "",
+					Version:  "v1",
+					Resource: "pods",
+				}, nil)
+			})
+
+			It("returns status OK", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.ListResourceWithContextCallCount()).To(Equal(7))
+				Expect(fakeSQLClient.DeleteKubernetesResourcesByAccountNameCallCount()).To(Equal(1))
+				Expect(fakeSQLClient.CreateKubernetesResourceCallCount()).To(Equal(1))
+
+				kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+				Expect(kr.AccountName).To(Equal("test-account"))
+				Expect(kr.APIGroup).To(BeEmpty())
+				Expect(kr.ArtifactName).To(Equal("test-pod"))
+				Expect(kr.Cluster).To(BeEmpty())
+				Expect(kr.ID).ToNot(BeEmpty())
+				Expect(kr.Kind).To(Equal("Pod"))
+				Expect(kr.Name).To(Equal("test-pod"))
+				Expect(kr.Namespace).To(Equal("test-namespace"))
+				Expect(kr.Resource).To(Equal("pods"))
+				Expect(kr.SpinnakerApp).To(Equal("test-application"))
+				Expect(kr.TaskID).ToNot(BeEmpty())
+				Expect(kr.TaskType).To(BeEmpty())
+				Expect(kr.Timestamp).ToNot(BeNil())
+				Expect(kr.Version).To(Equal("v1"))
+			})
+		})
+
+		When("list resources returns a versioned replicaset", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(4, fakeReplicaSets, nil)
+				fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{}, nil)
+				fakeKubeClient.GVRForKindReturns(schema.GroupVersionResource{
+					Group:    "",
+					Version:  "v1",
+					Resource: "replicasets",
+				}, nil)
+			})
+
+			It("returns status OK and NameWithoutVersion is called", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.ListResourceWithContextCallCount()).To(Equal(7))
+				Expect(fakeSQLClient.DeleteKubernetesResourcesByAccountNameCallCount()).To(Equal(1))
+				Expect(fakeSQLClient.CreateKubernetesResourceCallCount()).To(Equal(1))
+
+				kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+				Expect(kr.AccountName).To(Equal("test-account"))
+				Expect(kr.APIGroup).To(BeEmpty())
+				Expect(kr.ArtifactName).To(Equal("test-replicaset"))
+				Expect(kr.Cluster).To(Equal("replicaSet test-replicaset"))
+				Expect(kr.ID).ToNot(BeEmpty())
+				Expect(kr.Kind).To(Equal("ReplicaSet"))
+				Expect(kr.Name).To(Equal("test-replicaset-v001"))
+				Expect(kr.Namespace).To(Equal("test-namespace"))
+				Expect(kr.Resource).To(Equal("replicasets"))
+				Expect(kr.SpinnakerApp).To(Equal("test-application"))
+				Expect(kr.TaskID).ToNot(BeEmpty())
+				Expect(kr.TaskType).To(BeEmpty())
+				Expect(kr.Timestamp).ToNot(BeNil())
+				Expect(kr.Version).To(Equal("v1"))
+			})
+		})
+
+		When("list resources returns a service", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(5, fakeServices, nil)
+				fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{}, nil)
+				fakeKubeClient.GVRForKindReturns(schema.GroupVersionResource{
+					Group:    "",
+					Version:  "v1",
+					Resource: "services",
+				}, nil)
+			})
+
+			It("returns status OK", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.ListResourceWithContextCallCount()).To(Equal(7))
+				Expect(fakeSQLClient.DeleteKubernetesResourcesByAccountNameCallCount()).To(Equal(1))
+				Expect(fakeSQLClient.CreateKubernetesResourceCallCount()).To(Equal(1))
+
+				kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+				Expect(kr.AccountName).To(Equal("test-account"))
+				Expect(kr.APIGroup).To(BeEmpty())
+				Expect(kr.ArtifactName).To(Equal("test-service"))
+				Expect(kr.Cluster).To(Equal("service test-service"))
+				Expect(kr.ID).ToNot(BeEmpty())
+				Expect(kr.Kind).To(Equal("Service"))
+				Expect(kr.Name).To(Equal("test-service"))
+				Expect(kr.Namespace).To(Equal("test-namespace"))
+				Expect(kr.Resource).To(Equal("services"))
+				Expect(kr.SpinnakerApp).To(Equal("test-application"))
+				Expect(kr.TaskID).ToNot(BeEmpty())
+				Expect(kr.TaskType).To(BeEmpty())
+				Expect(kr.Timestamp).ToNot(BeNil())
+				Expect(kr.Version).To(Equal("v1"))
+			})
+		})
+
+		When("list resources returns a statefulset", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(6, fakeStatefulSets, nil)
+				fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{}, nil)
+				fakeKubeClient.GVRForKindReturns(schema.GroupVersionResource{
+					Group:    "",
+					Version:  "v1",
+					Resource: "statefulsets",
+				}, nil)
+			})
+
+			It("returns status OK", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.ListResourceWithContextCallCount()).To(Equal(7))
+				Expect(fakeSQLClient.DeleteKubernetesResourcesByAccountNameCallCount()).To(Equal(1))
+				Expect(fakeSQLClient.CreateKubernetesResourceCallCount()).To(Equal(1))
+
+				kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+				Expect(kr.AccountName).To(Equal("test-account"))
+				Expect(kr.APIGroup).To(BeEmpty())
+				Expect(kr.ArtifactName).To(Equal("test-statefulset"))
+				Expect(kr.Cluster).To(Equal("statefulSet test-statefulset"))
+				Expect(kr.ID).ToNot(BeEmpty())
+				Expect(kr.Kind).To(Equal("StatefulSet"))
+				Expect(kr.Name).To(Equal("test-statefulset"))
+				Expect(kr.Namespace).To(Equal("test-namespace"))
+				Expect(kr.Resource).To(Equal("statefulsets"))
+				Expect(kr.SpinnakerApp).To(Equal("test-application"))
+				Expect(kr.TaskID).ToNot(BeEmpty())
+				Expect(kr.TaskType).To(BeEmpty())
+				Expect(kr.Timestamp).ToNot(BeNil())
+				Expect(kr.Version).To(Equal("v1"))
+			})
+		})
+
+		When("All list resources call return resources", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(0, fakeDaemonSets, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(1, fakeDeployments, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(2, fakeIngresses, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(3, fakePods, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(4, fakeReplicaSets, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(5, fakeServices, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(6, fakeStatefulSets, nil)
+				fakeKubeClient.GVRForKindReturns(schema.GroupVersionResource{
+					Group:    "",
+					Version:  "v1",
+					Resource: "statefulsets",
+				}, nil)
+			})
+
+			It("returns status OK and creates all resource rows", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.ListResourceWithContextCallCount()).To(Equal(7))
+				Expect(fakeSQLClient.DeleteKubernetesResourcesByAccountNameCallCount()).To(Equal(1))
+				Expect(fakeSQLClient.CreateKubernetesResourceCallCount()).To(Equal(8))
+			})
+		})
+	})
+
+	Describe("#DeleteKubernetesResources", func() {
+		BeforeEach(func() {
+			setup()
+			uri = svr.URL + "/v1/kubernetes/providers/test-name/resources"
+			createRequest(http.MethodDelete)
+		})
+
+		AfterEach(func() {
+			teardown()
+		})
+
+		JustBeforeEach(func() {
+			doRequest()
+		})
+
+		When("the record is not found", func() {
+			BeforeEach(func() {
+				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, gorm.ErrRecordNotFound)
+			})
+
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusNotFound))
+				validateResponse(payloadKubernetesProviderNotFound)
+			})
+		})
+
+		When("getting the provider returns a generic error", func() {
+			BeforeEach(func() {
+				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, errors.New("error getting provider"))
+			})
+
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				validateResponse(payloadKubernetesProviderGetGenericError)
+			})
+		})
+
+		When("deleting the resources returns an error", func() {
+			BeforeEach(func() {
+				fakeSQLClient.DeleteKubernetesResourcesByAccountNameReturns(errors.New("error deleting resources"))
+			})
+
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				validateResponse(payloadKubernetesResourcesDeleteGenericError)
+			})
+		})
+
+		When("it succeeds", func() {
+			It("returns status no content", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusNoContent))
+			})
+		})
+	})
+})

--- a/internal/controller.go
+++ b/internal/controller.go
@@ -13,6 +13,11 @@ import (
 	"k8s.io/client-go/rest"
 )
 
+const (
+	DefaultChanSize           = 100000
+	DefaultListTimeoutSeconds = 10
+)
+
 // Controller holds all non request-scoped objects.
 type Controller struct {
 	ArcadeClient                  arcade.Client

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -15,6 +15,11 @@ import (
 )
 
 var _ = Describe("Controller", func() {
+	Describe("#const", func() {
+		Expect(internal.DefaultListTimeoutSeconds).To(Equal(10))
+		Expect(internal.DefaultChanSize).To(Equal(100000))
+	})
+
 	var (
 		c                        *internal.Controller
 		fakeSQLClient            *sqlfakes.FakeClient

--- a/internal/kubernetes/annotation.go
+++ b/internal/kubernetes/annotation.go
@@ -125,3 +125,17 @@ func AnnotateTemplate(u *unstructured.Unstructured, key, value string) error {
 
 	return nil
 }
+
+// SpinnakerMonikerApplication returns the value the annotation
+// `moniker.spinnaker.io/application` of the given Kubernetes
+// unstructured resource, or an empty string if not present.
+func SpinnakerMonikerApplication(u unstructured.Unstructured) string {
+	annotations := u.GetAnnotations()
+	if annotations != nil {
+		if value, ok := annotations[AnnotationSpinnakerMonikerApplication]; ok {
+			return value
+		}
+	}
+
+	return ""
+}

--- a/internal/kubernetes/annotation_test.go
+++ b/internal/kubernetes/annotation_test.go
@@ -597,4 +597,48 @@ var _ = Describe("Annotation", func() {
 			})
 		})
 	})
+
+	Context("#SpinnakerMonikerApplication", func() {
+		var (
+			fakeResource unstructured.Unstructured
+			value        string
+		)
+
+		JustBeforeEach(func() {
+			value = SpinnakerMonikerApplication(fakeResource)
+		})
+
+		When("annotation is missing", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+					},
+				}
+			})
+
+			It("returns empty string", func() {
+				Expect(value).To(BeEmpty())
+			})
+		})
+
+		When("annotation is set", func() {
+			BeforeEach(func() {
+				fakeResource = unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"kind": "Deployment",
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"moniker.spinnaker.io/application": "test-application",
+							},
+						},
+					},
+				}
+			})
+
+			It("returns annotation value", func() {
+				Expect(value).To(Equal("test-application"))
+			})
+		})
+	})
 })

--- a/internal/kubernetes/cluster.go
+++ b/internal/kubernetes/cluster.go
@@ -1,0 +1,33 @@
+package kubernetes
+
+import (
+	"fmt"
+	"strings"
+	"unicode"
+)
+
+// Generate the cluster that a kind is a part of.
+// A Kubernetes cluster is of kind deployment, statefulSet, replicaSet, ingress, service, and daemonSet
+// so only generate a cluster for these kinds.
+func Cluster(kind, name string) string {
+	cluster := ""
+
+	if strings.EqualFold(kind, "deployment") ||
+		strings.EqualFold(kind, "statefulSet") ||
+		strings.EqualFold(kind, "replicaSet") ||
+		strings.EqualFold(kind, "ingress") ||
+		strings.EqualFold(kind, "service") ||
+		strings.EqualFold(kind, "daemonSet") {
+		cluster = fmt.Sprintf("%s %s", lowercaseFirst(kind), name)
+	}
+
+	return cluster
+}
+
+func lowercaseFirst(str string) string {
+	for i, v := range str {
+		return string(unicode.ToLower(v)) + str[i+1:]
+	}
+
+	return ""
+}

--- a/internal/kubernetes/cluster_test.go
+++ b/internal/kubernetes/cluster_test.go
@@ -1,0 +1,90 @@
+package kubernetes_test
+
+import (
+	. "github.com/homedepot/go-clouddriver/internal/kubernetes"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Cluster", func() {
+	Describe("#Cluster", func() {
+		var (
+			kind    string
+			cluster string
+		)
+
+		JustBeforeEach(func() {
+			cluster = Cluster(kind, "test-name")
+		})
+
+		When("the kind is daemonSet", func() {
+			BeforeEach(func() {
+				kind = "DaemonSet"
+			})
+
+			It("sets the cluster", func() {
+				Expect(cluster).To(Equal("daemonSet test-name"))
+			})
+		})
+
+		When("the kind is deployment", func() {
+			BeforeEach(func() {
+				kind = "Deployment"
+			})
+
+			It("sets the cluster", func() {
+				Expect(cluster).To(Equal("deployment test-name"))
+			})
+		})
+
+		When("the kind is ingress", func() {
+			BeforeEach(func() {
+				kind = "Ingress"
+			})
+
+			It("sets the cluster", func() {
+				Expect(cluster).To(Equal("ingress test-name"))
+			})
+		})
+
+		When("the kind is replicaSet", func() {
+			BeforeEach(func() {
+				kind = "ReplicaSet"
+			})
+
+			It("sets the cluster", func() {
+				Expect(cluster).To(Equal("replicaSet test-name"))
+			})
+		})
+
+		When("the kind is service", func() {
+			BeforeEach(func() {
+				kind = "Service"
+			})
+
+			It("sets the cluster", func() {
+				Expect(cluster).To(Equal("service test-name"))
+			})
+		})
+
+		When("the kind is statefulSet", func() {
+			BeforeEach(func() {
+				kind = "StatefulSet"
+			})
+
+			It("sets the cluster", func() {
+				Expect(cluster).To(Equal("statefulSet test-name"))
+			})
+		})
+
+		When("the kind is not a cluster type", func() {
+			BeforeEach(func() {
+				kind = "Pod"
+			})
+
+			It("does not set the cluster", func() {
+				Expect(cluster).To(BeEmpty())
+			})
+		})
+	})
+})

--- a/internal/kubernetes/resource.go
+++ b/internal/kubernetes/resource.go
@@ -10,7 +10,7 @@ type Resource struct {
 	TaskType     string    `json:"-"`
 	APIGroup     string    `json:"apiGroup"`
 	Name         string    `json:"name"`
-	ArtifactName string    `json:"_"`
+	ArtifactName string    `json:"-"`
 	Namespace    string    `json:"namespace"`
 	Resource     string    `json:"resource"`
 	Version      string    `json:"version"`

--- a/internal/kubernetes/version.go
+++ b/internal/kubernetes/version.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -13,8 +14,13 @@ const (
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/
 	AnnotationSpinnakerArtifactVersion = `artifact.spinnaker.io/version`
 	AnnotationSpinnakerMonikerSequence = `moniker.spinnaker.io/sequence`
-	// Maximum latest version before cycling back to V000.
+	// Maximum latest version before cycling back to v000.
 	maxLatestVersion = 999
+)
+
+var (
+	// Regular expresion to match trailing '-v###'
+	matchSpinnakerVersionRegexp = regexp.MustCompile("-v[0-9]{3}[0-9]*$")
 )
 
 type SpinnakerVersion struct {
@@ -94,4 +100,10 @@ func IncrementVersion(currentVersion string) SpinnakerVersion {
 		Short: latestVersionShortFormat,
 		Long:  latestVersionLongFormat,
 	}
+}
+
+// NameWithVersion removes the Spinnaker version (trailing '-v###)
+// from the name.
+func NameWithoutVersion(name string) string {
+	return matchSpinnakerVersionRegexp.ReplaceAllString(name, "")
 }

--- a/internal/kubernetes/version_test.go
+++ b/internal/kubernetes/version_test.go
@@ -279,4 +279,28 @@ var _ = Describe("Version", func() {
 			})
 		})
 	})
+
+	Context("#NameWithoutVersion", func() {
+		When("name is not versioned", func() {
+			It("returns the name", func() {
+				Expect(NameWithoutVersion("")).To(Equal(""))
+				Expect(NameWithoutVersion("test-name")).To(Equal("test-name"))
+				Expect(NameWithoutVersion("test-v001-name")).To(Equal("test-v001-name"))
+				// Must be 3 or more digits
+				Expect(NameWithoutVersion("test-name-v1")).To(Equal("test-name-v1"))
+				Expect(NameWithoutVersion("test-name-v99")).To(Equal("test-name-v99"))
+				// Must be lowercase 'v'
+				Expect(NameWithoutVersion("test-name-V001")).To(Equal("test-name-V001"))
+			})
+		})
+
+		When("name is versioned", func() {
+			It("returns the name with the version removed", func() {
+				Expect(NameWithoutVersion("test-name-v000")).To(Equal("test-name"))
+				Expect(NameWithoutVersion("test-name-v999")).To(Equal("test-name"))
+				Expect(NameWithoutVersion("test-name-v1000")).To(Equal("test-name"))
+			})
+		})
+	})
+
 })

--- a/internal/sql/sql.go
+++ b/internal/sql/sql.go
@@ -30,6 +30,7 @@ type Client interface {
 	CreateKubernetesProvider(kubernetes.Provider) error
 	CreateKubernetesResource(kubernetes.Resource) error
 	DeleteKubernetesProvider(string) error
+	DeleteKubernetesResourcesByAccountName(string) error
 	GetKubernetesProvider(string) (kubernetes.Provider, error)
 	GetKubernetesProviderAndPermissions(string) (kubernetes.Provider, error)
 	ListKubernetesAccountsBySpinnakerApp(string) ([]string, error)
@@ -151,6 +152,16 @@ func (c *client) DeleteKubernetesProvider(name string) error {
 	}
 
 	err = c.db.Where("account_name = ?", name).Delete(&clouddriver.WritePermission{}).Error
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// DeleteKubernetesResources deletes all resources for the given provider from the DB.
+func (c *client) DeleteKubernetesResourcesByAccountName(account string) error {
+	err := c.db.Where("account_name = ?", account).Delete(&kubernetes.Resource{}).Error
 	if err != nil {
 		return err
 	}

--- a/internal/sql/sql_test.go
+++ b/internal/sql/sql_test.go
@@ -220,6 +220,32 @@ var _ = Describe("Sql", func() {
 		})
 	})
 
+	Describe("#DeleteKubernetesResourcesByAccountName", func() {
+		var name string
+
+		BeforeEach(func() {
+			name = "test-name"
+		})
+
+		JustBeforeEach(func() {
+			err = c.DeleteKubernetesResourcesByAccountName(name)
+		})
+
+		When("it succeeds", func() {
+			BeforeEach(func() {
+				mock.ExpectBegin()
+				mock.ExpectExec(`(?i)^DELETE FROM "kubernetes_resources" WHERE
+				\(account_name = \?\)$`).
+					WillReturnResult(sqlmock.NewResult(1, 1))
+				mock.ExpectCommit()
+			})
+
+			It("succeeds", func() {
+				Expect(err).To(BeNil())
+			})
+		})
+	})
+
 	Describe("#GetKubernetesProvider", func() {
 		var provider kubernetes.Provider
 

--- a/internal/sql/sqlfakes/fake_client.go
+++ b/internal/sql/sqlfakes/fake_client.go
@@ -42,6 +42,17 @@ type FakeClient struct {
 	deleteKubernetesProviderReturnsOnCall map[int]struct {
 		result1 error
 	}
+	DeleteKubernetesResourcesByAccountNameStub        func(string) error
+	deleteKubernetesResourcesByAccountNameMutex       sync.RWMutex
+	deleteKubernetesResourcesByAccountNameArgsForCall []struct {
+		arg1 string
+	}
+	deleteKubernetesResourcesByAccountNameReturns struct {
+		result1 error
+	}
+	deleteKubernetesResourcesByAccountNameReturnsOnCall map[int]struct {
+		result1 error
+	}
 	GetKubernetesProviderStub        func(string) (kubernetes.Provider, error)
 	getKubernetesProviderMutex       sync.RWMutex
 	getKubernetesProviderArgsForCall []struct {
@@ -208,16 +219,15 @@ func (fake *FakeClient) CreateKubernetesProvider(arg1 kubernetes.Provider) error
 	fake.createKubernetesProviderArgsForCall = append(fake.createKubernetesProviderArgsForCall, struct {
 		arg1 kubernetes.Provider
 	}{arg1})
-	stub := fake.CreateKubernetesProviderStub
-	fakeReturns := fake.createKubernetesProviderReturns
 	fake.recordInvocation("CreateKubernetesProvider", []interface{}{arg1})
 	fake.createKubernetesProviderMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.CreateKubernetesProviderStub != nil {
+		return fake.CreateKubernetesProviderStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.createKubernetesProviderReturns
 	return fakeReturns.result1
 }
 
@@ -269,16 +279,15 @@ func (fake *FakeClient) CreateKubernetesResource(arg1 kubernetes.Resource) error
 	fake.createKubernetesResourceArgsForCall = append(fake.createKubernetesResourceArgsForCall, struct {
 		arg1 kubernetes.Resource
 	}{arg1})
-	stub := fake.CreateKubernetesResourceStub
-	fakeReturns := fake.createKubernetesResourceReturns
 	fake.recordInvocation("CreateKubernetesResource", []interface{}{arg1})
 	fake.createKubernetesResourceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.CreateKubernetesResourceStub != nil {
+		return fake.CreateKubernetesResourceStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.createKubernetesResourceReturns
 	return fakeReturns.result1
 }
 
@@ -330,16 +339,15 @@ func (fake *FakeClient) DeleteKubernetesProvider(arg1 string) error {
 	fake.deleteKubernetesProviderArgsForCall = append(fake.deleteKubernetesProviderArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.DeleteKubernetesProviderStub
-	fakeReturns := fake.deleteKubernetesProviderReturns
 	fake.recordInvocation("DeleteKubernetesProvider", []interface{}{arg1})
 	fake.deleteKubernetesProviderMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.DeleteKubernetesProviderStub != nil {
+		return fake.DeleteKubernetesProviderStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.deleteKubernetesProviderReturns
 	return fakeReturns.result1
 }
 
@@ -385,22 +393,81 @@ func (fake *FakeClient) DeleteKubernetesProviderReturnsOnCall(i int, result1 err
 	}{result1}
 }
 
+func (fake *FakeClient) DeleteKubernetesResourcesByAccountName(arg1 string) error {
+	fake.deleteKubernetesResourcesByAccountNameMutex.Lock()
+	ret, specificReturn := fake.deleteKubernetesResourcesByAccountNameReturnsOnCall[len(fake.deleteKubernetesResourcesByAccountNameArgsForCall)]
+	fake.deleteKubernetesResourcesByAccountNameArgsForCall = append(fake.deleteKubernetesResourcesByAccountNameArgsForCall, struct {
+		arg1 string
+	}{arg1})
+	fake.recordInvocation("DeleteKubernetesResourcesByAccountName", []interface{}{arg1})
+	fake.deleteKubernetesResourcesByAccountNameMutex.Unlock()
+	if fake.DeleteKubernetesResourcesByAccountNameStub != nil {
+		return fake.DeleteKubernetesResourcesByAccountNameStub(arg1)
+	}
+	if specificReturn {
+		return ret.result1
+	}
+	fakeReturns := fake.deleteKubernetesResourcesByAccountNameReturns
+	return fakeReturns.result1
+}
+
+func (fake *FakeClient) DeleteKubernetesResourcesByAccountNameCallCount() int {
+	fake.deleteKubernetesResourcesByAccountNameMutex.RLock()
+	defer fake.deleteKubernetesResourcesByAccountNameMutex.RUnlock()
+	return len(fake.deleteKubernetesResourcesByAccountNameArgsForCall)
+}
+
+func (fake *FakeClient) DeleteKubernetesResourcesByAccountNameCalls(stub func(string) error) {
+	fake.deleteKubernetesResourcesByAccountNameMutex.Lock()
+	defer fake.deleteKubernetesResourcesByAccountNameMutex.Unlock()
+	fake.DeleteKubernetesResourcesByAccountNameStub = stub
+}
+
+func (fake *FakeClient) DeleteKubernetesResourcesByAccountNameArgsForCall(i int) string {
+	fake.deleteKubernetesResourcesByAccountNameMutex.RLock()
+	defer fake.deleteKubernetesResourcesByAccountNameMutex.RUnlock()
+	argsForCall := fake.deleteKubernetesResourcesByAccountNameArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) DeleteKubernetesResourcesByAccountNameReturns(result1 error) {
+	fake.deleteKubernetesResourcesByAccountNameMutex.Lock()
+	defer fake.deleteKubernetesResourcesByAccountNameMutex.Unlock()
+	fake.DeleteKubernetesResourcesByAccountNameStub = nil
+	fake.deleteKubernetesResourcesByAccountNameReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeClient) DeleteKubernetesResourcesByAccountNameReturnsOnCall(i int, result1 error) {
+	fake.deleteKubernetesResourcesByAccountNameMutex.Lock()
+	defer fake.deleteKubernetesResourcesByAccountNameMutex.Unlock()
+	fake.DeleteKubernetesResourcesByAccountNameStub = nil
+	if fake.deleteKubernetesResourcesByAccountNameReturnsOnCall == nil {
+		fake.deleteKubernetesResourcesByAccountNameReturnsOnCall = make(map[int]struct {
+			result1 error
+		})
+	}
+	fake.deleteKubernetesResourcesByAccountNameReturnsOnCall[i] = struct {
+		result1 error
+	}{result1}
+}
+
 func (fake *FakeClient) GetKubernetesProvider(arg1 string) (kubernetes.Provider, error) {
 	fake.getKubernetesProviderMutex.Lock()
 	ret, specificReturn := fake.getKubernetesProviderReturnsOnCall[len(fake.getKubernetesProviderArgsForCall)]
 	fake.getKubernetesProviderArgsForCall = append(fake.getKubernetesProviderArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.GetKubernetesProviderStub
-	fakeReturns := fake.getKubernetesProviderReturns
 	fake.recordInvocation("GetKubernetesProvider", []interface{}{arg1})
 	fake.getKubernetesProviderMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.GetKubernetesProviderStub != nil {
+		return fake.GetKubernetesProviderStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.getKubernetesProviderReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -455,16 +522,15 @@ func (fake *FakeClient) GetKubernetesProviderAndPermissions(arg1 string) (kubern
 	fake.getKubernetesProviderAndPermissionsArgsForCall = append(fake.getKubernetesProviderAndPermissionsArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.GetKubernetesProviderAndPermissionsStub
-	fakeReturns := fake.getKubernetesProviderAndPermissionsReturns
 	fake.recordInvocation("GetKubernetesProviderAndPermissions", []interface{}{arg1})
 	fake.getKubernetesProviderAndPermissionsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.GetKubernetesProviderAndPermissionsStub != nil {
+		return fake.GetKubernetesProviderAndPermissionsStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.getKubernetesProviderAndPermissionsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -519,16 +585,15 @@ func (fake *FakeClient) ListKubernetesAccountsBySpinnakerApp(arg1 string) ([]str
 	fake.listKubernetesAccountsBySpinnakerAppArgsForCall = append(fake.listKubernetesAccountsBySpinnakerAppArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListKubernetesAccountsBySpinnakerAppStub
-	fakeReturns := fake.listKubernetesAccountsBySpinnakerAppReturns
 	fake.recordInvocation("ListKubernetesAccountsBySpinnakerApp", []interface{}{arg1})
 	fake.listKubernetesAccountsBySpinnakerAppMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ListKubernetesAccountsBySpinnakerAppStub != nil {
+		return fake.ListKubernetesAccountsBySpinnakerAppStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listKubernetesAccountsBySpinnakerAppReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -583,16 +648,15 @@ func (fake *FakeClient) ListKubernetesClustersByApplication(arg1 string) ([]kube
 	fake.listKubernetesClustersByApplicationArgsForCall = append(fake.listKubernetesClustersByApplicationArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListKubernetesClustersByApplicationStub
-	fakeReturns := fake.listKubernetesClustersByApplicationReturns
 	fake.recordInvocation("ListKubernetesClustersByApplication", []interface{}{arg1})
 	fake.listKubernetesClustersByApplicationMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ListKubernetesClustersByApplicationStub != nil {
+		return fake.ListKubernetesClustersByApplicationStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listKubernetesClustersByApplicationReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -647,16 +711,15 @@ func (fake *FakeClient) ListKubernetesClustersByFields(arg1 ...string) ([]kubern
 	fake.listKubernetesClustersByFieldsArgsForCall = append(fake.listKubernetesClustersByFieldsArgsForCall, struct {
 		arg1 []string
 	}{arg1})
-	stub := fake.ListKubernetesClustersByFieldsStub
-	fakeReturns := fake.listKubernetesClustersByFieldsReturns
 	fake.recordInvocation("ListKubernetesClustersByFields", []interface{}{arg1})
 	fake.listKubernetesClustersByFieldsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1...)
+	if fake.ListKubernetesClustersByFieldsStub != nil {
+		return fake.ListKubernetesClustersByFieldsStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listKubernetesClustersByFieldsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -710,16 +773,15 @@ func (fake *FakeClient) ListKubernetesProviders() ([]kubernetes.Provider, error)
 	ret, specificReturn := fake.listKubernetesProvidersReturnsOnCall[len(fake.listKubernetesProvidersArgsForCall)]
 	fake.listKubernetesProvidersArgsForCall = append(fake.listKubernetesProvidersArgsForCall, struct {
 	}{})
-	stub := fake.ListKubernetesProvidersStub
-	fakeReturns := fake.listKubernetesProvidersReturns
 	fake.recordInvocation("ListKubernetesProviders", []interface{}{})
 	fake.listKubernetesProvidersMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ListKubernetesProvidersStub != nil {
+		return fake.ListKubernetesProvidersStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listKubernetesProvidersReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -766,16 +828,15 @@ func (fake *FakeClient) ListKubernetesProvidersAndPermissions() ([]kubernetes.Pr
 	ret, specificReturn := fake.listKubernetesProvidersAndPermissionsReturnsOnCall[len(fake.listKubernetesProvidersAndPermissionsArgsForCall)]
 	fake.listKubernetesProvidersAndPermissionsArgsForCall = append(fake.listKubernetesProvidersAndPermissionsArgsForCall, struct {
 	}{})
-	stub := fake.ListKubernetesProvidersAndPermissionsStub
-	fakeReturns := fake.listKubernetesProvidersAndPermissionsReturns
 	fake.recordInvocation("ListKubernetesProvidersAndPermissions", []interface{}{})
 	fake.listKubernetesProvidersAndPermissionsMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.ListKubernetesProvidersAndPermissionsStub != nil {
+		return fake.ListKubernetesProvidersAndPermissionsStub()
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listKubernetesProvidersAndPermissionsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -825,16 +886,15 @@ func (fake *FakeClient) ListKubernetesResourceNamesByAccountNameAndKindAndNamesp
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
-	stub := fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub
-	fakeReturns := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns
 	fake.recordInvocation("ListKubernetesResourceNamesByAccountNameAndKindAndNamespace", []interface{}{arg1, arg2, arg3})
 	fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
+	if fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub != nil {
+		return fake.ListKubernetesResourceNamesByAccountNameAndKindAndNamespaceStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listKubernetesResourceNamesByAccountNameAndKindAndNamespaceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -889,16 +949,15 @@ func (fake *FakeClient) ListKubernetesResourcesByFields(arg1 ...string) ([]kuber
 	fake.listKubernetesResourcesByFieldsArgsForCall = append(fake.listKubernetesResourcesByFieldsArgsForCall, struct {
 		arg1 []string
 	}{arg1})
-	stub := fake.ListKubernetesResourcesByFieldsStub
-	fakeReturns := fake.listKubernetesResourcesByFieldsReturns
 	fake.recordInvocation("ListKubernetesResourcesByFields", []interface{}{arg1})
 	fake.listKubernetesResourcesByFieldsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1...)
+	if fake.ListKubernetesResourcesByFieldsStub != nil {
+		return fake.ListKubernetesResourcesByFieldsStub(arg1...)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listKubernetesResourcesByFieldsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -953,16 +1012,15 @@ func (fake *FakeClient) ListKubernetesResourcesByTaskID(arg1 string) ([]kubernet
 	fake.listKubernetesResourcesByTaskIDArgsForCall = append(fake.listKubernetesResourcesByTaskIDArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListKubernetesResourcesByTaskIDStub
-	fakeReturns := fake.listKubernetesResourcesByTaskIDReturns
 	fake.recordInvocation("ListKubernetesResourcesByTaskID", []interface{}{arg1})
 	fake.listKubernetesResourcesByTaskIDMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ListKubernetesResourcesByTaskIDStub != nil {
+		return fake.ListKubernetesResourcesByTaskIDStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listKubernetesResourcesByTaskIDReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1017,16 +1075,15 @@ func (fake *FakeClient) ListReadGroupsByAccountName(arg1 string) ([]string, erro
 	fake.listReadGroupsByAccountNameArgsForCall = append(fake.listReadGroupsByAccountNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListReadGroupsByAccountNameStub
-	fakeReturns := fake.listReadGroupsByAccountNameReturns
 	fake.recordInvocation("ListReadGroupsByAccountName", []interface{}{arg1})
 	fake.listReadGroupsByAccountNameMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ListReadGroupsByAccountNameStub != nil {
+		return fake.ListReadGroupsByAccountNameStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listReadGroupsByAccountNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1081,16 +1138,15 @@ func (fake *FakeClient) ListWriteGroupsByAccountName(arg1 string) ([]string, err
 	fake.listWriteGroupsByAccountNameArgsForCall = append(fake.listWriteGroupsByAccountNameArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.ListWriteGroupsByAccountNameStub
-	fakeReturns := fake.listWriteGroupsByAccountNameReturns
 	fake.recordInvocation("ListWriteGroupsByAccountName", []interface{}{arg1})
 	fake.listWriteGroupsByAccountNameMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ListWriteGroupsByAccountNameStub != nil {
+		return fake.ListWriteGroupsByAccountNameStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listWriteGroupsByAccountNameReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1148,6 +1204,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.createKubernetesResourceMutex.RUnlock()
 	fake.deleteKubernetesProviderMutex.RLock()
 	defer fake.deleteKubernetesProviderMutex.RUnlock()
+	fake.deleteKubernetesResourcesByAccountNameMutex.RLock()
+	defer fake.deleteKubernetesResourcesByAccountNameMutex.RUnlock()
 	fake.getKubernetesProviderMutex.RLock()
 	defer fake.getKubernetesProviderMutex.RUnlock()
 	fake.getKubernetesProviderAndPermissionsMutex.RLock()


### PR DESCRIPTION
This PR:
- Adds `PUT /v1/kubernetes/provider/:name/resources` API Endpoint which retrieves 'infrastructure pages' kinds from the provider's cluster and creates entries in the `kubernetes_resources` table for each one.  This is a flush and fill, all entries from the `kubernetes_resources` for the provider name are first deleted before the rows are inserted.  I considered a few options before deciding on PUT
   1. Adding a query parameter to the `POST/PUT /v1/kuberentes/provider` API endpoint to indicate where or not to load the resources, but then needed to decide how to handle when the resources couldn't be retrieved.  Should the provider still be created or not?  I decided it is cleaner to  maintain resource creation separate from provider creation.
   2. Creating a `POST /v1/kubernetes/provider/:name/loadResources` API endpoint, but found this [SO Post](https://softwareengineering.stackexchange.com/questions/261552/which-http-verb-should-i-use-to-trigger-an-action-in-a-rest-web-service), with this comment that I agreed with.
   
      > You have an RPC (remote procedure call), which isn't RESTful - you want to DO something on the server. So if you're trying to create a purely RESTful API, you should reconsider what you're doing.
      >
      > That said, sometimes you do need to bend the rules a bit. Especially if you're developing an internal api that isn't going to be exposed to the public, you may decide that the trade-off is worth it.
      >
      > If you do, I would recommend a PUT or POST, depending on whether or not the RPC is idempotent or not.
   
- Adds `DELETE /v1/kubernetes/provider/:name/resources` API Endpoint which deletes all rows from the `kubernetes_resources` table for the given provider name.
  - No real need for this endpoint, but since the `DeleteKubernetesResourcesByAccountName` function was created to support the flush and fill, I decided to exposed it.
- Moves the `cluster(kind, name)` function to kubernetes packages so that it can be called by `applications.go` and `resources.go`
- Moves the constants `DefaultChanSize` and `DefaultListTimeoutSeconds` to the internal package so that they can be used by `deploy.go` and `resources.go`