### PR TITLE
Add ability to bind artifacts for Patch (Manifest) stage

### DIFF
--- a/internal/api/core/kubernetes/kubernetes_test.go
+++ b/internal/api/core/kubernetes/kubernetes_test.go
@@ -1,6 +1,7 @@
 package kubernetes_test
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 
@@ -260,6 +261,22 @@ func newPatchManifestRequest() PatchManifestRequest {
 		Options: PatchManifestRequestOptions{
 			MergeStrategy: "strategic",
 		},
+		PatchBody: json.RawMessage(
+			`{
+        "spec": {
+          "template": {
+            "spec": {
+              "containers": [
+                {
+							    "name":  "test-container-name",
+							    "image": "gcr.io/test-project/test-container-image"
+                }
+              ]
+            }
+          }
+        }
+      }`,
+		),
 	}
 }
 

--- a/internal/api/core/kubernetes/ops.go
+++ b/internal/api/core/kubernetes/ops.go
@@ -69,29 +69,18 @@ type PatchManifestRequest struct {
 	Cluster  string `json:"cluster"`
 	Criteria string `json:"criteria"`
 	// Kind          string                         `json:"kind"`
-	ManifestName  string                         `json:"manifestName"`
-	Source        string                         `json:"source"`
-	Mode          string                         `json:"mode"`
-	PatchBody     json.RawMessage                `json:"patchBody"`
-	CloudProvider string                         `json:"cloudProvider"`
-	AllArtifacts  []PatchManifestRequestArtifact `json:"allArtifacts"`
-	Options       PatchManifestRequestOptions    `json:"options"`
+	ManifestName  string                      `json:"manifestName"`
+	Source        string                      `json:"source"`
+	Mode          string                      `json:"mode"`
+	PatchBody     json.RawMessage             `json:"patchBody"`
+	CloudProvider string                      `json:"cloudProvider"`
+	Options       PatchManifestRequestOptions `json:"options"`
 	// Manifests         []map[string]interface{}       `json:"manifests"`
-	Location string `json:"location"`
-	Account  string `json:"account"`
-	// RequiredArtifacts []interface{}                  `json:"requiredArtifacts"`
-}
-
-type PatchManifestRequestArtifact struct {
-	CustomKind bool   `json:"customKind"`
-	Reference  string `json:"reference"`
-	Metadata   struct {
-		Account string `json:"account"`
-	} `json:"metadata"`
-	Name     string `json:"name"`
-	Location string `json:"location"`
-	Type     string `json:"type"`
-	Version  string `json:"version"`
+	Location          string                 `json:"location"`
+	Account           string                 `json:"account"`
+	AllArtifacts      []clouddriver.Artifact `json:"allArtifacts"`
+	RequiredArtifacts []clouddriver.Artifact `json:"requiredArtifacts"`
+	OptionalArtifacts []clouddriver.Artifact `json:"optionalArtifacts"`
 }
 
 // Merge strategy can be "strategic", "json", or "merge".

--- a/internal/api/core/kubernetes/patch.go
+++ b/internal/api/core/kubernetes/patch.go
@@ -10,6 +10,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/homedepot/go-clouddriver/internal/kubernetes"
 	clouddriver "github.com/homedepot/go-clouddriver/pkg"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -48,6 +49,30 @@ func (cc *Controller) Patch(c *gin.Context, pm PatchManifestRequest) {
 	if err != nil {
 		clouddriver.Error(c, http.StatusBadRequest, err)
 		return
+	}
+
+	// Only bind artifacts for "strategic" or "merge" strategy.
+	//
+	// See https://spinnaker.io/docs/guides/user/kubernetes-v2/patch-manifest/#override-artifacts
+	if pm.Options.MergeStrategy == "strategic" ||
+		pm.Options.MergeStrategy == "merge" {
+		m := map[string]interface{}{}
+
+		if err := json.Unmarshal(b, &m); err != nil {
+			clouddriver.Error(c, http.StatusBadRequest, err)
+			return
+		}
+
+		u := unstructured.Unstructured{
+			Object: m,
+		}
+		kubernetes.BindArtifacts(&u, pm.AllArtifacts)
+
+		b, err = json.Marshal(&u.Object)
+		if err != nil {
+			clouddriver.Error(c, http.StatusInternalServerError, err)
+			return
+		}
 	}
 
 	// Merge strategy can be "strategic", "json", or "merge".

--- a/internal/api/core/kubernetes/patch.go
+++ b/internal/api/core/kubernetes/patch.go
@@ -57,7 +57,6 @@ func (cc *Controller) Patch(c *gin.Context, pm PatchManifestRequest) {
 	if pm.Options.MergeStrategy == "strategic" ||
 		pm.Options.MergeStrategy == "merge" {
 		m := map[string]interface{}{}
-
 		if err := json.Unmarshal(b, &m); err != nil {
 			clouddriver.Error(c, http.StatusBadRequest, err)
 			return

--- a/internal/kubernetes/artifact.go
+++ b/internal/kubernetes/artifact.go
@@ -3,8 +3,8 @@ package kubernetes
 import (
 	"strings"
 
-	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 	"github.com/homedepot/go-clouddriver/internal/artifact"
+	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 


### PR DESCRIPTION
- adds support for artifacts in the Patch (Manifest) stage

Notes:
- we only need to support binding artifacts for patch types of "strategic" or "merge" as per the documentation https://spinnaker.io/docs/guides/user/kubernetes-v2/patch-manifest/#override-artifacts