### PR TITLE
Fix location annotation

### DIFF
--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -82,7 +82,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			manifest.SetName(generateName + rand.String(randNameNumber))
 		}
 
-		err = kubernetes.AddSpinnakerAnnotations(&manifest, application)
+		err = kubernetes.AddSpinnakerAnnotations(&manifest, application, namespace)
 		if err != nil {
 			clouddriver.Error(c, http.StatusInternalServerError, err)
 			return

--- a/internal/api/core/kubernetes/runjob.go
+++ b/internal/api/core/kubernetes/runjob.go
@@ -28,7 +28,12 @@ func (cc *Controller) RunJob(c *gin.Context, rj RunJobRequest) {
 		return
 	}
 
-	err = kube.AddSpinnakerAnnotations(&u, rj.Application)
+	namespace := u.GetNamespace()
+	if provider.Namespace != nil {
+		namespace = *provider.Namespace
+	}
+
+	err = kube.AddSpinnakerAnnotations(&u, rj.Application, namespace)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
@@ -45,11 +50,6 @@ func (cc *Controller) RunJob(c *gin.Context, rj RunJobRequest) {
 
 	if name == "" && generateName != "" {
 		u.SetName(generateName + rand.String(randNameNumber))
-	}
-
-	namespace := u.GetNamespace()
-	if provider.Namespace != nil {
-		namespace = *provider.Namespace
 	}
 
 	kubernetes.BindArtifacts(&u, append(rj.RequiredArtifacts, rj.OptionalArtifacts...))

--- a/internal/api/core/kubernetes/runjob_test.go
+++ b/internal/api/core/kubernetes/runjob_test.go
@@ -113,4 +113,69 @@ var _ = Describe("RunJob", func() {
 			Expect(name).To(HaveLen(10))
 		})
 	})
+
+	Context("annotating 'artifact.spinnaker.io/location'", func() {
+		When("the namespace is not set", func() {
+			BeforeEach(func() {
+				runJobRequest.Manifest = map[string]interface{}{
+					"kind":       "Job",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"generateName": "test-",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name":  "test-container-name",
+										"image": "gcr.io/test-project/test-container-image",
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("annotates the object accordingly", func() {
+				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+				u, _ := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+				annotations := u.GetAnnotations()
+				Expect(annotations[kubernetes.AnnotationSpinnakerArtifactLocation]).To(Equal("default"))
+			})
+		})
+
+		When("the namespace is set", func() {
+			BeforeEach(func() {
+				runJobRequest.Manifest = map[string]interface{}{
+					"kind":       "Job",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"generateName": "test-",
+						"namespace":    "test-namespace",
+					},
+					"spec": map[string]interface{}{
+						"template": map[string]interface{}{
+							"spec": map[string]interface{}{
+								"containers": []interface{}{
+									map[string]interface{}{
+										"name":  "test-container-name",
+										"image": "gcr.io/test-project/test-container-image",
+									},
+								},
+							},
+						},
+					},
+				}
+			})
+
+			It("annotates the object accordingly", func() {
+				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+				u, _ := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+				annotations := u.GetAnnotations()
+				Expect(annotations[kubernetes.AnnotationSpinnakerArtifactLocation]).To(Equal("test-namespace"))
+			})
+		})
+	})
 })

--- a/internal/kubernetes/annotation.go
+++ b/internal/kubernetes/annotation.go
@@ -19,13 +19,23 @@ const (
 
 // AddSpinnakerAnnotations adds Spinnaker-defined annotations to a given
 // unstructured resource.
-func AddSpinnakerAnnotations(u *unstructured.Unstructured, application string) error {
+func AddSpinnakerAnnotations(u *unstructured.Unstructured, application, namespace string) error {
 	name := u.GetName()
-	namespace := u.GetNamespace()
-
-	// possible bug ToLower
 	t := fmt.Sprintf("kubernetes/%s", strcase.ToLowerCamel(u.GetKind()))
 	cluster := fmt.Sprintf("%s %s", strcase.ToLowerCamel(u.GetKind()), name)
+	// If no namespace was passed in and this is a namespace-scoped
+	// Kubernetes kind, grab the namespace from the passed in object. If
+	// that is not set, set it to be 'default'.
+	if isNamespaceScoped(u.GetKind()) && namespace == "" {
+		namespace = u.GetNamespace()
+		if namespace == "" {
+			namespace = "default"
+		}
+	} else if !isNamespaceScoped(u.GetKind()) && namespace != "" {
+		// If we've passed in a namespace-override for a kind that is
+		// cluster-scoped, make the namespace empty for the annotation.
+		namespace = ""
+	}
 
 	// Add reserved annotations.
 	// https://spinnaker.io/reference/providers/kubernetes-v2/#reserved-annotations
@@ -138,4 +148,34 @@ func SpinnakerMonikerApplication(u unstructured.Unstructured) string {
 	}
 
 	return ""
+}
+
+// isNamespaceScoped returns true if the kind is namespace-scoped.
+//
+// Cluster-scoped kinds are:
+//   - apiService
+//   - clusterRole
+//   - clusterRoleBinding
+//   - customResourceDefinition
+//   - mutatingWebhookConfiguration
+//   - namespace
+//   - persistentVolume
+//   - podSecurityPolicy
+//   - storageClass
+//   - validatingWebhookConfiguration
+//
+// See https://github.com/spinnaker/clouddriver/blob/58ab154b0ec0d62772201b5b319af349498a4e3f/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKindProperties.java#L31
+// for clouddriver OSS namespace-scoped kinds.
+func isNamespaceScoped(kind string) bool {
+	namespaceScoped := true
+
+	for _, value := range clusterScopedKinds {
+		if strings.EqualFold(value, kind) {
+			namespaceScoped = false
+
+			break
+		}
+	}
+
+	return namespaceScoped
 }


### PR DESCRIPTION
- Fixes annotating `artifact.spinnaker.io/location` for objects that do not specify a namespace

Notes:
- There were a few ways to do this, but I decided to not mess with any of the logic in the `internal/api/core/kubernetes/*` files, except for passing the namespace to the `AddSpinnakerAnnotations` function. I felt this was much safer than moving any logic that the dynamic client's [helper](https://github.com/homedepot/go-clouddriver/blob/master/internal/kubernetes/unstructured.go#L51) is performing to check if a kind is cluster scoped. This is much less intrusive and I did not want to mess with anything responsible for applying the manifest to a cluster as that code is copied from the `kubectl` source code.
- OSS annotates an empty string for cluster-scoped resources, so the annotation `artifact.spinnaker.io/location: ''` is expected for these resources.