### PR TITLE
Support large CA certificate chains

### DIFF
--- a/internal/kubernetes/provider.go
+++ b/internal/kubernetes/provider.go
@@ -23,7 +23,7 @@ var (
 type Provider struct {
 	Name          string              `json:"name" gorm:"primary_key"`
 	Host          string              `json:"host"`
-	CAData        string              `json:"caData" gorm:"size:8192"`
+	CAData        string              `json:"caData" gorm:"type:text"`
 	BearerToken   string              `json:"bearerToken,omitempty" gorm:"size:2048"`
 	TokenProvider string              `json:"tokenProvider,omitempty" gorm:"size:32;not null;default:'google'"`
 	Namespace     *string             `json:"namespace,omitempty" gorm:"size:253"`

--- a/internal/sql/client_test.go
+++ b/internal/sql/client_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Sql", func() {
 		mock.ExpectExec("(?i)^CREATE TABLE `kubernetes_providers` " +
 			"\\(`name`\\ varchar\\(256\\)," +
 			"`host` varchar\\(256\\)," +
-			"`ca_data` varchar\\(8192\\)," +
+			"`ca_data` text," +
 			"`bearer_token` varchar\\(2048\\)," +
 			"`token_provider` varchar\\(32\\) NOT NULL DEFAULT 'google'," +
 			"`namespace` varchar\\(253\\)," +


### PR DESCRIPTION
To support a large certificate chains, changed the data type of the `kubernetes_providers.ca_data` column from `VARCHAR(8196)` to `TEXT`.

For MySQL, the maximum length of a `VARCHAR` column is `65,535`, but effectively is only `21,844` as described [here](https://newbedev.com/equivalent-of-varchar-max-in-mysql).  Changing to a `TEXT` data type allows for a true limit of `65,535` bytes.