### PR TITLE
Set namespace on manifests

### DIFF
--- a/internal/api/core/kubernetes/restart.go
+++ b/internal/api/core/kubernetes/restart.go
@@ -58,7 +58,7 @@ func (cc *Controller) RollingRestart(c *gin.Context, rr RollingRestartManifestRe
 			return
 		}
 
-		meta, err = provider.Client.ApplyWithNamespaceOverride(u, namespace)
+		meta, err = provider.Client.Apply(u)
 		if err != nil {
 			clouddriver.Error(c, http.StatusInternalServerError, err)
 			return

--- a/internal/api/core/kubernetes/restart_test.go
+++ b/internal/api/core/kubernetes/restart_test.go
@@ -42,7 +42,7 @@ var _ = Describe("RollingRestart", func() {
 
 	When("applying the manifest returns an error", func() {
 		BeforeEach(func() {
-			fakeKubeClient.ApplyWithNamespaceOverrideReturns(kubernetes.Metadata{}, errors.New("error applying manifest"))
+			fakeKubeClient.ApplyReturns(kubernetes.Metadata{}, errors.New("error applying manifest"))
 		})
 
 		It("returns an error", func() {
@@ -76,8 +76,6 @@ var _ = Describe("RollingRestart", func() {
 	When("it succeeds", func() {
 		It("succeeds", func() {
 			Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-			_, namespace := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
-			Expect(string(namespace)).To(Equal(""))
 		})
 	})
 
@@ -100,8 +98,8 @@ var _ = Describe("RollingRestart", func() {
 		When("the kind is supported", func() {
 			It("succeeds", func() {
 				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-				_, namespace := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
-				Expect(string(namespace)).To(Equal("provider-namespace"))
+				_, _, namespace := fakeKubeClient.GetArgsForCall(0)
+				Expect(namespace).To(Equal("provider-namespace"))
 			})
 		})
 	})

--- a/internal/api/core/kubernetes/rollback.go
+++ b/internal/api/core/kubernetes/rollback.go
@@ -153,7 +153,7 @@ func (cc *Controller) Rollback(c *gin.Context, ur UndoRolloutManifestRequest) {
 		return
 	}
 
-	meta, err := provider.Client.ApplyWithNamespaceOverride(&u, namespace)
+	meta, err := provider.Client.Apply(&u)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/internal/api/core/kubernetes/rollback_test.go
+++ b/internal/api/core/kubernetes/rollback_test.go
@@ -89,7 +89,7 @@ var _ = Describe("Rollback", func() {
 
 	When("applying the manifest returns an error", func() {
 		BeforeEach(func() {
-			fakeKubeClient.ApplyWithNamespaceOverrideReturns(kubernetes.Metadata{}, errors.New("error applying manifest"))
+			fakeKubeClient.ApplyReturns(kubernetes.Metadata{}, errors.New("error applying manifest"))
 		})
 
 		It("returns an error", func() {
@@ -283,9 +283,9 @@ var _ = Describe("Rollback", func() {
 	When("it succeeds", func() {
 		It("succeeds", func() {
 			Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-			u, namespace := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+			u := fakeKubeClient.ApplyArgsForCall(0)
 			b, _ := json.Marshal(&u)
-			Expect(string(namespace)).To(Equal(""))
+			Expect(u.GetNamespace()).To(Equal(""))
 			Expect(string(b)).To(Equal("{\"metadata\":{\"annotations\":{\"artifact.spinnaker.io/name\":\"test-deployment\",\"artifact.spinnaker.io/type\":\"kubernetes/deployment\",\"moniker.spinnaker.io/application\":\"test-app\"},\"creationTimestamp\":null},\"spec\":{\"selector\":null,\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null},\"spec\":{\"containers\":null}}},\"status\":{}}"))
 		})
 	})
@@ -331,9 +331,10 @@ var _ = Describe("Rollback", func() {
 		When("the kind is supported", func() {
 			It("succeeds", func() {
 				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-				u, namespace := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+				_, _, namespace := fakeKubeClient.GetArgsForCall(0)
+				Expect(namespace).To(Equal("provider-namespace"))
+				u := fakeKubeClient.ApplyArgsForCall(0)
 				b, _ := json.Marshal(&u)
-				Expect(string(namespace)).To(Equal("provider-namespace"))
 				Expect(string(b)).To(Equal("{\"metadata\":{\"annotations\":{\"artifact.spinnaker.io/name\":\"test-deployment\",\"artifact.spinnaker.io/type\":\"kubernetes/deployment\",\"moniker.spinnaker.io/application\":\"test-app\"},\"creationTimestamp\":null},\"spec\":{\"selector\":null,\"strategy\":{},\"template\":{\"metadata\":{\"creationTimestamp\":null},\"spec\":{\"containers\":null}}},\"status\":{}}"))
 			})
 		})

--- a/internal/api/core/kubernetes/runjob.go
+++ b/internal/api/core/kubernetes/runjob.go
@@ -28,12 +28,14 @@ func (cc *Controller) RunJob(c *gin.Context, rj RunJobRequest) {
 		return
 	}
 
-	namespace := u.GetNamespace()
+	namespace := ""
 	if provider.Namespace != nil {
 		namespace = *provider.Namespace
 	}
 
-	err = kube.AddSpinnakerAnnotations(&u, rj.Application, namespace)
+	kubernetes.SetNamespaceOnManifest(&u, namespace)
+
+	err = kube.AddSpinnakerAnnotations(&u, rj.Application)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return
@@ -54,7 +56,7 @@ func (cc *Controller) RunJob(c *gin.Context, rj RunJobRequest) {
 
 	kubernetes.BindArtifacts(&u, append(rj.RequiredArtifacts, rj.OptionalArtifacts...))
 
-	meta, err := provider.Client.ApplyWithNamespaceOverride(&u, namespace)
+	meta, err := provider.Client.Apply(&u)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/internal/api/core/kubernetes/runjob_test.go
+++ b/internal/api/core/kubernetes/runjob_test.go
@@ -44,7 +44,7 @@ var _ = Describe("RunJob", func() {
 
 	When("applying the manifest returns an error", func() {
 		BeforeEach(func() {
-			fakeKubeClient.ApplyWithNamespaceOverrideReturns(kubernetes.Metadata{}, errors.New("error applying manifest"))
+			fakeKubeClient.ApplyReturns(kubernetes.Metadata{}, errors.New("error applying manifest"))
 		})
 
 		It("returns an error", func() {
@@ -76,7 +76,7 @@ var _ = Describe("RunJob", func() {
 		})
 
 		It("replaces the artifact reference", func() {
-			u, _ := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+			u := fakeKubeClient.ApplyArgsForCall(0)
 			j := kubernetes.NewJob(u.Object)
 			containers := j.Object().Spec.Template.Spec.Containers
 			Expect(containers).To(HaveLen(1))
@@ -91,9 +91,8 @@ var _ = Describe("RunJob", func() {
 
 		It("generates the name correctly", func() {
 			Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-			u, namespace := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+			u := fakeKubeClient.ApplyArgsForCall(0)
 			name := u.GetName()
-			Expect(string(namespace)).To(Equal("default"))
 			Expect(name).To(HavePrefix("test-"))
 			Expect(name).To(HaveLen(10))
 		})
@@ -106,9 +105,9 @@ var _ = Describe("RunJob", func() {
 
 		It("succeeds, using providers namespace", func() {
 			Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-			u, namespace := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+			u := fakeKubeClient.ApplyArgsForCall(0)
+			Expect(u.GetNamespace()).To(Equal("provider-namespace"))
 			name := u.GetName()
-			Expect(string(namespace)).To(Equal("provider-namespace"))
 			Expect(name).To(HavePrefix("test-"))
 			Expect(name).To(HaveLen(10))
 		})
@@ -140,7 +139,7 @@ var _ = Describe("RunJob", func() {
 
 			It("annotates the object accordingly", func() {
 				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-				u, _ := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+				u := fakeKubeClient.ApplyArgsForCall(0)
 				annotations := u.GetAnnotations()
 				Expect(annotations[kubernetes.AnnotationSpinnakerArtifactLocation]).To(Equal("default"))
 			})
@@ -172,7 +171,7 @@ var _ = Describe("RunJob", func() {
 
 			It("annotates the object accordingly", func() {
 				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-				u, _ := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+				u := fakeKubeClient.ApplyArgsForCall(0)
 				annotations := u.GetAnnotations()
 				Expect(annotations[kubernetes.AnnotationSpinnakerArtifactLocation]).To(Equal("test-namespace"))
 			})

--- a/internal/api/core/kubernetes/scale.go
+++ b/internal/api/core/kubernetes/scale.go
@@ -60,7 +60,7 @@ func (cc *Controller) Scale(c *gin.Context, sm ScaleManifestRequest) {
 			return
 		}
 
-		meta, err = provider.Client.ApplyWithNamespaceOverride(u, namespace)
+		meta, err = provider.Client.Apply(u)
 		if err != nil {
 			clouddriver.Error(c, http.StatusInternalServerError, err)
 			return

--- a/internal/api/core/kubernetes/scale_test.go
+++ b/internal/api/core/kubernetes/scale_test.go
@@ -54,7 +54,7 @@ var _ = Describe("Scale", func() {
 
 	When("applying the manifest returns an error", func() {
 		BeforeEach(func() {
-			fakeKubeClient.ApplyWithNamespaceOverrideReturns(kubernetes.Metadata{}, errors.New("error applying manifest"))
+			fakeKubeClient.ApplyReturns(kubernetes.Metadata{}, errors.New("error applying manifest"))
 		})
 
 		It("returns an error", func() {
@@ -108,9 +108,10 @@ var _ = Describe("Scale", func() {
 	When("it succeeds", func() {
 		It("succeeds", func() {
 			Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-			u, namespace := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+			_, _, namespace := fakeKubeClient.GetArgsForCall(0)
+			Expect(namespace).To(Equal(""))
+			u := fakeKubeClient.ApplyArgsForCall(0)
 			b, _ := json.Marshal(&u)
-			Expect(string(namespace)).To(Equal(""))
 			Expect(string(b)).To(Equal("{\"spec\":{\"replicas\":16}}"))
 		})
 	})
@@ -134,9 +135,10 @@ var _ = Describe("Scale", func() {
 		When("the kind is supported", func() {
 			It("succeeds", func() {
 				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-				u, namespace := fakeKubeClient.ApplyWithNamespaceOverrideArgsForCall(0)
+				_, _, namespace := fakeKubeClient.GetArgsForCall(0)
+				Expect(namespace).To(Equal("provider-namespace"))
+				u := fakeKubeClient.ApplyArgsForCall(0)
 				b, _ := json.Marshal(&u)
-				Expect(string(namespace)).To(Equal("provider-namespace"))
 				Expect(string(b)).To(Equal("{\"spec\":{\"replicas\":16}}"))
 			})
 		})

--- a/internal/kubernetes/cached/disk/diskfakes/fake_cache_round_tripper.go
+++ b/internal/kubernetes/cached/disk/diskfakes/fake_cache_round_tripper.go
@@ -36,10 +36,9 @@ func (fake *FakeCacheRoundTripper) CancelRequest(arg1 *http.Request) {
 	fake.cancelRequestArgsForCall = append(fake.cancelRequestArgsForCall, struct {
 		arg1 *http.Request
 	}{arg1})
-	stub := fake.CancelRequestStub
 	fake.recordInvocation("CancelRequest", []interface{}{arg1})
 	fake.cancelRequestMutex.Unlock()
-	if stub != nil {
+	if fake.CancelRequestStub != nil {
 		fake.CancelRequestStub(arg1)
 	}
 }
@@ -69,16 +68,15 @@ func (fake *FakeCacheRoundTripper) RoundTrip(arg1 *http.Request) (*http.Response
 	fake.roundTripArgsForCall = append(fake.roundTripArgsForCall, struct {
 		arg1 *http.Request
 	}{arg1})
-	stub := fake.RoundTripStub
-	fakeReturns := fake.roundTripReturns
 	fake.recordInvocation("RoundTrip", []interface{}{arg1})
 	fake.roundTripMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.RoundTripStub != nil {
+		return fake.RoundTripStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.roundTripReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/internal/kubernetes/kubernetesfakes/fake_client.go
+++ b/internal/kubernetes/kubernetesfakes/fake_client.go
@@ -26,20 +26,6 @@ type FakeClient struct {
 		result1 kubernetes.Metadata
 		result2 error
 	}
-	ApplyWithNamespaceOverrideStub        func(*unstructured.Unstructured, string) (kubernetes.Metadata, error)
-	applyWithNamespaceOverrideMutex       sync.RWMutex
-	applyWithNamespaceOverrideArgsForCall []struct {
-		arg1 *unstructured.Unstructured
-		arg2 string
-	}
-	applyWithNamespaceOverrideReturns struct {
-		result1 kubernetes.Metadata
-		result2 error
-	}
-	applyWithNamespaceOverrideReturnsOnCall map[int]struct {
-		result1 kubernetes.Metadata
-		result2 error
-	}
 	DeleteResourceByKindAndNameAndNamespaceStub        func(string, string, string, v1.DeleteOptions) error
 	deleteResourceByKindAndNameAndNamespaceMutex       sync.RWMutex
 	deleteResourceByKindAndNameAndNamespaceArgsForCall []struct {
@@ -228,16 +214,15 @@ func (fake *FakeClient) Apply(arg1 *unstructured.Unstructured) (kubernetes.Metad
 	fake.applyArgsForCall = append(fake.applyArgsForCall, struct {
 		arg1 *unstructured.Unstructured
 	}{arg1})
-	stub := fake.ApplyStub
-	fakeReturns := fake.applyReturns
 	fake.recordInvocation("Apply", []interface{}{arg1})
 	fake.applyMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.ApplyStub != nil {
+		return fake.ApplyStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.applyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -286,71 +271,6 @@ func (fake *FakeClient) ApplyReturnsOnCall(i int, result1 kubernetes.Metadata, r
 	}{result1, result2}
 }
 
-func (fake *FakeClient) ApplyWithNamespaceOverride(arg1 *unstructured.Unstructured, arg2 string) (kubernetes.Metadata, error) {
-	fake.applyWithNamespaceOverrideMutex.Lock()
-	ret, specificReturn := fake.applyWithNamespaceOverrideReturnsOnCall[len(fake.applyWithNamespaceOverrideArgsForCall)]
-	fake.applyWithNamespaceOverrideArgsForCall = append(fake.applyWithNamespaceOverrideArgsForCall, struct {
-		arg1 *unstructured.Unstructured
-		arg2 string
-	}{arg1, arg2})
-	stub := fake.ApplyWithNamespaceOverrideStub
-	fakeReturns := fake.applyWithNamespaceOverrideReturns
-	fake.recordInvocation("ApplyWithNamespaceOverride", []interface{}{arg1, arg2})
-	fake.applyWithNamespaceOverrideMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
-	}
-	if specificReturn {
-		return ret.result1, ret.result2
-	}
-	return fakeReturns.result1, fakeReturns.result2
-}
-
-func (fake *FakeClient) ApplyWithNamespaceOverrideCallCount() int {
-	fake.applyWithNamespaceOverrideMutex.RLock()
-	defer fake.applyWithNamespaceOverrideMutex.RUnlock()
-	return len(fake.applyWithNamespaceOverrideArgsForCall)
-}
-
-func (fake *FakeClient) ApplyWithNamespaceOverrideCalls(stub func(*unstructured.Unstructured, string) (kubernetes.Metadata, error)) {
-	fake.applyWithNamespaceOverrideMutex.Lock()
-	defer fake.applyWithNamespaceOverrideMutex.Unlock()
-	fake.ApplyWithNamespaceOverrideStub = stub
-}
-
-func (fake *FakeClient) ApplyWithNamespaceOverrideArgsForCall(i int) (*unstructured.Unstructured, string) {
-	fake.applyWithNamespaceOverrideMutex.RLock()
-	defer fake.applyWithNamespaceOverrideMutex.RUnlock()
-	argsForCall := fake.applyWithNamespaceOverrideArgsForCall[i]
-	return argsForCall.arg1, argsForCall.arg2
-}
-
-func (fake *FakeClient) ApplyWithNamespaceOverrideReturns(result1 kubernetes.Metadata, result2 error) {
-	fake.applyWithNamespaceOverrideMutex.Lock()
-	defer fake.applyWithNamespaceOverrideMutex.Unlock()
-	fake.ApplyWithNamespaceOverrideStub = nil
-	fake.applyWithNamespaceOverrideReturns = struct {
-		result1 kubernetes.Metadata
-		result2 error
-	}{result1, result2}
-}
-
-func (fake *FakeClient) ApplyWithNamespaceOverrideReturnsOnCall(i int, result1 kubernetes.Metadata, result2 error) {
-	fake.applyWithNamespaceOverrideMutex.Lock()
-	defer fake.applyWithNamespaceOverrideMutex.Unlock()
-	fake.ApplyWithNamespaceOverrideStub = nil
-	if fake.applyWithNamespaceOverrideReturnsOnCall == nil {
-		fake.applyWithNamespaceOverrideReturnsOnCall = make(map[int]struct {
-			result1 kubernetes.Metadata
-			result2 error
-		})
-	}
-	fake.applyWithNamespaceOverrideReturnsOnCall[i] = struct {
-		result1 kubernetes.Metadata
-		result2 error
-	}{result1, result2}
-}
-
 func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg2 string, arg3 string, arg4 v1.DeleteOptions) error {
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.Lock()
 	ret, specificReturn := fake.deleteResourceByKindAndNameAndNamespaceReturnsOnCall[len(fake.deleteResourceByKindAndNameAndNamespaceArgsForCall)]
@@ -360,16 +280,15 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg
 		arg3 string
 		arg4 v1.DeleteOptions
 	}{arg1, arg2, arg3, arg4})
-	stub := fake.DeleteResourceByKindAndNameAndNamespaceStub
-	fakeReturns := fake.deleteResourceByKindAndNameAndNamespaceReturns
 	fake.recordInvocation("DeleteResourceByKindAndNameAndNamespace", []interface{}{arg1, arg2, arg3, arg4})
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+	if fake.DeleteResourceByKindAndNameAndNamespaceStub != nil {
+		return fake.DeleteResourceByKindAndNameAndNamespaceStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.deleteResourceByKindAndNameAndNamespaceReturns
 	return fakeReturns.result1
 }
 
@@ -420,16 +339,15 @@ func (fake *FakeClient) Discover() error {
 	ret, specificReturn := fake.discoverReturnsOnCall[len(fake.discoverArgsForCall)]
 	fake.discoverArgsForCall = append(fake.discoverArgsForCall, struct {
 	}{})
-	stub := fake.DiscoverStub
-	fakeReturns := fake.discoverReturns
 	fake.recordInvocation("Discover", []interface{}{})
 	fake.discoverMutex.Unlock()
-	if stub != nil {
-		return stub()
+	if fake.DiscoverStub != nil {
+		return fake.DiscoverStub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
+	fakeReturns := fake.discoverReturns
 	return fakeReturns.result1
 }
 
@@ -474,16 +392,15 @@ func (fake *FakeClient) GVRForKind(arg1 string) (schema.GroupVersionResource, er
 	fake.gVRForKindArgsForCall = append(fake.gVRForKindArgsForCall, struct {
 		arg1 string
 	}{arg1})
-	stub := fake.GVRForKindStub
-	fakeReturns := fake.gVRForKindReturns
 	fake.recordInvocation("GVRForKind", []interface{}{arg1})
 	fake.gVRForKindMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.GVRForKindStub != nil {
+		return fake.GVRForKindStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.gVRForKindReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -540,16 +457,15 @@ func (fake *FakeClient) Get(arg1 string, arg2 string, arg3 string) (*unstructure
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
-	stub := fake.GetStub
-	fakeReturns := fake.getReturns
 	fake.recordInvocation("Get", []interface{}{arg1, arg2, arg3})
 	fake.getMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
+	if fake.GetStub != nil {
+		return fake.GetStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.getReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -605,16 +521,15 @@ func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 v1.List
 		arg1 schema.GroupVersionResource
 		arg2 v1.ListOptions
 	}{arg1, arg2})
-	stub := fake.ListByGVRStub
-	fakeReturns := fake.listByGVRReturns
 	fake.recordInvocation("ListByGVR", []interface{}{arg1, arg2})
 	fake.listByGVRMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
+	if fake.ListByGVRStub != nil {
+		return fake.ListByGVRStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listByGVRReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -671,16 +586,15 @@ func (fake *FakeClient) ListByGVRWithContext(arg1 context.Context, arg2 schema.G
 		arg2 schema.GroupVersionResource
 		arg3 v1.ListOptions
 	}{arg1, arg2, arg3})
-	stub := fake.ListByGVRWithContextStub
-	fakeReturns := fake.listByGVRWithContextReturns
 	fake.recordInvocation("ListByGVRWithContext", []interface{}{arg1, arg2, arg3})
 	fake.listByGVRWithContextMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
+	if fake.ListByGVRWithContextStub != nil {
+		return fake.ListByGVRWithContextStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listByGVRWithContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -736,16 +650,15 @@ func (fake *FakeClient) ListResource(arg1 string, arg2 v1.ListOptions) (*unstruc
 		arg1 string
 		arg2 v1.ListOptions
 	}{arg1, arg2})
-	stub := fake.ListResourceStub
-	fakeReturns := fake.listResourceReturns
 	fake.recordInvocation("ListResource", []interface{}{arg1, arg2})
 	fake.listResourceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2)
+	if fake.ListResourceStub != nil {
+		return fake.ListResourceStub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listResourceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -802,16 +715,15 @@ func (fake *FakeClient) ListResourceWithContext(arg1 context.Context, arg2 strin
 		arg2 string
 		arg3 v1.ListOptions
 	}{arg1, arg2, arg3})
-	stub := fake.ListResourceWithContextStub
-	fakeReturns := fake.listResourceWithContextReturns
 	fake.recordInvocation("ListResourceWithContext", []interface{}{arg1, arg2, arg3})
 	fake.listResourceWithContextMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
+	if fake.ListResourceWithContextStub != nil {
+		return fake.ListResourceWithContextStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listResourceWithContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -868,16 +780,15 @@ func (fake *FakeClient) ListResourcesByKindAndNamespace(arg1 string, arg2 string
 		arg2 string
 		arg3 v1.ListOptions
 	}{arg1, arg2, arg3})
-	stub := fake.ListResourcesByKindAndNamespaceStub
-	fakeReturns := fake.listResourcesByKindAndNamespaceReturns
 	fake.recordInvocation("ListResourcesByKindAndNamespace", []interface{}{arg1, arg2, arg3})
 	fake.listResourcesByKindAndNamespaceMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
+	if fake.ListResourcesByKindAndNamespaceStub != nil {
+		return fake.ListResourcesByKindAndNamespaceStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listResourcesByKindAndNamespaceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -935,16 +846,15 @@ func (fake *FakeClient) ListResourcesByKindAndNamespaceWithContext(arg1 context.
 		arg3 string
 		arg4 v1.ListOptions
 	}{arg1, arg2, arg3, arg4})
-	stub := fake.ListResourcesByKindAndNamespaceWithContextStub
-	fakeReturns := fake.listResourcesByKindAndNamespaceWithContextReturns
 	fake.recordInvocation("ListResourcesByKindAndNamespaceWithContext", []interface{}{arg1, arg2, arg3, arg4})
 	fake.listResourcesByKindAndNamespaceWithContextMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+	if fake.ListResourcesByKindAndNamespaceWithContextStub != nil {
+		return fake.ListResourcesByKindAndNamespaceWithContextStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.listResourcesByKindAndNamespaceWithContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -1007,16 +917,15 @@ func (fake *FakeClient) Patch(arg1 string, arg2 string, arg3 string, arg4 []byte
 		arg3 string
 		arg4 []byte
 	}{arg1, arg2, arg3, arg4Copy})
-	stub := fake.PatchStub
-	fakeReturns := fake.patchReturns
 	fake.recordInvocation("Patch", []interface{}{arg1, arg2, arg3, arg4Copy})
 	fake.patchMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4)
+	if fake.PatchStub != nil {
+		return fake.PatchStub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
+	fakeReturns := fake.patchReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1083,16 +992,15 @@ func (fake *FakeClient) PatchUsingStrategy(arg1 string, arg2 string, arg3 string
 		arg4 []byte
 		arg5 types.PatchType
 	}{arg1, arg2, arg3, arg4Copy, arg5})
-	stub := fake.PatchUsingStrategyStub
-	fakeReturns := fake.patchUsingStrategyReturns
 	fake.recordInvocation("PatchUsingStrategy", []interface{}{arg1, arg2, arg3, arg4Copy, arg5})
 	fake.patchUsingStrategyMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3, arg4, arg5)
+	if fake.PatchUsingStrategyStub != nil {
+		return fake.PatchUsingStrategyStub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
+	fakeReturns := fake.patchUsingStrategyReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -1149,8 +1057,6 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.invocationsMutex.RUnlock()
 	fake.applyMutex.RLock()
 	defer fake.applyMutex.RUnlock()
-	fake.applyWithNamespaceOverrideMutex.RLock()
-	defer fake.applyWithNamespaceOverrideMutex.RUnlock()
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.RLock()
 	defer fake.deleteResourceByKindAndNameAndNamespaceMutex.RUnlock()
 	fake.discoverMutex.RLock()

--- a/internal/kubernetes/kubernetesfakes/fake_clientset.go
+++ b/internal/kubernetes/kubernetesfakes/fake_clientset.go
@@ -35,16 +35,15 @@ func (fake *FakeClientset) PodLogs(arg1 string, arg2 string, arg3 string) (strin
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
-	stub := fake.PodLogsStub
-	fakeReturns := fake.podLogsReturns
 	fake.recordInvocation("PodLogs", []interface{}{arg1, arg2, arg3})
 	fake.podLogsMutex.Unlock()
-	if stub != nil {
-		return stub(arg1, arg2, arg3)
+	if fake.PodLogsStub != nil {
+		return fake.PodLogsStub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.podLogsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/internal/kubernetes/kubernetesfakes/fake_controller.go
+++ b/internal/kubernetes/kubernetesfakes/fake_controller.go
@@ -45,16 +45,15 @@ func (fake *FakeController) NewClient(arg1 *rest.Config) (kubernetes.Client, err
 	fake.newClientArgsForCall = append(fake.newClientArgsForCall, struct {
 		arg1 *rest.Config
 	}{arg1})
-	stub := fake.NewClientStub
-	fakeReturns := fake.newClientReturns
 	fake.recordInvocation("NewClient", []interface{}{arg1})
 	fake.newClientMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.NewClientStub != nil {
+		return fake.NewClientStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.newClientReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -109,16 +108,15 @@ func (fake *FakeController) NewClientset(arg1 *rest.Config) (kubernetes.Clientse
 	fake.newClientsetArgsForCall = append(fake.newClientsetArgsForCall, struct {
 		arg1 *rest.Config
 	}{arg1})
-	stub := fake.NewClientsetStub
-	fakeReturns := fake.newClientsetReturns
 	fake.recordInvocation("NewClientset", []interface{}{arg1})
 	fake.newClientsetMutex.Unlock()
-	if stub != nil {
-		return stub(arg1)
+	if fake.NewClientsetStub != nil {
+		return fake.NewClientsetStub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
+	fakeReturns := fake.newClientsetReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/internal/kubernetes/namespace.go
+++ b/internal/kubernetes/namespace.go
@@ -1,0 +1,69 @@
+package kubernetes
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+)
+
+// SetNamespaceOnManifest updates the namespace on the given manifest.
+//
+// If no namespace is set on the manifest and no namespace override is passed
+// in then we set the namespace to 'default'.
+//
+// If namespaceOverride is empty it will NOT override the namespace set
+// on the manifest.
+//
+// We only override the namespace if the manifest is NOT cluster scoped
+// (i.e. a ClusterRole) and namespaceOverride is NOT an empty string.
+func SetNamespaceOnManifest(u *unstructured.Unstructured, namespaceOverride string) {
+	if namespaceOverride == "" {
+		setDefaultNamespaceIfScopedAndNoneSet(u)
+	} else {
+		setNamespaceIfScoped(namespaceOverride, u)
+	}
+}
+
+func setDefaultNamespaceIfScopedAndNoneSet(u *unstructured.Unstructured) {
+	namespace := u.GetNamespace()
+	if isNamespaceScoped(u.GetKind()) && namespace == "" {
+		namespace = "default"
+		u.SetNamespace(namespace)
+	}
+}
+
+func setNamespaceIfScoped(namespace string, u *unstructured.Unstructured) {
+	if isNamespaceScoped(u.GetKind()) {
+		u.SetNamespace(namespace)
+	}
+}
+
+// isNamespaceScoped returns true if the kind is namespace-scoped.
+//
+// Cluster-scoped kinds are:
+//   - apiService
+//   - clusterRole
+//   - clusterRoleBinding
+//   - customResourceDefinition
+//   - mutatingWebhookConfiguration
+//   - namespace
+//   - persistentVolume
+//   - podSecurityPolicy
+//   - storageClass
+//   - validatingWebhookConfiguration
+//
+// See https://github.com/spinnaker/clouddriver/blob/58ab154b0ec0d62772201b5b319af349498a4e3f/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKindProperties.java#L31
+// for clouddriver OSS namespace-scoped kinds.
+func isNamespaceScoped(kind string) bool {
+	namespaceScoped := true
+
+	for _, value := range clusterScopedKinds {
+		if strings.EqualFold(value, kind) {
+			namespaceScoped = false
+
+			break
+		}
+	}
+
+	return namespaceScoped
+}

--- a/internal/kubernetes/namespace_test.go
+++ b/internal/kubernetes/namespace_test.go
@@ -1,0 +1,189 @@
+package kubernetes_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	. "github.com/homedepot/go-clouddriver/internal/kubernetes"
+)
+
+var _ = Describe("Namespace", func() {
+	var (
+		err       error
+		m         map[string]interface{}
+		manifest  unstructured.Unstructured
+		namespace string
+	)
+
+	Context("#SetNamspaceOnManifest", func() {
+		BeforeEach(func() {
+			m = map[string]interface{}{
+				"kind":       "DaemonSet",
+				"apiVersion": "apps/v1",
+				"metadata": map[string]interface{}{
+					"name":      "test-name",
+					"namespace": "test-namespace",
+				},
+			}
+		})
+
+		JustBeforeEach(func() {
+			manifest, err = ToUnstructured(m)
+			Expect(err).To(BeNil())
+			SetNamespaceOnManifest(&manifest, namespace)
+		})
+
+		When("there is no namespace override", func() {
+			BeforeEach(func() {
+				namespace = ""
+			})
+
+			Context("kubernetes kind is namespace scoped", func() {
+				When("manifest namespace is not set", func() {
+					BeforeEach(func() {
+						m = map[string]interface{}{
+							"kind":       "Deployment",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name": "test-name",
+							},
+						}
+					})
+
+					It("sets namespace to 'default'", func() {
+						Expect(manifest.GetNamespace()).To(Equal("default"))
+					})
+				})
+
+				When("manifest namespace is set", func() {
+					BeforeEach(func() {
+						m = map[string]interface{}{
+							"kind":       "Deployment",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-name",
+								"namespace": "test-namespace",
+							},
+						}
+					})
+
+					It("does not override namespace", func() {
+						Expect(manifest.GetNamespace()).To(Equal("test-namespace"))
+					})
+				})
+			})
+
+			Context("kubernetes kind is cluster scoped", func() {
+				When("manifest namespace is not set", func() {
+					BeforeEach(func() {
+						m = map[string]interface{}{
+							"kind":       "Namespace",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name": "test-name",
+							},
+						}
+					})
+
+					It("does not override namespace", func() {
+						Expect(manifest.GetNamespace()).To(Equal(""))
+					})
+				})
+
+				When("manifest namespace is set", func() {
+					BeforeEach(func() {
+						m = map[string]interface{}{
+							"kind":       "Namespace",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-name",
+								"namespace": "test-namespace",
+							},
+						}
+					})
+
+					It("does not override namespace", func() {
+						Expect(manifest.GetNamespace()).To(Equal("test-namespace"))
+					})
+				})
+			})
+		})
+
+		When("there is a namespace override", func() {
+			BeforeEach(func() {
+				namespace = "test-namespace-override"
+			})
+
+			Context("kubernetes kind is namespace scoped", func() {
+				When("manifest namespace is not set", func() {
+					BeforeEach(func() {
+						m = map[string]interface{}{
+							"kind":       "Deployment",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name": "test-name",
+							},
+						}
+					})
+
+					It("overrides namespace", func() {
+						Expect(manifest.GetNamespace()).To(Equal("test-namespace-override"))
+					})
+				})
+
+				When("manifest namespace is set", func() {
+					BeforeEach(func() {
+						m = map[string]interface{}{
+							"kind":       "Deployment",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-name",
+								"namespace": "test-namespace",
+							},
+						}
+					})
+
+					It("overrides namespace", func() {
+						Expect(manifest.GetNamespace()).To(Equal("test-namespace-override"))
+					})
+				})
+			})
+
+			Context("kubernetes kind is cluster scoped", func() {
+				When("manifest namespace is not set", func() {
+					BeforeEach(func() {
+						m = map[string]interface{}{
+							"kind":       "Namespace",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name": "test-name",
+							},
+						}
+					})
+
+					It("does not override namespace", func() {
+						Expect(manifest.GetNamespace()).To(Equal(""))
+					})
+				})
+
+				When("manifest namespace is set", func() {
+					BeforeEach(func() {
+						m = map[string]interface{}{
+							"kind":       "Namespace",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-name",
+								"namespace": "test-namespace",
+							},
+						}
+					})
+
+					It("does not override namespace", func() {
+						Expect(manifest.GetNamespace()).To(Equal("test-namespace"))
+					})
+				})
+			})
+		})
+	})
+})


### PR DESCRIPTION
This PR sets the namespace in the manifests before processing them.  For namespace-scoped Kubernetes kinds, the order of precedence for determining the namespace is
 - the namespace of a namespace-scoped provider
 - the namespace override from the `/kubernetes/ops` request
 - the literal `default`, when the namespace is not specified in the manifest
 - the namespace in the manifest, when specified - that is, left unchanged
 
By setting the namespace early in the processing, downstream logic is assured that the namespace will always have a value and doesn't have to do any namespace determination of its own (or equate `"default"` with `""`).  The code has been refactored to remove this redundant processing.

This corrects an issue with handling the `traffic.spinnaker.io/load-balancers` annotation of a deployment with
- the namespace was overridden (either in the request or by the provider)
- the Service and ReplicaSet included in the manifests, but with no `namespace` value set

```yaml
apiVersion: v1
kind: Service
metadata:
  name: example
spec:
  selector:
    lb: example
---
apiVersion: apps/v1
kind: ReplicaSet
metadata:
  annotations:
    traffic.spinnaker.io/load-balancers: '["service example"]'
  name: example
spec:
   ...
```
When this was processed, which a namespace override value set to `example`
1. First, based on the sorted priority, the Service manifest is processed, which set the namespace in the manifest to the override value, `example` and deployed it
    ```yaml
    apiVersion: v1
    kind: Service
    metadata:
     name: example
     namespace: example
   spec:
     selector:
       lb: example
    ```
2. Next, the ReplicaSet manifest is processed, but failed to attach the load balancer because
    1. The Service was not found in the manifest because the namespace on the ReplicaSet (empty string) did not match the namespace on the Service, `example`
    2. The Service was also not found in the cluster either because the it was looking for Services in the namespace of the ReplicaSet manifest, which is an empty string, so the `default` namespace, instead of the `example` namespace based on the override value