### PR TITLE
fix finding oldest manifest coords when only one resource found

### DIFF
--- a/internal/api/core/manifest.go
+++ b/internal/api/core/manifest.go
@@ -148,9 +148,10 @@ func (cc *Controller) GetManifestByTarget(c *gin.Context) {
 	var result = items[0]
 
 	// Target can be newest, second_newest, oldest, largest, smallest.
-	// TODO fill in for largest and smallest targets.
+	//
+	// Java source code here: https://github.com/spinnaker/clouddriver/blob/0fb3e75faa586f213a39c9fd4145f08e519b2e97/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/controllers/ManifestController.java#L132-L148
 	switch strings.ToLower(target) {
-	case "newest":
+	case "newest", "largest":
 		result = items[0]
 	case "second_newest":
 		if len(items) < 2 {
@@ -160,13 +161,7 @@ func (cc *Controller) GetManifestByTarget(c *gin.Context) {
 		}
 
 		result = items[1]
-	case "oldest":
-		if len(items) < 2 {
-			clouddriver.Error(c, http.StatusBadRequest,
-				errors.New("requested target \"Oldest\" for cluster "+cluster+", but only one resource was found"))
-			return
-		}
-
+	case "oldest", "smallest":
 		result = items[len(items)-1]
 	default:
 		clouddriver.Error(c, http.StatusNotImplemented,

--- a/internal/api/core/manifest_test.go
+++ b/internal/api/core/manifest_test.go
@@ -228,7 +228,7 @@ var _ = Describe("Manifest", func() {
 				target = "oldest"
 			})
 
-			When("there are less than two resources returned", func() {
+			When("there is one resource returned", func() {
 				BeforeEach(func() {
 					fakeKubeClient.ListByGVRReturns(&unstructured.UnstructuredList{
 						Items: []unstructured.Unstructured{
@@ -239,6 +239,8 @@ var _ = Describe("Manifest", func() {
 											kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
 											kubernetes.AnnotationSpinnakerMonikerApplication: "wrong-application",
 										},
+										"name":      "test-name",
+										"namespace": "test-namespace",
 									},
 								},
 							},
@@ -249,6 +251,8 @@ var _ = Describe("Manifest", func() {
 											kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
 											kubernetes.AnnotationSpinnakerMonikerApplication: "test-application",
 										},
+										"name":      "test-name",
+										"namespace": "test-namespace",
 									},
 								},
 							},
@@ -256,12 +260,9 @@ var _ = Describe("Manifest", func() {
 					}, nil)
 				})
 
-				It("returns an error", func() {
-					Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
-					ce := getClouddriverError()
-					Expect(ce.Error).To(HavePrefix("Bad Request"))
-					Expect(ce.Message).To(Equal("requested target \"Oldest\" for cluster deployment test-deployment, but only one resource was found"))
-					Expect(ce.Status).To(Equal(http.StatusBadRequest))
+				It("returns this resource", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					validateResponse(payloadManifestCoordinates)
 				})
 			})
 
@@ -270,6 +271,68 @@ var _ = Describe("Manifest", func() {
 					Expect(res.StatusCode).To(Equal(http.StatusOK))
 					validateResponse(payloadManifestCoordinates)
 				})
+			})
+		})
+
+		Context("target is smallest", func() {
+			BeforeEach(func() {
+				target = "smallest"
+			})
+
+			When("there is one resource returned", func() {
+				BeforeEach(func() {
+					fakeKubeClient.ListByGVRReturns(&unstructured.UnstructuredList{
+						Items: []unstructured.Unstructured{
+							{
+								Object: map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"annotations": map[string]interface{}{
+											kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
+											kubernetes.AnnotationSpinnakerMonikerApplication: "wrong-application",
+										},
+										"name":      "test-name",
+										"namespace": "test-namespace",
+									},
+								},
+							},
+							{
+								Object: map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"annotations": map[string]interface{}{
+											kubernetes.AnnotationSpinnakerMonikerCluster:     "deployment test-deployment",
+											kubernetes.AnnotationSpinnakerMonikerApplication: "test-application",
+										},
+										"name":      "test-name",
+										"namespace": "test-namespace",
+									},
+								},
+							},
+						},
+					}, nil)
+				})
+
+				It("returns this resource", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					validateResponse(payloadManifestCoordinates)
+				})
+			})
+
+			When("it succeeds", func() {
+				It("succeeds", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					validateResponse(payloadManifestCoordinates)
+				})
+			})
+		})
+
+		When("target is newest", func() {
+			BeforeEach(func() {
+				target = "newest"
+			})
+
+			It("succeeds", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				validateResponse(payloadManifestCoordinates)
 			})
 		})
 


### PR DESCRIPTION
- Adds support for `largest` and `smallest` targets as per [source code](https://github.com/spinnaker/clouddriver/blob/0fb3e75faa586f213a39c9fd4145f08e519b2e97/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/controllers/ManifestController.java#L132-L148)
- Adds test cases for `largest` and `smallest` targets
- Removes error if attempting to get `oldest` target and only one resource is returned - in this case that is the oldest resource