### PR TITLE
Add support for getting manifest events

### DIFF
--- a/internal/api/core/kubernetes/ops.go
+++ b/internal/api/core/kubernetes/ops.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/homedepot/go-clouddriver/internal/kubernetes/manifest"
 	clouddriver "github.com/homedepot/go-clouddriver/pkg"
+	v1 "k8s.io/api/core/v1"
 )
 
 type OperationsResponse struct {
@@ -105,7 +106,7 @@ type ManifestResponse struct {
 		Reference string `json:"reference"`
 		Type      string `json:"type"`
 	} `json:"artifacts"`
-	Events   []interface{}           `json:"events"`
+	Events   []v1.Event              `json:"events"`
 	Location string                  `json:"location"`
 	Manifest map[string]interface{}  `json:"manifest"`
 	Metrics  []interface{}           `json:"metrics"`

--- a/internal/api/core/payload_test.go
+++ b/internal/api/core/payload_test.go
@@ -2759,6 +2759,121 @@ const payloadManifestClusterRoleNoRules = `{
             "warnings": []
           }`
 
+const payloadManifestNoEvents = `{
+            "account": "test-account",
+            "artifacts": null,
+            "events": [],
+            "location": "test-namespace",
+            "manifest": {},
+            "metrics": [],
+            "moniker": {
+              "app": "unknown",
+              "cluster": "pod test-pod"
+            },
+            "name": "pod test-pod",
+            "status": {
+              "available": {
+                "state": true,
+                "message": ""
+              },
+              "failed": {
+                "state": false,
+                "message": ""
+              },
+              "paused": {
+                "state": false,
+                "message": ""
+              },
+              "stable": {
+                "state": true,
+                "message": ""
+              }
+            },
+            "warnings": []
+          }`
+
+const payloadManifestIncludeEvents = `{
+              "account": "test-account",
+              "artifacts": null,
+              "events": [
+                {
+                  "kind": "test-kind",
+                  "apiVersion": "test-api-version",
+                  "metadata": {
+                    "name": "test-event-name",
+                    "generateName": "test-event-generate-name",
+                    "namespace": "test-event-namespace",
+                    "creationTimestamp": null
+                  },
+                  "involvedObject": {
+                    "kind": "test-kind",
+                    "namespace": "test-namespace",
+                    "name": "test-pod"
+                  },
+                  "reason": "test reason",
+                  "message": "test message",
+                  "source": {},
+                  "firstTimestamp": null,
+                  "lastTimestamp": null,
+                  "count": 1,
+                  "eventTime": null,
+                  "reportingComponent": "",
+                  "reportingInstance": ""
+                },
+                {
+                  "kind": "test-kind",
+                  "apiVersion": "test-api-version",
+                  "metadata": {
+                    "name": "test-event-name2",
+                    "generateName": "test-event-generate-name",
+                    "namespace": "test-event-namespace",
+                    "creationTimestamp": null
+                  },
+                  "involvedObject": {
+                    "kind": "test-kind",
+                    "namespace": "test-namespace",
+                    "name": "test-pod"
+                  },
+                  "reason": "test reason",
+                  "message": "test message",
+                  "source": {},
+                  "firstTimestamp": null,
+                  "lastTimestamp": null,
+                  "count": 2,
+                  "eventTime": null,
+                  "reportingComponent": "",
+                  "reportingInstance": ""
+                }
+              ],
+              "location": "test-namespace",
+              "manifest": {},
+              "metrics": [],
+              "moniker": {
+                "app": "unknown",
+                "cluster": "pod test-pod"
+              },
+              "name": "pod test-pod",
+              "status": {
+                "available": {
+                  "state": true,
+                  "message": ""
+                },
+                "failed": {
+                  "state": false,
+                  "message": ""
+                },
+                "paused": {
+                  "state": false,
+                  "message": ""
+                },
+                "stable": {
+                  "state": true,
+                  "message": ""
+                }
+              },
+              "warnings": []
+            }`
+
 const payloadGetInstance = `{
             "account": "test-account",
             "apiVersion": "v1",

--- a/internal/kubernetes/cached/disk/diskfakes/fake_cache_round_tripper.go
+++ b/internal/kubernetes/cached/disk/diskfakes/fake_cache_round_tripper.go
@@ -36,9 +36,10 @@ func (fake *FakeCacheRoundTripper) CancelRequest(arg1 *http.Request) {
 	fake.cancelRequestArgsForCall = append(fake.cancelRequestArgsForCall, struct {
 		arg1 *http.Request
 	}{arg1})
+	stub := fake.CancelRequestStub
 	fake.recordInvocation("CancelRequest", []interface{}{arg1})
 	fake.cancelRequestMutex.Unlock()
-	if fake.CancelRequestStub != nil {
+	if stub != nil {
 		fake.CancelRequestStub(arg1)
 	}
 }
@@ -68,15 +69,16 @@ func (fake *FakeCacheRoundTripper) RoundTrip(arg1 *http.Request) (*http.Response
 	fake.roundTripArgsForCall = append(fake.roundTripArgsForCall, struct {
 		arg1 *http.Request
 	}{arg1})
+	stub := fake.RoundTripStub
+	fakeReturns := fake.roundTripReturns
 	fake.recordInvocation("RoundTrip", []interface{}{arg1})
 	fake.roundTripMutex.Unlock()
-	if fake.RoundTripStub != nil {
-		return fake.RoundTripStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.roundTripReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 

--- a/internal/kubernetes/kubernetesfakes/fake_client.go
+++ b/internal/kubernetes/kubernetesfakes/fake_client.go
@@ -214,15 +214,16 @@ func (fake *FakeClient) Apply(arg1 *unstructured.Unstructured) (kubernetes.Metad
 	fake.applyArgsForCall = append(fake.applyArgsForCall, struct {
 		arg1 *unstructured.Unstructured
 	}{arg1})
+	stub := fake.ApplyStub
+	fakeReturns := fake.applyReturns
 	fake.recordInvocation("Apply", []interface{}{arg1})
 	fake.applyMutex.Unlock()
-	if fake.ApplyStub != nil {
-		return fake.ApplyStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.applyReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -280,15 +281,16 @@ func (fake *FakeClient) DeleteResourceByKindAndNameAndNamespace(arg1 string, arg
 		arg3 string
 		arg4 v1.DeleteOptions
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.DeleteResourceByKindAndNameAndNamespaceStub
+	fakeReturns := fake.deleteResourceByKindAndNameAndNamespaceReturns
 	fake.recordInvocation("DeleteResourceByKindAndNameAndNamespace", []interface{}{arg1, arg2, arg3, arg4})
 	fake.deleteResourceByKindAndNameAndNamespaceMutex.Unlock()
-	if fake.DeleteResourceByKindAndNameAndNamespaceStub != nil {
-		return fake.DeleteResourceByKindAndNameAndNamespaceStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.deleteResourceByKindAndNameAndNamespaceReturns
 	return fakeReturns.result1
 }
 
@@ -339,15 +341,16 @@ func (fake *FakeClient) Discover() error {
 	ret, specificReturn := fake.discoverReturnsOnCall[len(fake.discoverArgsForCall)]
 	fake.discoverArgsForCall = append(fake.discoverArgsForCall, struct {
 	}{})
+	stub := fake.DiscoverStub
+	fakeReturns := fake.discoverReturns
 	fake.recordInvocation("Discover", []interface{}{})
 	fake.discoverMutex.Unlock()
-	if fake.DiscoverStub != nil {
-		return fake.DiscoverStub()
+	if stub != nil {
+		return stub()
 	}
 	if specificReturn {
 		return ret.result1
 	}
-	fakeReturns := fake.discoverReturns
 	return fakeReturns.result1
 }
 
@@ -392,15 +395,16 @@ func (fake *FakeClient) GVRForKind(arg1 string) (schema.GroupVersionResource, er
 	fake.gVRForKindArgsForCall = append(fake.gVRForKindArgsForCall, struct {
 		arg1 string
 	}{arg1})
+	stub := fake.GVRForKindStub
+	fakeReturns := fake.gVRForKindReturns
 	fake.recordInvocation("GVRForKind", []interface{}{arg1})
 	fake.gVRForKindMutex.Unlock()
-	if fake.GVRForKindStub != nil {
-		return fake.GVRForKindStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.gVRForKindReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -457,15 +461,16 @@ func (fake *FakeClient) Get(arg1 string, arg2 string, arg3 string) (*unstructure
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.GetStub
+	fakeReturns := fake.getReturns
 	fake.recordInvocation("Get", []interface{}{arg1, arg2, arg3})
 	fake.getMutex.Unlock()
-	if fake.GetStub != nil {
-		return fake.GetStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.getReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -521,15 +526,16 @@ func (fake *FakeClient) ListByGVR(arg1 schema.GroupVersionResource, arg2 v1.List
 		arg1 schema.GroupVersionResource
 		arg2 v1.ListOptions
 	}{arg1, arg2})
+	stub := fake.ListByGVRStub
+	fakeReturns := fake.listByGVRReturns
 	fake.recordInvocation("ListByGVR", []interface{}{arg1, arg2})
 	fake.listByGVRMutex.Unlock()
-	if fake.ListByGVRStub != nil {
-		return fake.ListByGVRStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listByGVRReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -586,15 +592,16 @@ func (fake *FakeClient) ListByGVRWithContext(arg1 context.Context, arg2 schema.G
 		arg2 schema.GroupVersionResource
 		arg3 v1.ListOptions
 	}{arg1, arg2, arg3})
+	stub := fake.ListByGVRWithContextStub
+	fakeReturns := fake.listByGVRWithContextReturns
 	fake.recordInvocation("ListByGVRWithContext", []interface{}{arg1, arg2, arg3})
 	fake.listByGVRWithContextMutex.Unlock()
-	if fake.ListByGVRWithContextStub != nil {
-		return fake.ListByGVRWithContextStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listByGVRWithContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -650,15 +657,16 @@ func (fake *FakeClient) ListResource(arg1 string, arg2 v1.ListOptions) (*unstruc
 		arg1 string
 		arg2 v1.ListOptions
 	}{arg1, arg2})
+	stub := fake.ListResourceStub
+	fakeReturns := fake.listResourceReturns
 	fake.recordInvocation("ListResource", []interface{}{arg1, arg2})
 	fake.listResourceMutex.Unlock()
-	if fake.ListResourceStub != nil {
-		return fake.ListResourceStub(arg1, arg2)
+	if stub != nil {
+		return stub(arg1, arg2)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listResourceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -715,15 +723,16 @@ func (fake *FakeClient) ListResourceWithContext(arg1 context.Context, arg2 strin
 		arg2 string
 		arg3 v1.ListOptions
 	}{arg1, arg2, arg3})
+	stub := fake.ListResourceWithContextStub
+	fakeReturns := fake.listResourceWithContextReturns
 	fake.recordInvocation("ListResourceWithContext", []interface{}{arg1, arg2, arg3})
 	fake.listResourceWithContextMutex.Unlock()
-	if fake.ListResourceWithContextStub != nil {
-		return fake.ListResourceWithContextStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listResourceWithContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -780,15 +789,16 @@ func (fake *FakeClient) ListResourcesByKindAndNamespace(arg1 string, arg2 string
 		arg2 string
 		arg3 v1.ListOptions
 	}{arg1, arg2, arg3})
+	stub := fake.ListResourcesByKindAndNamespaceStub
+	fakeReturns := fake.listResourcesByKindAndNamespaceReturns
 	fake.recordInvocation("ListResourcesByKindAndNamespace", []interface{}{arg1, arg2, arg3})
 	fake.listResourcesByKindAndNamespaceMutex.Unlock()
-	if fake.ListResourcesByKindAndNamespaceStub != nil {
-		return fake.ListResourcesByKindAndNamespaceStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listResourcesByKindAndNamespaceReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -846,15 +856,16 @@ func (fake *FakeClient) ListResourcesByKindAndNamespaceWithContext(arg1 context.
 		arg3 string
 		arg4 v1.ListOptions
 	}{arg1, arg2, arg3, arg4})
+	stub := fake.ListResourcesByKindAndNamespaceWithContextStub
+	fakeReturns := fake.listResourcesByKindAndNamespaceWithContextReturns
 	fake.recordInvocation("ListResourcesByKindAndNamespaceWithContext", []interface{}{arg1, arg2, arg3, arg4})
 	fake.listResourcesByKindAndNamespaceWithContextMutex.Unlock()
-	if fake.ListResourcesByKindAndNamespaceWithContextStub != nil {
-		return fake.ListResourcesByKindAndNamespaceWithContextStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.listResourcesByKindAndNamespaceWithContextReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -917,15 +928,16 @@ func (fake *FakeClient) Patch(arg1 string, arg2 string, arg3 string, arg4 []byte
 		arg3 string
 		arg4 []byte
 	}{arg1, arg2, arg3, arg4Copy})
+	stub := fake.PatchStub
+	fakeReturns := fake.patchReturns
 	fake.recordInvocation("Patch", []interface{}{arg1, arg2, arg3, arg4Copy})
 	fake.patchMutex.Unlock()
-	if fake.PatchStub != nil {
-		return fake.PatchStub(arg1, arg2, arg3, arg4)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.patchReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 
@@ -992,15 +1004,16 @@ func (fake *FakeClient) PatchUsingStrategy(arg1 string, arg2 string, arg3 string
 		arg4 []byte
 		arg5 types.PatchType
 	}{arg1, arg2, arg3, arg4Copy, arg5})
+	stub := fake.PatchUsingStrategyStub
+	fakeReturns := fake.patchUsingStrategyReturns
 	fake.recordInvocation("PatchUsingStrategy", []interface{}{arg1, arg2, arg3, arg4Copy, arg5})
 	fake.patchUsingStrategyMutex.Unlock()
-	if fake.PatchUsingStrategyStub != nil {
-		return fake.PatchUsingStrategyStub(arg1, arg2, arg3, arg4, arg5)
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4, arg5)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2, ret.result3
 	}
-	fakeReturns := fake.patchUsingStrategyReturns
 	return fakeReturns.result1, fakeReturns.result2, fakeReturns.result3
 }
 

--- a/internal/kubernetes/kubernetesfakes/fake_clientset.go
+++ b/internal/kubernetes/kubernetesfakes/fake_clientset.go
@@ -2,12 +2,30 @@
 package kubernetesfakes
 
 import (
+	"context"
 	"sync"
 
 	"github.com/homedepot/go-clouddriver/internal/kubernetes"
+	v1 "k8s.io/api/core/v1"
 )
 
 type FakeClientset struct {
+	EventsStub        func(context.Context, string, string, string) ([]v1.Event, error)
+	eventsMutex       sync.RWMutex
+	eventsArgsForCall []struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 string
+	}
+	eventsReturns struct {
+		result1 []v1.Event
+		result2 error
+	}
+	eventsReturnsOnCall map[int]struct {
+		result1 []v1.Event
+		result2 error
+	}
 	PodLogsStub        func(string, string, string) (string, error)
 	podLogsMutex       sync.RWMutex
 	podLogsArgsForCall []struct {
@@ -27,6 +45,73 @@ type FakeClientset struct {
 	invocationsMutex sync.RWMutex
 }
 
+func (fake *FakeClientset) Events(arg1 context.Context, arg2 string, arg3 string, arg4 string) ([]v1.Event, error) {
+	fake.eventsMutex.Lock()
+	ret, specificReturn := fake.eventsReturnsOnCall[len(fake.eventsArgsForCall)]
+	fake.eventsArgsForCall = append(fake.eventsArgsForCall, struct {
+		arg1 context.Context
+		arg2 string
+		arg3 string
+		arg4 string
+	}{arg1, arg2, arg3, arg4})
+	stub := fake.EventsStub
+	fakeReturns := fake.eventsReturns
+	fake.recordInvocation("Events", []interface{}{arg1, arg2, arg3, arg4})
+	fake.eventsMutex.Unlock()
+	if stub != nil {
+		return stub(arg1, arg2, arg3, arg4)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClientset) EventsCallCount() int {
+	fake.eventsMutex.RLock()
+	defer fake.eventsMutex.RUnlock()
+	return len(fake.eventsArgsForCall)
+}
+
+func (fake *FakeClientset) EventsCalls(stub func(context.Context, string, string, string) ([]v1.Event, error)) {
+	fake.eventsMutex.Lock()
+	defer fake.eventsMutex.Unlock()
+	fake.EventsStub = stub
+}
+
+func (fake *FakeClientset) EventsArgsForCall(i int) (context.Context, string, string, string) {
+	fake.eventsMutex.RLock()
+	defer fake.eventsMutex.RUnlock()
+	argsForCall := fake.eventsArgsForCall[i]
+	return argsForCall.arg1, argsForCall.arg2, argsForCall.arg3, argsForCall.arg4
+}
+
+func (fake *FakeClientset) EventsReturns(result1 []v1.Event, result2 error) {
+	fake.eventsMutex.Lock()
+	defer fake.eventsMutex.Unlock()
+	fake.EventsStub = nil
+	fake.eventsReturns = struct {
+		result1 []v1.Event
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClientset) EventsReturnsOnCall(i int, result1 []v1.Event, result2 error) {
+	fake.eventsMutex.Lock()
+	defer fake.eventsMutex.Unlock()
+	fake.EventsStub = nil
+	if fake.eventsReturnsOnCall == nil {
+		fake.eventsReturnsOnCall = make(map[int]struct {
+			result1 []v1.Event
+			result2 error
+		})
+	}
+	fake.eventsReturnsOnCall[i] = struct {
+		result1 []v1.Event
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClientset) PodLogs(arg1 string, arg2 string, arg3 string) (string, error) {
 	fake.podLogsMutex.Lock()
 	ret, specificReturn := fake.podLogsReturnsOnCall[len(fake.podLogsArgsForCall)]
@@ -35,15 +120,16 @@ func (fake *FakeClientset) PodLogs(arg1 string, arg2 string, arg3 string) (strin
 		arg2 string
 		arg3 string
 	}{arg1, arg2, arg3})
+	stub := fake.PodLogsStub
+	fakeReturns := fake.podLogsReturns
 	fake.recordInvocation("PodLogs", []interface{}{arg1, arg2, arg3})
 	fake.podLogsMutex.Unlock()
-	if fake.PodLogsStub != nil {
-		return fake.PodLogsStub(arg1, arg2, arg3)
+	if stub != nil {
+		return stub(arg1, arg2, arg3)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.podLogsReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -95,6 +181,8 @@ func (fake *FakeClientset) PodLogsReturnsOnCall(i int, result1 string, result2 e
 func (fake *FakeClientset) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
+	fake.eventsMutex.RLock()
+	defer fake.eventsMutex.RUnlock()
 	fake.podLogsMutex.RLock()
 	defer fake.podLogsMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}

--- a/internal/kubernetes/kubernetesfakes/fake_controller.go
+++ b/internal/kubernetes/kubernetesfakes/fake_controller.go
@@ -45,15 +45,16 @@ func (fake *FakeController) NewClient(arg1 *rest.Config) (kubernetes.Client, err
 	fake.newClientArgsForCall = append(fake.newClientArgsForCall, struct {
 		arg1 *rest.Config
 	}{arg1})
+	stub := fake.NewClientStub
+	fakeReturns := fake.newClientReturns
 	fake.recordInvocation("NewClient", []interface{}{arg1})
 	fake.newClientMutex.Unlock()
-	if fake.NewClientStub != nil {
-		return fake.NewClientStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newClientReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 
@@ -108,15 +109,16 @@ func (fake *FakeController) NewClientset(arg1 *rest.Config) (kubernetes.Clientse
 	fake.newClientsetArgsForCall = append(fake.newClientsetArgsForCall, struct {
 		arg1 *rest.Config
 	}{arg1})
+	stub := fake.NewClientsetStub
+	fakeReturns := fake.newClientsetReturns
 	fake.recordInvocation("NewClientset", []interface{}{arg1})
 	fake.newClientsetMutex.Unlock()
-	if fake.NewClientsetStub != nil {
-		return fake.NewClientsetStub(arg1)
+	if stub != nil {
+		return stub(arg1)
 	}
 	if specificReturn {
 		return ret.result1, ret.result2
 	}
-	fakeReturns := fake.newClientsetReturns
 	return fakeReturns.result1, fakeReturns.result2
 }
 


### PR DESCRIPTION
- Adds support for getting manifest events if the query param `includeEvents` is not set to false

Example events for a pod from the clusters page:
![image](https://user-images.githubusercontent.com/7597848/142950630-3c458819-fe73-4cfe-834f-8568e3aec83f.png)

Notes:
- We run requests to grab the manifest and events concurrently
- We use a `select` when grabbing the manifest to handle errors or a successful response
- Failure to grab events is silent and still returns the manifest
- I used the Kubernetes Clientset's `CoreV1().Events(namespace)` to grab any events regardless of kind. In testing this works for Deployments, ReplicaSets, and Pods, even though not all of these are part of the core API group
- See [this StackOverflow post](https://stackoverflow.com/questions/53638778/kubernetes-go-client-list-events) for source code used to grab events