### PR TITLE
add support for spinnaker managed traffic

### DIFF
--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -337,24 +337,26 @@ func handleRecreate(kubeClient kubernetes.Client, u *unstructured.Unstructured) 
 // annotation accordingly if not set and errors if it is set.
 func handleTrafficManagement(target *unstructured.Unstructured, tm TrafficManagement) error {
 	annotations := target.GetAnnotations()
-	if annotations != nil {
-		if value, ok := annotations[kubernetes.AnnotationSpinnakerTrafficLoadBalancers]; ok && value != "" {
-			return fmt.Errorf("manifest already has traffic.spinnaker.io/load-balancers annotation set to %s. "+
-				"Failed attempting to set it to [%s]", value, strings.Join(tm.Options.Services, ", "))
-		}
-
-		loadBalancers := "["
-		for i, service := range tm.Options.Services {
-			loadBalancers += `"` + service + `"`
-			if i < len(tm.Options.Services)-1 {
-				loadBalancers += `, `
-			}
-		}
-
-		loadBalancers += "]"
-		annotations[kubernetes.AnnotationSpinnakerTrafficLoadBalancers] = loadBalancers
-		target.SetAnnotations(annotations)
+	if annotations == nil {
+		annotations = map[string]string{}
 	}
+
+	if value, ok := annotations[kubernetes.AnnotationSpinnakerTrafficLoadBalancers]; ok && value != "" {
+		return fmt.Errorf("manifest already has traffic.spinnaker.io/load-balancers annotation set to %s. "+
+			"Failed attempting to set it to [%s]", value, strings.Join(tm.Options.Services, ", "))
+	}
+
+	loadBalancers := "["
+	for i, service := range tm.Options.Services {
+		loadBalancers += `"` + service + `"`
+		if i < len(tm.Options.Services)-1 {
+			loadBalancers += `, `
+		}
+	}
+
+	loadBalancers += "]"
+	annotations[kubernetes.AnnotationSpinnakerTrafficLoadBalancers] = loadBalancers
+	target.SetAnnotations(annotations)
 
 	return nil
 }

--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -126,10 +126,26 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			}
 		}
 
-		err = handleAttachingLoadBalancers(provider.Client, &manifest, manifests)
-		if err != nil {
-			clouddriver.Error(c, http.StatusBadRequest, err)
-			return
+		// Set the `traffic.spinnaker.io/load-balancers` annotation if the user
+		// has requested for Spinnaker to manage a resources traffic.
+		if dm.TrafficManagement.Enabled {
+			err = handleTrafficManagement(&manifest, dm.TrafficManagement)
+			if err != nil {
+				clouddriver.Error(c, http.StatusBadRequest, err)
+				return
+			}
+		}
+
+		// Only handle attaching load balancers if not using Spinnaker traffic management
+		// (i.e. user is manually setting the `traffic.spinnaker.io/load-balancers` annotation)
+		// or if using Spinnaker traffic management and the user has requested to route traffic
+		// to pods.
+		if !dm.TrafficManagement.Enabled || (dm.TrafficManagement.Enabled && dm.TrafficManagement.Options.EnableTraffic) {
+			err = handleAttachingLoadBalancers(provider.Client, &manifest, manifests)
+			if err != nil {
+				clouddriver.Error(c, http.StatusBadRequest, err)
+				return
+			}
 		}
 
 		meta, err := provider.Client.Apply(&manifest)
@@ -312,6 +328,32 @@ func handleRecreate(kubeClient kubernetes.Client, u *unstructured.Unstructured) 
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// handleTrafficManagement sets the `traffic.spinnaker.io/load-balancers`
+// annotation accordingly if not set and errors if it is set.
+func handleTrafficManagement(target *unstructured.Unstructured, tm TrafficManagement) error {
+	annotations := target.GetAnnotations()
+	if annotations != nil {
+		if value, ok := annotations[kubernetes.AnnotationSpinnakerTrafficLoadBalancers]; ok && value != "" {
+			return fmt.Errorf("manifest already has traffic.spinnaker.io/load-balancers annotation set to %s. "+
+				"Failed attempting to set it to [%s]", value, strings.Join(tm.Options.Services, ", "))
+		}
+
+		loadBalancers := "["
+		for i, service := range tm.Options.Services {
+			loadBalancers += `"` + service + `"`
+			if i < len(tm.Options.Services)-1 {
+				loadBalancers += `, `
+			}
+		}
+
+		loadBalancers += "]"
+		annotations[kubernetes.AnnotationSpinnakerTrafficLoadBalancers] = loadBalancers
+		target.SetAnnotations(annotations)
 	}
 
 	return nil

--- a/internal/api/core/kubernetes/deploy_test.go
+++ b/internal/api/core/kubernetes/deploy_test.go
@@ -314,6 +314,274 @@ var _ = Describe("Deploy", func() {
 		})
 	})
 
+	Context("when the manifest uses Spinnaker managed traffic", func() {
+		BeforeEach(func() {
+			deployManifestRequest = DeployManifestRequest{
+				Manifests: []map[string]interface{}{
+					{
+						"kind":       "ReplicaSet",
+						"apiVersion": "apps/v1",
+						"metadata": map[string]interface{}{
+							"name":      "test-name",
+							"namespace": "test-namespace",
+						},
+						"spec": map[string]interface{}{
+							"template": map[string]interface{}{
+								"metadata": map[string]interface{}{
+									"labels": map[string]interface{}{
+										"labelKey1": "labelValue1",
+										"labelKey2": "labelValue2",
+									},
+								},
+							},
+						},
+					},
+				},
+				TrafficManagement: TrafficManagement{
+					Enabled: true,
+					Options: TrafficManagementOptions{
+						EnableTraffic: true,
+						Namespace:     "test-namespace",
+						Services: []string{
+							"service test-service",
+							"service test-service2",
+						},
+					},
+				},
+			}
+			fakeService := unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Service",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"name":      "test-service",
+						"namespace": "test-namespace",
+					},
+					"spec": map[string]interface{}{
+						"selector": map[string]interface{}{
+							"selectorKey1": "selectorValue1",
+							"selectorKey2": "selectorValue2",
+						},
+					},
+				},
+			}
+			fakeService2 := unstructured.Unstructured{
+				Object: map[string]interface{}{
+					"kind":       "Service",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"name":      "test-service2",
+						"namespace": "test-namespace",
+					},
+					"spec": map[string]interface{}{
+						"selector": map[string]interface{}{
+							"selectorKey3": "selectorValue3",
+							"selectorKey4": "selectorValue4",
+						},
+					},
+				},
+			}
+			fakeKubeClient.GetReturnsOnCall(0, &fakeService, nil)
+			fakeKubeClient.GetReturnsOnCall(1, &fakeService2, nil)
+		})
+
+		When("the load balancer is annotation is already set", func() {
+			BeforeEach(func() {
+				deployManifestRequest = DeployManifestRequest{
+					Manifests: []map[string]interface{}{
+						{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"annotations": map[string]interface{}{
+									"traffic.spinnaker.io/load-balancers": "[\"service test-service\"]",
+								},
+								"name":      "test-name",
+								"namespace": "test-namespace",
+							},
+						},
+					},
+					TrafficManagement: TrafficManagement{
+						Enabled: true,
+						Options: TrafficManagementOptions{
+							EnableTraffic: true,
+							Namespace:     "test-namespace",
+							Services: []string{
+								"service test-service",
+								"service test-service2",
+							},
+						},
+					},
+				}
+			})
+
+			It("returns an error", func() {
+				Expect(c.Writer.Status()).To(Equal(http.StatusBadRequest))
+				Expect(c.Errors.Last().Error()).To(Equal("manifest already has traffic.spinnaker.io/load-balancers annotation set to [\"service test-service\"]. Failed attempting to set it to [service test-service, service test-service2]"))
+			})
+		})
+
+		When("the load balancer is part of the current request's manifests", func() {
+			BeforeEach(func() {
+				deployManifestRequest = DeployManifestRequest{
+					Manifests: []map[string]interface{}{
+						{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-name",
+								"namespace": "test-namespace",
+							},
+							"spec": map[string]interface{}{
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"labelKey1": "labelValue1",
+											"labelKey2": "labelValue2",
+										},
+									},
+								},
+							},
+						},
+						{
+							"kind":       "Service",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-service",
+								"namespace": "test-namespace",
+							},
+							"spec": map[string]interface{}{
+								"selector": map[string]interface{}{
+									"selectorKey1": "selectorValue1",
+									"selectorKey2": "selectorValue2",
+								},
+							},
+						},
+					},
+					TrafficManagement: TrafficManagement{
+						Enabled: true,
+						Options: TrafficManagementOptions{
+							EnableTraffic: true,
+							Namespace:     "test-namespace",
+							Services: []string{
+								"service test-service",
+							},
+						},
+					},
+				}
+			})
+
+			It("succeeds and does not call the cluster to get the load balancer", func() {
+				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.GetCallCount()).To(BeZero())
+			})
+		})
+
+		When("the load balancer is part of the current request's manifests and the namespace is overridden", func() {
+			BeforeEach(func() {
+				deployManifestRequest = DeployManifestRequest{
+					NamespaceOverride: "test-namespace",
+					Manifests: []map[string]interface{}{
+						{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-name",
+								"namespace": "test-1",
+							},
+							"spec": map[string]interface{}{
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"labelKey1": "labelValue1",
+											"labelKey2": "labelValue2",
+										},
+									},
+								},
+							},
+						},
+						{
+							"kind":       "Service",
+							"apiVersion": "v1",
+							"metadata": map[string]interface{}{
+								"name":      "test-service",
+								"namespace": "test-2",
+							},
+							"spec": map[string]interface{}{
+								"selector": map[string]interface{}{
+									"selectorKey1": "selectorValue1",
+									"selectorKey2": "selectorValue2",
+								},
+							},
+						},
+					},
+					TrafficManagement: TrafficManagement{
+						Enabled: true,
+						Options: TrafficManagementOptions{
+							EnableTraffic: true,
+							Namespace:     "test-namespace",
+							Services: []string{
+								"service test-service",
+							},
+						},
+					},
+				}
+			})
+
+			It("succeeds and does not call the cluster to get the load balancer", func() {
+				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.GetCallCount()).To(BeZero())
+			})
+		})
+
+		When("the client has requested to not forward requests to pods", func() {
+			BeforeEach(func() {
+				deployManifestRequest.TrafficManagement = TrafficManagement{
+					Enabled: true,
+					Options: TrafficManagementOptions{
+						EnableTraffic: false,
+						Namespace:     "test-namespace",
+						Services: []string{
+							"service test-service",
+						},
+					},
+				}
+			})
+
+			It("annotates the manifest and does not call the cluster to get the load balancer", func() {
+				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.GetCallCount()).To(BeZero())
+				u := fakeKubeClient.ApplyArgsForCall(0)
+				annotations := u.GetAnnotations()
+				Expect(annotations[kubernetes.AnnotationSpinnakerTrafficLoadBalancers]).To(Equal(`["service test-service"]`))
+			})
+		})
+
+		When("it succeeds", func() {
+			It("attaches the load balancer", func() {
+				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+				u := fakeKubeClient.ApplyArgsForCall(0)
+				labels, _, _ := unstructured.NestedStringMap(u.Object, "spec", "template", "metadata", "labels")
+				Expect(labels["labelKey1"]).To(Equal("labelValue1"))
+				Expect(labels["labelKey2"]).To(Equal("labelValue2"))
+				Expect(labels["selectorKey1"]).To(Equal("selectorValue1"))
+				Expect(labels["selectorKey2"]).To(Equal("selectorValue2"))
+				Expect(labels["selectorKey3"]).To(Equal("selectorValue3"))
+				Expect(labels["selectorKey4"]).To(Equal("selectorValue4"))
+				annotations := u.GetAnnotations()
+				Expect(annotations[kubernetes.AnnotationSpinnakerTrafficLoadBalancers]).To(Equal(`["service test-service", "service test-service2"]`))
+				kind, name, namespace := fakeKubeClient.GetArgsForCall(0)
+				Expect(kind).To(Equal("service"))
+				Expect(name).To(Equal("test-service"))
+				Expect(namespace).To(Equal("test-namespace"))
+				kind2, name2, namespace2 := fakeKubeClient.GetArgsForCall(1)
+				Expect(kind2).To(Equal("service"))
+				Expect(name2).To(Equal("test-service2"))
+				Expect(namespace2).To(Equal("test-namespace"))
+			})
+		})
+	})
+
 	Context("when the manifest uses load balancer annotations", func() {
 		BeforeEach(func() {
 			deployManifestRequest = DeployManifestRequest{

--- a/internal/api/core/kubernetes/ops.go
+++ b/internal/api/core/kubernetes/ops.go
@@ -32,13 +32,8 @@ type DeployManifestRequest struct {
 	NamespaceOverride string                   `json:"namespaceOverride"`
 	CloudProvider     string                   `json:"cloudProvider"`
 	Manifests         []map[string]interface{} `json:"manifests"`
-	TrafficManagement struct {
-		Options struct {
-			EnableTraffic bool `json:"enableTraffic"`
-		} `json:"options"`
-		Enabled bool `json:"enabled"`
-	} `json:"trafficManagement"`
-	Moniker struct {
+	TrafficManagement TrafficManagement        `json:"trafficManagement"`
+	Moniker           struct {
 		App string `json:"app"`
 	} `json:"moniker"`
 	Source                   string                 `json:"source"`
@@ -46,6 +41,17 @@ type DeployManifestRequest struct {
 	SkipExpressionEvaluation bool                   `json:"skipExpressionEvaluation"`
 	RequiredArtifacts        []clouddriver.Artifact `json:"requiredArtifacts"`
 	OptionalArtifacts        []clouddriver.Artifact `json:"optionalArtifacts"`
+}
+
+type TrafficManagement struct {
+	Enabled bool                     `json:"enabled"`
+	Options TrafficManagementOptions `json:"options"`
+}
+
+type TrafficManagementOptions struct {
+	EnableTraffic bool     `json:"enableTraffic"`
+	Namespace     string   `json:"namespace"`
+	Services      []string `json:"services"`
 }
 
 type DisableManifestRequest struct {


### PR DESCRIPTION
- Adds support for Spinnaker managed traffic

Notes:
This is the error that is returned when the annotation `traffic.spinnaker.io/load-balancers` is already set:
```
manifest already has traffic.spinnaker.io/load-balancers annotation set to ["service test-service"]. Failed attempting to set it to [service test-service, service test-service2]
```
I did a simple `strings.Join(...)` on the array to build the error which is why the services in the second array are not wrapped in double quotes. If this is bothersome please request changes to build the string array.