### PR TITLE
Remove null-valued fields from manifests

### DIFF
--- a/internal/api/core/manifest.go
+++ b/internal/api/core/manifest.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/gin-gonic/gin"
+	"github.com/homedepot/go-clouddriver/internal"
 	ops "github.com/homedepot/go-clouddriver/internal/api/core/kubernetes"
 	"github.com/homedepot/go-clouddriver/internal/kubernetes"
 	clouddriver "github.com/homedepot/go-clouddriver/pkg"
@@ -69,7 +70,7 @@ func (cc *Controller) GetManifest(c *gin.Context) {
 		Account:  account,
 		Events:   []interface{}{},
 		Location: namespace,
-		Manifest: result.Object,
+		Manifest: internal.DeleteNilValues(result.Object),
 		Metrics:  []interface{}{},
 		Moniker: ops.ManifestResponseMoniker{
 			App:     app,

--- a/internal/api/core/manifest_test.go
+++ b/internal/api/core/manifest_test.go
@@ -55,6 +55,43 @@ var _ = Describe("Manifest", func() {
 			})
 		})
 
+		When("getting the manifest returns null values", func() {
+			BeforeEach(func() {
+				uri = svr.URL + "/manifests/test-account/test-namespace/clusterRole test-cluster-role"
+				createRequest(http.MethodGet)
+				fakeKubeClient.GetReturns(&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "rbac.authorization.k8s.io/v1",
+						"kind":       "ClusterRole",
+						"metadata": map[string]interface{}{
+							"annotations": map[string]interface{}{
+								"artifact.spinnaker.io/location":   "",
+								"artifact.spinnaker.io/name":       "test-cluster-role",
+								"artifact.spinnaker.io/type":       "kubernetes/clusterRole",
+								"artifact.spinnaker.io/version":    "",
+								"moniker.spinnaker.io/application": "test-application",
+								"moniker.spinnaker.io/cluster":     "clusterRole test-cluster-role",
+							},
+							"creationTimestamp": "2021-10-20T15:29:26Z",
+							"labels": map[string]interface{}{
+								"app.kubernetes.io/managed-by": "spinnaker",
+								"app.kubernetes.io/name":       "test-application",
+							},
+							"name":            "test-cluster-role",
+							"resourceVersion": "53990465",
+							"uid":             "d1f1ab80-1320-4e2d-8d12-893c326af416",
+						},
+						"rules": nil,
+					},
+				}, nil)
+			})
+
+			It("succeeds", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				validateResponse(payloadManifestClusterRoleNoRules)
+			})
+		})
+
 		When("it succeeds", func() {
 			It("succeeds", func() {
 				Expect(res.StatusCode).To(Equal(http.StatusOK))

--- a/internal/api/core/payload_test.go
+++ b/internal/api/core/payload_test.go
@@ -2759,6 +2759,59 @@ const payloadManifestCoordinatesList = `[
             }
           ]`
 
+const payloadManifestClusterRoleNoRules = `{
+            "account": "test-account",
+            "events": [],
+            "location": "test-namespace",
+            "manifest": {
+              "apiVersion": "rbac.authorization.k8s.io/v1",
+              "kind": "ClusterRole",
+              "metadata": {
+                "annotations": {
+                  "artifact.spinnaker.io/location": "",
+                  "artifact.spinnaker.io/name": "test-cluster-role",
+                  "artifact.spinnaker.io/type": "kubernetes/clusterRole",
+                  "artifact.spinnaker.io/version": "",
+                  "moniker.spinnaker.io/application": "test-application",
+                  "moniker.spinnaker.io/cluster": "clusterRole test-cluster-role"
+                },
+                "creationTimestamp": "2021-10-20T15:29:26Z",
+                "labels": {
+                  "app.kubernetes.io/managed-by": "spinnaker",
+                  "app.kubernetes.io/name": "test-application"
+                },
+                "name": "test-cluster-role",
+                "resourceVersion": "53990465",
+                "uid": "d1f1ab80-1320-4e2d-8d12-893c326af416"
+              }
+            },
+            "metrics": [],
+            "moniker": {
+              "app": "test-application",
+              "cluster": "clusterRole test-cluster-role"
+            },
+            "name": "clusterRole test-cluster-role",
+            "status": {
+              "available": {
+                "state": true,
+                "message": ""
+              },
+              "failed": {
+                "state": false,
+                "message": ""
+              },
+              "paused": {
+                "state": false,
+                "message": ""
+              },
+              "stable": {
+                "state": true,
+                "message": ""
+              }
+            },
+            "warnings": []
+          }`
+
 const payloadGetInstance = `{
             "account": "test-account",
             "apiVersion": "v1",

--- a/internal/map.go
+++ b/internal/map.go
@@ -1,0 +1,32 @@
+package internal
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DeleteNilVaules returns the given map with all keys
+// with nil values removed.
+func DeleteNilValues(m map[string]interface{}) map[string]interface{} {
+	newMap := make(map[string]interface{})
+
+	for k, v := range m {
+		if v != nil {
+			if isMap(v) {
+				newMap[k] = DeleteNilValues(v.(map[string]interface{}))
+			} else {
+				newMap[k] = v
+			}
+		}
+	}
+
+	return newMap
+}
+
+// isMap returns true if the argument is of type map
+//
+// see https://stackoverflow.com/questions/20759803/how-to-check-variable-type-is-map-in-go-language
+func isMap(x interface{}) bool {
+	t := fmt.Sprintf("%T", x)
+	return strings.HasPrefix(t, "map[")
+}

--- a/internal/map_test.go
+++ b/internal/map_test.go
@@ -1,0 +1,91 @@
+package internal_test
+
+import (
+	. "github.com/homedepot/go-clouddriver/internal"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Map", func() {
+
+	var m, actual map[string]interface{}
+
+	Describe("#DeleteNilValues", func() {
+
+		JustBeforeEach(func() {
+			actual = DeleteNilValues(m)
+		})
+
+		When("the map is empty", func() {
+			BeforeEach(func() {
+				m = map[string]interface{}{}
+			})
+
+			It("returns an empty map", func() {
+				Expect(actual).To(Equal(m))
+			})
+		})
+
+		When("the map has no nil-valued keys", func() {
+			BeforeEach(func() {
+				m = map[string]interface{}{
+					"a": 1,
+					"b": true,
+					"c": "three",
+				}
+			})
+
+			It("returns the map unchanged", func() {
+				Expect(actual).To(Equal(m))
+			})
+		})
+
+		When("the map has nil-valued keys", func() {
+			BeforeEach(func() {
+				m = map[string]interface{}{
+					"a": 1,
+					"b": nil,
+					"c": "three",
+				}
+			})
+
+			It("succeeds", func() {
+				expected := map[string]interface{}{
+					"a": 1,
+					"c": "three",
+				}
+				Expect(actual).To(Equal(expected))
+			})
+		})
+
+		When("the map has nested nil-valued keys", func() {
+			BeforeEach(func() {
+				m = map[string]interface{}{
+					"a": 1,
+					"b": "nil",
+					"c": "three",
+					"d": map[string]interface{}{
+						"e": nil,
+						"f": "f",
+						"g": map[string]interface{}{
+							"h": nil,
+						},
+					},
+				}
+			})
+
+			It("succeeds", func() {
+				expected := map[string]interface{}{
+					"a": 1,
+					"b": "nil",
+					"c": "three",
+					"d": map[string]interface{}{
+						"f": "f",
+						"g": map[string]interface{}{},
+					},
+				}
+				Expect(actual).To(Equal(expected))
+			})
+		})
+	})
+})


### PR DESCRIPTION
Removes ___all___ null-valued fields from manifests in the `GET /manifests/:account/:location/:kind` response.

This fixes an issue when a `ClusterRole` with no `rules` is deployed 
```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  name: test-cluster-role
rules: []
```

This results in the `rules` attribute have a value of `null`
```
$ kubectl get clusterroles test-cluster-role -o yaml
```

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: ClusterRole
metadata:
  annotations:
    artifact.spinnaker.io/location: ""
    artifact.spinnaker.io/name: test-cluster-role
    artifact.spinnaker.io/type: kubernetes/clusterRole
    artifact.spinnaker.io/version: ""
    moniker.spinnaker.io/application: test-application
    moniker.spinnaker.io/cluster: clusterRole test-cluster-role
  creationTimestamp: "2021-10-20T14:37:29Z"
  name: test-cluster-role
  resourceVersion: "118829131"
  uid: ec1b4237-123b-4dbc-8e03-d8a00cf0b732
rules: null
```

Which `orca` fails to parse with error
```
retrofit.RetrofitError: com.fasterxml.jackson.databind.exc.ValueInstantiationException: \
      Cannot construct instance of `com.netflix.spinnaker.orca.clouddriver.model.Manifest$ManifestBuilder`, \
      problem: null value in entry: rules=null
  at [Source: (retrofit.ExceptionCatchingTypedInput$ExceptionCatchingInputStream); line: 1, column: 2427]
  at retrofit.RetrofitError.conversionError(RetrofitError.java:33)
  at retrofit.RestAdapter$RestHandler.invokeRequest(RestAdapter.java:383)
  at retrofit.RestAdapter$RestHandler.invoke(RestAdapter.java:240) at com.sun.proxy.$Proxy170.getManifest(Unknown Source) at com.netflix.spinnaker.orca.clouddriver.DelegatingOortService.getManifest(DelegatingOortService.java:48)
  ...
```

The same deployment using Spinnaker `clouddriver` succeeds because the `GET /manifests/:account/:location/:kind` response does not include the `rules` field.
```json
{
  "account": "test-account",
  "artifacts": [],
  "events": [],
  "location": "",
  "manifest": {
    "apiVersion": "rbac.authorization.k8s.io/v1",
    "kind": "ClusterRole",
    "metadata": {
      "annotations": {
        "artifact.spinnaker.io/location": "",
        "artifact.spinnaker.io/name": "test-cluster-role",
        "artifact.spinnaker.io/type": "kubernetes/clusterRole",
        "artifact.spinnaker.io/version": "",
        "moniker.spinnaker.io/application": "test-application",
        "moniker.spinnaker.io/cluster": "clusterRole test-cluster-role"
      },
      "creationTimestamp": "2021-10-20T15:29:26Z",
      "labels": {
        "app.kubernetes.io/managed-by": "spinnaker",
        "app.kubernetes.io/name": "test-application"
      },
      "name": "test-cluster-role",
      "resourceVersion": "53990465",
      "uid": "d1f1ab80-1320-4e2d-8d12-893c326af416"
    }
  },
  "metrics": [],
  "moniker": {
    "app": "test-application",
    "cluster": "clusterRole test-cluster-role"
  },
  "name": "clusterRole test-cluster-role",
  "status": {
    "available": {
      "state": true
    },
    "failed": {
      "state": false
    },
    "paused": {
      "state": false
    },
    "stable": {
      "state": true
    }
  },
  "warnings": []
}
```

With this change, `go-clouddriver` will also remove the `rules` field.