### PR TITLE
Add support for enabled/disabled manifests in clusters page

### DIFF
--- a/internal/api/core/payload_test.go
+++ b/internal/api/core/payload_test.go
@@ -1137,6 +1137,279 @@ const payloadServerGroupManagersSorted = `[
             }
           ]`
 
+const payloadListServerGroupsDisabled = `[
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 2,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-ds1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 2,
+                "unknown": 0,
+                "up": 1
+              },
+              "instances": [
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod1"
+                }
+              ],
+              "isDisabled": false,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "daemonSet",
+              "labels": null,
+              "loadBalancers": null,
+              "manifest": null,
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "daemonSet test-ds1",
+              "namespace": "test-namespace1",
+              "providerType": "",
+              "region": "test-namespace1",
+              "securityGroups": null,
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            },
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod1"
+                }
+              ],
+              "isDisabled": true,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "replicaSet",
+              "labels": null,
+              "loadBalancers": [
+							  "service test-svc1",
+							  "service my-managed-service1",
+							  "service my-managed-service2"
+							],
+              "manifest": null,
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "replicaSet test-rs1",
+              "namespace": "test-namespace1",
+              "providerType": "",
+              "region": "test-namespace1",
+              "securityGroups": null,
+              "serverGroupManagers": [
+                {
+                  "account": "account1",
+                  "location": "test-namespace1",
+                  "name": "test-deployment1"
+                }
+              ],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            },
+            {
+              "account": "account1",
+              "accountName": "",
+              "buildInfo": {
+                "images": [
+                  "test-image1",
+                  "test-image2"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "cluster": "deployment test-deployment1",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-sts1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [
+                {
+                  "availabilityZone": "test-namespace1",
+                  "health": [
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/pod"
+                    },
+                    {
+                      "state": "Down",
+                      "type": "kubernetes/container"
+                    }
+                  ],
+                  "healthState": "Down",
+                  "id": "cec15437-4e6a-11ea-9788-4201ac100006",
+                  "key": {
+                    "account": "",
+                    "group": "",
+                    "kubernetesKind": "",
+                    "name": "",
+                    "namespace": "",
+                    "provider": ""
+                  },
+                  "moniker": {
+                    "app": "",
+                    "cluster": ""
+                  },
+                  "name": "pod test-pod1"
+                }
+              ],
+              "isDisabled": false,
+              "key": {
+                "account": "",
+                "group": "",
+                "kubernetesKind": "",
+                "name": "",
+                "namespace": "",
+                "provider": ""
+              },
+              "kind": "statefulSet",
+              "labels": null,
+              "loadBalancers": [
+							  "service test-svc2"
+							],
+              "manifest": null,
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "statefulSet test-sts1",
+              "namespace": "test-namespace1",
+              "providerType": "",
+              "region": "test-namespace1",
+              "securityGroups": null,
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "",
+              "zone": "",
+              "zones": null,
+              "insightActions": null
+            }
+          ]`
+
 const payloadListServerGroups = `[
             {
               "account": "account1",
@@ -2409,6 +2682,646 @@ const payloadListClusters2 = `{
             ]
           }`
 
+const payloadGetServerGroupManagedLoadBalancersMalformed = `{
+              "account": "test-account",
+              "accountName": "test-account",
+              "buildInfo": {
+                "images": [
+                  "test-image3",
+                  "test-image4"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [],
+              "isDisabled": false,
+              "key": {
+                "account": "test-account",
+                "group": "replicaSet",
+                "kubernetesKind": "replicaSet",
+                "name": "test-rs1",
+                "namespace": "test-namespace1",
+                "provider": "kubernetes"
+              },
+              "kind": "replicaSet",
+              "labels": null,
+              "loadBalancers": [],
+              "manifest": {
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "metadata": {
+                  "annotations": {
+                    "artifact.spinnaker.io/location": "test-namespace1",
+                    "artifact.spinnaker.io/name": "test-deployment1",
+                    "artifact.spinnaker.io/type": "kubernetes/deployment",
+                    "moniker.spinnaker.io/application": "test-application",
+                    "moniker.spinnaker.io/cluster": "deployment test-deployment1",
+                    "moniker.spinnaker.io/sequence": "19",
+                    "traffic.spinnaker.io/load-balancers": "[malformed]"
+                  },
+                  "creationTimestamp": "2020-02-13T14:12:03Z",
+                  "name": "test-rs1",
+                  "namespace": "test-namespace1",
+                  "ownerReferences": [
+                    {
+                      "kind": "Deployment",
+                      "name": "test-deployment1",
+                      "uid": "test-uid3"
+                    }
+                  ],
+                  "uid": "test-uid1"
+                },
+                "spec": {
+                  "replicas": 1,
+                  "template": {
+                    "metadata": {
+                      "labels": {
+                        "test": "label"
+                      }
+                    },
+                    "spec": {
+                      "containers": [
+                        {
+                          "image": "test-image3"
+                        },
+                        {
+                          "image": "test-image4"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "status": {
+                  "readyReplicas": 0,
+                  "replicas": 1
+                }
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "replicaSet test-rs1",
+              "namespace": "test-namespace1",
+              "providerType": "kubernetes",
+              "region": "test-namespace1",
+              "securityGroups": [],
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "test-uid1",
+              "zone": "test-namespace1",
+              "zones": [],
+              "insightActions": []
+            }`
+
+const payloadGetServerGroupManagedLoadBalancersNoKind = `{
+              "account": "test-account",
+              "accountName": "test-account",
+              "buildInfo": {
+                "images": [
+                  "test-image3",
+                  "test-image4"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [],
+              "isDisabled": false,
+              "key": {
+                "account": "test-account",
+                "group": "replicaSet",
+                "kubernetesKind": "replicaSet",
+                "name": "test-rs1",
+                "namespace": "test-namespace1",
+                "provider": "kubernetes"
+              },
+              "kind": "replicaSet",
+              "labels": null,
+              "loadBalancers": [],
+              "manifest": {
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "metadata": {
+                  "annotations": {
+                    "artifact.spinnaker.io/location": "test-namespace1",
+                    "artifact.spinnaker.io/name": "test-deployment1",
+                    "artifact.spinnaker.io/type": "kubernetes/deployment",
+                    "moniker.spinnaker.io/application": "test-application",
+                    "moniker.spinnaker.io/cluster": "deployment test-deployment1",
+                    "moniker.spinnaker.io/sequence": "19",
+                    "traffic.spinnaker.io/load-balancers": "[\"my-managed-service-no-kind\"]"
+                  },
+                  "creationTimestamp": "2020-02-13T14:12:03Z",
+                  "name": "test-rs1",
+                  "namespace": "test-namespace1",
+                  "ownerReferences": [
+                    {
+                      "kind": "Deployment",
+                      "name": "test-deployment1",
+                      "uid": "test-uid3"
+                    }
+                  ],
+                  "uid": "test-uid1"
+                },
+                "spec": {
+                  "replicas": 1,
+                  "template": {
+                    "metadata": {
+                      "labels": {
+                        "test": "label"
+                      }
+                    },
+                    "spec": {
+                      "containers": [
+                        {
+                          "image": "test-image3"
+                        },
+                        {
+                          "image": "test-image4"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "status": {
+                  "readyReplicas": 0,
+                  "replicas": 1
+                }
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "replicaSet test-rs1",
+              "namespace": "test-namespace1",
+              "providerType": "kubernetes",
+              "region": "test-namespace1",
+              "securityGroups": [],
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "test-uid1",
+              "zone": "test-namespace1",
+              "zones": [],
+              "insightActions": []
+            }`
+
+const payloadGetServerGroupManagedLoadBalancersWrongKind = `{
+              "account": "test-account",
+              "accountName": "test-account",
+              "buildInfo": {
+                "images": [
+                  "test-image3",
+                  "test-image4"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [],
+              "isDisabled": false,
+              "key": {
+                "account": "test-account",
+                "group": "replicaSet",
+                "kubernetesKind": "replicaSet",
+                "name": "test-rs1",
+                "namespace": "test-namespace1",
+                "provider": "kubernetes"
+              },
+              "kind": "replicaSet",
+              "labels": null,
+              "loadBalancers": [],
+              "manifest": {
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "metadata": {
+                  "annotations": {
+                    "artifact.spinnaker.io/location": "test-namespace1",
+                    "artifact.spinnaker.io/name": "test-deployment1",
+                    "artifact.spinnaker.io/type": "kubernetes/deployment",
+                    "moniker.spinnaker.io/application": "test-application",
+                    "moniker.spinnaker.io/cluster": "deployment test-deployment1",
+                    "moniker.spinnaker.io/sequence": "19",
+                    "traffic.spinnaker.io/load-balancers": "[\"ingress my-managed-ingress\"]"
+                  },
+                  "creationTimestamp": "2020-02-13T14:12:03Z",
+                  "name": "test-rs1",
+                  "namespace": "test-namespace1",
+                  "ownerReferences": [
+                    {
+                      "kind": "Deployment",
+                      "name": "test-deployment1",
+                      "uid": "test-uid3"
+                    }
+                  ],
+                  "uid": "test-uid1"
+                },
+                "spec": {
+                  "replicas": 1,
+                  "template": {
+                    "metadata": {
+                      "labels": {
+                        "test": "label"
+                      }
+                    },
+                    "spec": {
+                      "containers": [
+                        {
+                          "image": "test-image3"
+                        },
+                        {
+                          "image": "test-image4"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "status": {
+                  "readyReplicas": 0,
+                  "replicas": 1
+                }
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "replicaSet test-rs1",
+              "namespace": "test-namespace1",
+              "providerType": "kubernetes",
+              "region": "test-namespace1",
+              "securityGroups": [],
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "test-uid1",
+              "zone": "test-namespace1",
+              "zones": [],
+              "insightActions": []
+            }`
+
+const payloadGetServerGroupManagedLoadBalancersErrorGettingService = `{
+              "account": "test-account",
+              "accountName": "test-account",
+              "buildInfo": {
+                "images": [
+                  "test-image3",
+                  "test-image4"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [],
+              "isDisabled": false,
+              "key": {
+                "account": "test-account",
+                "group": "replicaSet",
+                "kubernetesKind": "replicaSet",
+                "name": "test-rs1",
+                "namespace": "test-namespace1",
+                "provider": "kubernetes"
+              },
+              "kind": "replicaSet",
+              "labels": null,
+              "loadBalancers": [],
+              "manifest": {
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "metadata": {
+                  "annotations": {
+                    "artifact.spinnaker.io/location": "test-namespace1",
+                    "artifact.spinnaker.io/name": "test-deployment1",
+                    "artifact.spinnaker.io/type": "kubernetes/deployment",
+                    "moniker.spinnaker.io/application": "test-application",
+                    "moniker.spinnaker.io/cluster": "deployment test-deployment1",
+                    "moniker.spinnaker.io/sequence": "19",
+                    "traffic.spinnaker.io/load-balancers": "[\"service my-managed-service\"]"
+                  },
+                  "creationTimestamp": "2020-02-13T14:12:03Z",
+                  "name": "test-rs1",
+                  "namespace": "test-namespace1",
+                  "ownerReferences": [
+                    {
+                      "kind": "Deployment",
+                      "name": "test-deployment1",
+                      "uid": "test-uid3"
+                    }
+                  ],
+                  "uid": "test-uid1"
+                },
+                "spec": {
+                  "replicas": 1,
+                  "template": {
+                    "metadata": {
+                      "labels": {
+                        "test": "label"
+                      }
+                    },
+                    "spec": {
+                      "containers": [
+                        {
+                          "image": "test-image3"
+                        },
+                        {
+                          "image": "test-image4"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "status": {
+                  "readyReplicas": 0,
+                  "replicas": 1
+                }
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "replicaSet test-rs1",
+              "namespace": "test-namespace1",
+              "providerType": "kubernetes",
+              "region": "test-namespace1",
+              "securityGroups": [],
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "test-uid1",
+              "zone": "test-namespace1",
+              "zones": [],
+              "insightActions": []
+            }`
+
+const payloadGetServerGroupManagedLoadBalancersDisabled = `{
+              "account": "test-account",
+              "accountName": "test-account",
+              "buildInfo": {
+                "images": [
+                  "test-image3",
+                  "test-image4"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "disabled": true,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [],
+              "isDisabled": false,
+              "key": {
+                "account": "test-account",
+                "group": "replicaSet",
+                "kubernetesKind": "replicaSet",
+                "name": "test-rs1",
+                "namespace": "test-namespace1",
+                "provider": "kubernetes"
+              },
+              "kind": "replicaSet",
+              "labels": null,
+              "loadBalancers": [
+                "service my-managed-service"
+							],
+              "manifest": {
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "metadata": {
+                  "annotations": {
+                    "artifact.spinnaker.io/location": "test-namespace1",
+                    "artifact.spinnaker.io/name": "test-deployment1",
+                    "artifact.spinnaker.io/type": "kubernetes/deployment",
+                    "moniker.spinnaker.io/application": "test-application",
+                    "moniker.spinnaker.io/cluster": "deployment test-deployment1",
+                    "moniker.spinnaker.io/sequence": "19",
+                    "traffic.spinnaker.io/load-balancers": "[\"service my-managed-service\"]"
+                  },
+                  "creationTimestamp": "2020-02-13T14:12:03Z",
+                  "name": "test-rs1",
+                  "namespace": "test-namespace1",
+                  "ownerReferences": [
+                    {
+                      "kind": "Deployment",
+                      "name": "test-deployment1",
+                      "uid": "test-uid3"
+                    }
+                  ],
+                  "uid": "test-uid1"
+                },
+                "spec": {
+                  "replicas": 1,
+                  "template": {
+                    "metadata": {
+                      "labels": {
+                        "test": "label"
+                      }
+                    },
+                    "spec": {
+                      "containers": [
+                        {
+                          "image": "test-image3"
+                        },
+                        {
+                          "image": "test-image4"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "status": {
+                  "readyReplicas": 0,
+                  "replicas": 1
+                }
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "replicaSet test-rs1",
+              "namespace": "test-namespace1",
+              "providerType": "kubernetes",
+              "region": "test-namespace1",
+              "securityGroups": [],
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "test-uid1",
+              "zone": "test-namespace1",
+              "zones": [],
+              "insightActions": []
+            }`
+
+const payloadGetServerGroupManagedLoadBalancers = `{
+              "account": "test-account",
+              "accountName": "test-account",
+              "buildInfo": {
+                "images": [
+                  "test-image3",
+                  "test-image4"
+                ]
+              },
+              "capacity": {
+                "desired": 1,
+                "pinned": false
+              },
+              "cloudProvider": "kubernetes",
+              "createdTime": 1581603123000,
+              "disabled": false,
+              "displayName": "test-rs1",
+              "instanceCounts": {
+                "down": 0,
+                "outOfService": 0,
+                "starting": 0,
+                "total": 1,
+                "unknown": 0,
+                "up": 0
+              },
+              "instances": [],
+              "isDisabled": false,
+              "key": {
+                "account": "test-account",
+                "group": "replicaSet",
+                "kubernetesKind": "replicaSet",
+                "name": "test-rs1",
+                "namespace": "test-namespace1",
+                "provider": "kubernetes"
+              },
+              "kind": "replicaSet",
+              "labels": null,
+              "loadBalancers": [
+                "service my-managed-service"
+							],
+              "manifest": {
+                "apiVersion": "apps/v1",
+                "kind": "ReplicaSet",
+                "metadata": {
+                  "annotations": {
+                    "artifact.spinnaker.io/location": "test-namespace1",
+                    "artifact.spinnaker.io/name": "test-deployment1",
+                    "artifact.spinnaker.io/type": "kubernetes/deployment",
+                    "moniker.spinnaker.io/application": "test-application",
+                    "moniker.spinnaker.io/cluster": "deployment test-deployment1",
+                    "moniker.spinnaker.io/sequence": "19",
+                    "traffic.spinnaker.io/load-balancers": "[\"service my-managed-service\"]"
+                  },
+                  "creationTimestamp": "2020-02-13T14:12:03Z",
+                  "name": "test-rs1",
+                  "namespace": "test-namespace1",
+                  "ownerReferences": [
+                    {
+                      "kind": "Deployment",
+                      "name": "test-deployment1",
+                      "uid": "test-uid3"
+                    }
+                  ],
+                  "uid": "test-uid1"
+                },
+                "spec": {
+                  "replicas": 1,
+                  "template": {
+                    "metadata": {
+                      "labels": {
+                        "test": "label"
+                      }
+                    },
+                    "spec": {
+                      "containers": [
+                        {
+                          "image": "test-image3"
+                        },
+                        {
+                          "image": "test-image4"
+                        }
+                      ]
+                    }
+                  }
+                },
+                "status": {
+                  "readyReplicas": 0,
+                  "replicas": 1
+                }
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment1",
+                "sequence": 19
+              },
+              "name": "replicaSet test-rs1",
+              "namespace": "test-namespace1",
+              "providerType": "kubernetes",
+              "region": "test-namespace1",
+              "securityGroups": [],
+              "serverGroupManagers": [],
+              "type": "kubernetes",
+              "uid": "test-uid1",
+              "zone": "test-namespace1",
+              "zones": [],
+              "insightActions": []
+            }`
+
 const payloadGetServerGroup = `{
             "account": "test-account",
             "accountName": "test-account",
@@ -2590,9 +3503,14 @@ const payloadGetServerGroup = `{
                 "name": "test-rs1",
                 "namespace": "test-namespace1"
               },
-              "spec": {
+							"spec": {
                 "replicas": 1,
                 "template": {
+                  "metadata": {
+                    "labels": {
+                      "selectorKey1": "selectorValue1"
+                    }
+                  },
                   "spec": {
                     "containers": [
                       {


### PR DESCRIPTION
This PR adds the necessary functions to show the user in the clusters page if a server group is enabled or disabled.

Here is an example server group (Replica Set) that is enabled (receiving traffic from its managed load balancers in the `traffic.spinnaker.io/load-balancers` annotation).
![image](https://user-images.githubusercontent.com/7597848/143917707-1c870864-a6dc-44bf-b32a-83399de6ddcd.png)

We can see upon clicking the server group that under *Replica Set Actions* we have the option to "Disable" the Replica Set.
![image](https://user-images.githubusercontent.com/7597848/143917978-bdf3c69b-3c37-4f86-bbba-2a5e6f9ff76b.png)

Clicking "Disable" patches the Replica Set and its pods' templates to not be fronted by its managed load balancer. It is then shown as disabled in the right pane.
![image](https://user-images.githubusercontent.com/7597848/143918203-06b89ea2-4f93-40d1-9c4e-8f88db87d84a.png)

The clusters page now shows this server group to be "Disabled" and is greyed-out, however its detached load balancer is still associated with the server group.
![image](https://user-images.githubusercontent.com/7597848/143918380-0f1b797d-47bc-4d19-b184-d12218db9fa4.png)

Under *Replica Set Actions* for this server group we now have the option to "Enable" it.
![image](https://user-images.githubusercontent.com/7597848/143918879-5445f3d1-21b4-42a8-a9f6-15dceb13a89c.png)

Notes:
- I did not do anything special using go routines to retrieve all load balancers along with pods to associate with the server group. These Spinnaker managed load balancers seem like an edge case and will usually only result in one extra call to the cluster even when enabled.
