### PR TITLE
Helm authentication

### DIFF
--- a/internal/helm/client.go
+++ b/internal/helm/client.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"sync"
 
 	"gopkg.in/yaml.v2"
@@ -137,8 +136,8 @@ func (c *client) GetChart(name, version string) ([]byte, error) {
 
 			continue
 		}
-		// Set credentials when chart is hosted in authenticated repository
-		if strings.HasPrefix(url, c.url) && c.username != "" && c.password != "" {
+		// Set credentials to pull the chant.
+		if c.username != "" && c.password != "" {
 			req.SetBasicAuth(c.username, c.password)
 		}
 


### PR DESCRIPTION
If the helm repository is configured with credentials, then always them to retrieve the charts.  I was under the misconception that a repository might host charts with remote URLs, in which case, the authentication would not apply.  Our experience with jFrog Artifactory is not this way, the URLs for remotely hosted charts have URLs with jFrog Artifactory server as the hostname.

Also, I had failed to put in a unit test when support for helm authentication was added, which is why there is no change to tests now that I removed the URL check.