### PR TITLE
Associate pod only once to same server group

### DIFF
--- a/internal/api/core/applications.go
+++ b/internal/api/core/applications.go
@@ -872,12 +872,26 @@ func makeServerGroupMap(pods []resource) map[string][]Instance {
 			if uid == "" {
 				continue
 			}
-
-			serverGroupMap[uid] = append(serverGroupMap[uid], newInstance(pod.u))
+			// Add pod to the server group, if it doesn't already contain it.
+			if !containsPod(serverGroupMap[uid], pod) {
+				serverGroupMap[uid] = append(serverGroupMap[uid], newInstance(pod.u))
+			}
 		}
 	}
 
 	return serverGroupMap
+}
+
+// containsPod returns true if the given slice of pod instances
+// contains an element with the same UID as the given pod.
+func containsPod(instances []Instance, pod resource) bool {
+	for _, instance := range instances {
+		if instance.ID == string(pod.u.GetUID()) {
+			return true
+		}
+	}
+
+	return false
 }
 
 // newInstance returns an "Instance" object from a given

--- a/internal/api/core/applications_test.go
+++ b/internal/api/core/applications_test.go
@@ -2259,6 +2259,120 @@ var _ = Describe("Application", func() {
 			})
 		})
 
+		When("the same pod instance is returned more than once", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(0, &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"kind":       "Pod",
+								"apiVersion": "v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-pod3",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
+									"labels": map[string]interface{}{
+										"label1": "test-label1",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-rs1",
+											"kind": "replicaSet",
+											"uid":  "test-uid1",
+										},
+									},
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100000",
+								},
+							},
+						},
+						{
+							Object: map[string]interface{}{
+								"kind":       "Pod",
+								"apiVersion": "v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-pod3",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"moniker.spinnaker.io/application": "test-application",
+									},
+									"labels": map[string]interface{}{
+										"label1": "test-label1",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-rs1",
+											"kind": "replicaSet",
+											"uid":  "test-uid1",
+										},
+									},
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100000",
+								},
+							},
+						},
+					},
+				}, nil)
+				fakeKubeClient.ListResourceWithContextReturnsOnCall(1, &unstructured.UnstructuredList{
+					Items: []unstructured.Unstructured{
+						{
+							Object: map[string]interface{}{
+								"kind":       "ReplicaSet",
+								"apiVersion": "apps/v1",
+								"metadata": map[string]interface{}{
+									"name":              "test-rs1",
+									"namespace":         "test-namespace1",
+									"creationTimestamp": "2020-02-13T14:12:03Z",
+									"annotations": map[string]interface{}{
+										"artifact.spinnaker.io/name":       "test-deployment1",
+										"artifact.spinnaker.io/type":       "kubernetes/deployment",
+										"artifact.spinnaker.io/location":   "test-namespace1",
+										"moniker.spinnaker.io/application": "test-application",
+										"moniker.spinnaker.io/cluster":     "deployment test-deployment1",
+										"moniker.spinnaker.io/sequence":    "19",
+									},
+									"ownerReferences": []interface{}{
+										map[string]interface{}{
+											"name": "test-deployment1",
+											"kind": "Deployment",
+											"uid":  "test-uid3",
+										},
+									},
+									"uid": "test-uid1",
+								},
+								"spec": map[string]interface{}{
+									"replicas": 1,
+									"template": map[string]interface{}{
+										"spec": map[string]interface{}{
+											"containers": []map[string]interface{}{
+												{
+													"image": "test-image1",
+												},
+												{
+													"image": "test-image2",
+												},
+											},
+										},
+									},
+								},
+								"status": map[string]interface{}{
+									"replicas":      1,
+									"readyReplicas": 0,
+								},
+							},
+						},
+					},
+				}, nil)
+			})
+
+			It("returns list of resources, removing the duplicate pod instances", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				validateResponse(payloadListServerGroupsUniquePodInstances)
+			})
+		})
+
 		When("the resources are not sorted", func() {
 			BeforeEach(func() {
 				fakeKubeClient.ListResourceWithContextReturnsOnCall(0, &unstructured.UnstructuredList{
@@ -2284,7 +2398,7 @@ var _ = Describe("Application", func() {
 											"uid":  "test-uid1",
 										},
 									},
-									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100000",
 								},
 							},
 						},
@@ -2309,7 +2423,7 @@ var _ = Describe("Application", func() {
 											"uid":  "test-uid1",
 										},
 									},
-									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100001",
 								},
 							},
 						},
@@ -2334,7 +2448,7 @@ var _ = Describe("Application", func() {
 											"uid":  "test-uid2",
 										},
 									},
-									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100002",
 								},
 							},
 						},
@@ -2359,7 +2473,7 @@ var _ = Describe("Application", func() {
 											"uid":  "test-uid2",
 										},
 									},
-									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100003",
 								},
 							},
 						},
@@ -2384,7 +2498,7 @@ var _ = Describe("Application", func() {
 											"uid":  "test-uid2",
 										},
 									},
-									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100004",
 								},
 							},
 						},
@@ -2409,7 +2523,7 @@ var _ = Describe("Application", func() {
 											"uid":  "test-uid3",
 										},
 									},
-									"uid": "cec15437-4e6a-11ea-9788-4201ac100006",
+									"uid": "cec15437-4e6a-11ea-9788-4201ac100005",
 								},
 							},
 						},

--- a/internal/api/core/payload_test.go
+++ b/internal/api/core/payload_test.go
@@ -1392,6 +1392,217 @@ const payloadListServerGroups = `[
             }
           ]`
 
+const payloadListServerGroupsUniquePodInstances = `[
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 2,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-ds1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 2,
+                "unknown": 0,
+                "up": 1
+              },
+              "instances": [],
+              "isDisabled": false,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "daemonSet",
+              "labels": null,
+              "loadBalancers": null,
+              "manifest": null,
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "daemonSet test-ds1",
+              "namespace": "test-namespace1",
+              "providerType": "",
+              "region": "test-namespace1",
+              "securityGroups": null,
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            },
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100000",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod3"
+                }
+              ],
+              "isDisabled": false,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "replicaSet",
+              "labels": null,
+              "loadBalancers": null,
+              "manifest": null,
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "replicaSet test-rs1",
+              "namespace": "test-namespace1",
+              "providerType": "",
+              "region": "test-namespace1",
+              "securityGroups": null,
+              "serverGroupManagers": [
+                {
+                  "account": "account1",
+                  "location": "test-namespace1",
+                  "name": "test-deployment1"
+                }
+              ],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            },
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-sts1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [],
+              "isDisabled": false,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "statefulSet",
+              "labels": null,
+              "loadBalancers": [
+                "service test-svc2"
+              ],
+              "manifest": null,
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "statefulSet test-sts1",
+              "namespace": "test-namespace1",
+              "providerType": "",
+              "region": "test-namespace1",
+              "securityGroups": null,
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            }
+          ]`
+
 const payloadListServerGroupsSorted = `[
             {
               "account": "account1",
@@ -1433,7 +1644,7 @@ const payloadListServerGroupsSorted = `[
                     }
                   ],
                   "healthState": "Down",
-                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100004",
                   "key": {
                     "account": "",
                     "group": "",
@@ -1461,7 +1672,7 @@ const payloadListServerGroupsSorted = `[
                     }
                   ],
                   "healthState": "Down",
-                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100003",
                   "key": {
                     "account": "",
                     "group": "",
@@ -1489,7 +1700,7 @@ const payloadListServerGroupsSorted = `[
                     }
                   ],
                   "healthState": "Down",
-                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100002",
                   "key": {
                     "account": "",
                     "group": "",
@@ -1575,7 +1786,7 @@ const payloadListServerGroupsSorted = `[
                     }
                   ],
                   "healthState": "Down",
-                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100001",
                   "key": {
                     "account": "",
                     "group": "",
@@ -1667,7 +1878,7 @@ const payloadListServerGroupsSorted = `[
                     }
                   ],
                   "healthState": "Down",
-                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100005",
                   "key": {
                     "account": "",
                     "group": "",
@@ -1753,7 +1964,7 @@ const payloadListServerGroupsSorted = `[
                     }
                   ],
                   "healthState": "Down",
-                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100004",
                   "key": {
                     "account": "",
                     "group": "",
@@ -1781,7 +1992,7 @@ const payloadListServerGroupsSorted = `[
                     }
                   ],
                   "healthState": "Down",
-                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100003",
                   "key": {
                     "account": "",
                     "group": "",
@@ -1809,7 +2020,7 @@ const payloadListServerGroupsSorted = `[
                     }
                   ],
                   "healthState": "Down",
-                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100002",
                   "key": {
                     "account": "",
                     "group": "",
@@ -1895,7 +2106,7 @@ const payloadListServerGroupsSorted = `[
                     }
                   ],
                   "healthState": "Down",
-                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100005",
                   "key": {
                     "account": "",
                     "group": "",


### PR DESCRIPTION
This PR fixes an issue where the same pod instance was showing multiple times for a server group in the clusters page, which occurred when there are multiple accounts for the same kubernetes cluster.

Before:
<img width="1640" alt="image" src="https://user-images.githubusercontent.com/16955707/137904103-f9d1b7d2-5356-40c0-9311-ae0ee3e7a492.png">

After:
<img width="1386" alt="image" src="https://user-images.githubusercontent.com/16955707/137904439-7114d0b6-77d7-4354-b201-5f95b278a534.png">
