### PR TITLE
Index out of range error

### DIFF
--- a/internal/api/core/applications.go
+++ b/internal/api/core/applications.go
@@ -1132,6 +1132,12 @@ func (cc *Controller) GetServerGroup(c *gin.Context) {
 	application := c.Param("application")
 	location := c.Param("location")
 	nameArray := strings.Split(c.Param("name"), " ")
+
+	if len(nameArray) != 2 {
+		clouddriver.Error(c, http.StatusBadRequest, fmt.Errorf("name parameter must be in the format of 'kind name', got: %s", c.Param("name")))
+		return
+	}
+
 	kind := nameArray[0]
 	name := nameArray[1]
 
@@ -1326,6 +1332,12 @@ func (cc *Controller) GetJob(c *gin.Context) {
 	// application := c.Param("application")
 	location := c.Param("location")
 	nameArray := strings.Split(c.Param("name"), " ")
+
+	if len(nameArray) != 2 {
+		clouddriver.Error(c, http.StatusBadRequest, fmt.Errorf("name parameter must be in the format of 'kind name', got: %s", c.Param("name")))
+		return
+	}
+
 	kind := nameArray[0]
 	name := nameArray[1]
 

--- a/internal/api/core/applications_test.go
+++ b/internal/api/core/applications_test.go
@@ -3031,6 +3031,21 @@ var _ = Describe("Application", func() {
 			doRequest()
 		})
 
+		When("name parameter is malformed", func() {
+			BeforeEach(func() {
+				uri = svr.URL + "/applications/test-application/serverGroups/test-account/test-namespace/invalid"
+				createRequest(http.MethodGet)
+			})
+
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
+				Expect(ce.Message).To(Equal("name parameter must be in the format of 'kind name', got: invalid"))
+				Expect(ce.Status).To(Equal(http.StatusBadRequest))
+			})
+		})
+
 		When("getting the provider returns an error", func() {
 			BeforeEach(func() {
 				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, errors.New("error getting provider"))
@@ -3129,6 +3144,21 @@ var _ = Describe("Application", func() {
 
 		JustBeforeEach(func() {
 			doRequest()
+		})
+
+		When("name parameter is malformed", func() {
+			BeforeEach(func() {
+				uri = svr.URL + "/applications/test-application/jobs/test-account/test-namespace/invalid"
+				createRequest(http.MethodGet)
+			})
+
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
+				Expect(ce.Message).To(Equal("name parameter must be in the format of 'kind name', got: invalid"))
+				Expect(ce.Status).To(Equal(http.StatusBadRequest))
+			})
 		})
 
 		When("getting the provider returns an error", func() {


### PR DESCRIPTION
Defensively checks the array size parsed from the `name` parameter, which is expected to have a format of `kind name` on these endpoints.
- `GET /applications/:application/serverGroups/:account/:location/:name`
- `GET /applications/:application/jobs/:account/:location/:name`

When the name parameter value doesn't contain a space, then the application panics with an `index out of range` error and returns a `500 (Internal Server Error)` status code.  This change handles the unexpected value and returns a `400 (Bad Request)` response instead.