### PR TITLE
Add ability to list clusters by name

### DIFF
--- a/internal/api/core/applications_test.go
+++ b/internal/api/core/applications_test.go
@@ -1737,6 +1737,315 @@ var _ = Describe("Application", func() {
 		})
 	})
 
+	Describe("#ListClustersByName", func() {
+		BeforeEach(func() {
+			setup()
+			uri = svr.URL + "/applications/test-application/clusters/test-account/deployment test-deployment/kubernetes"
+			createRequest(http.MethodGet)
+			fakeKubeClient.ListResourceWithContextReturns(&unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]interface{}{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-rs1",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":       "test-deployment1",
+									"artifact.spinnaker.io/type":       "kubernetes/deployment",
+									"artifact.spinnaker.io/location":   "test-namespace1",
+									"moniker.spinnaker.io/application": "test-application",
+									"moniker.spinnaker.io/cluster":     "deployment test-deployment",
+									"moniker.spinnaker.io/sequence":    "19",
+								},
+								"labels": map[string]interface{}{
+									"labelKey1": "labelValue1",
+									"labelKey2": "labelValue2",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-deployment",
+										"kind": "Deployment",
+										"uid":  "test-uid3",
+									},
+								},
+								"uid": "test-uid1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"test": "label",
+										},
+									},
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-rs2",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":       "test-deployment1",
+									"artifact.spinnaker.io/type":       "kubernetes/deployment",
+									"artifact.spinnaker.io/location":   "test-namespace1",
+									"moniker.spinnaker.io/application": "wrong-application",
+									"moniker.spinnaker.io/cluster":     "deployment test-deployment",
+									"moniker.spinnaker.io/sequence":    "19",
+								},
+								"labels": map[string]interface{}{
+									"labelKey1": "labelValue1",
+									"labelKey2": "labelValue2",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-deployment",
+										"kind": "Deployment",
+										"uid":  "test-uid3",
+									},
+								},
+								"uid": "test-uid1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"test": "label",
+										},
+									},
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-rs3",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":       "test-deployment1",
+									"artifact.spinnaker.io/type":       "kubernetes/deployment",
+									"artifact.spinnaker.io/location":   "test-namespace1",
+									"moniker.spinnaker.io/application": "test-application",
+									"moniker.spinnaker.io/cluster":     "deployment wrong-cluster",
+									"moniker.spinnaker.io/sequence":    "19",
+								},
+								"labels": map[string]interface{}{
+									"labelKey1": "labelValue1",
+									"labelKey2": "labelValue2",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-deployment1",
+										"kind": "Deployment",
+										"uid":  "test-uid3",
+									},
+								},
+								"uid": "test-uid1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"test": "label",
+										},
+									},
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
+							},
+						},
+					},
+					{
+						Object: map[string]interface{}{
+							"kind":       "ReplicaSet",
+							"apiVersion": "apps/v1",
+							"metadata": map[string]interface{}{
+								"name":              "test-rs4",
+								"namespace":         "test-namespace1",
+								"creationTimestamp": "2020-02-13T14:12:03Z",
+								"annotations": map[string]interface{}{
+									"artifact.spinnaker.io/name":       "test-deployment1",
+									"artifact.spinnaker.io/type":       "kubernetes/deployment",
+									"artifact.spinnaker.io/location":   "test-namespace1",
+									"moniker.spinnaker.io/application": "test-application",
+									"moniker.spinnaker.io/cluster":     "deployment test-deployment",
+									"moniker.spinnaker.io/sequence":    "19",
+								},
+								"labels": map[string]interface{}{
+									"labelKey1": "labelValue1",
+									"labelKey2": "labelValue2",
+								},
+								"ownerReferences": []interface{}{
+									map[string]interface{}{
+										"name": "test-deployment",
+										"kind": "Deployment",
+										"uid":  "test-uid3",
+									},
+								},
+								"uid": "test-uid1",
+							},
+							"spec": map[string]interface{}{
+								"replicas": 1,
+								"template": map[string]interface{}{
+									"metadata": map[string]interface{}{
+										"labels": map[string]interface{}{
+											"test": "label",
+										},
+									},
+									"spec": map[string]interface{}{
+										"containers": []map[string]interface{}{
+											{
+												"image": "test-image1",
+											},
+											{
+												"image": "test-image2",
+											},
+										},
+									},
+								},
+							},
+							"status": map[string]interface{}{
+								"replicas":      1,
+								"readyReplicas": 0,
+							},
+						},
+					},
+				},
+			}, nil)
+		})
+
+		AfterEach(func() {
+			teardown()
+		})
+
+		JustBeforeEach(func() {
+			doRequest()
+		})
+
+		When("the cluster name is not formatted correctly", func() {
+			BeforeEach(func() {
+				setup()
+				uri = svr.URL + "/applications/test-application/clusters/test-account/bad-cluster/kubernetes"
+				createRequest(http.MethodGet)
+			})
+
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
+				Expect(ce.Message).To(Equal("clusterName parameter must be in the format of 'kind name', got: bad-cluster"))
+				Expect(ce.Status).To(Equal(http.StatusBadRequest))
+			})
+		})
+
+		When("getting the provider returns an error", func() {
+			BeforeEach(func() {
+				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, errors.New("error getting provider"))
+			})
+
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusBadRequest))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(HavePrefix("Bad Request"))
+				Expect(ce.Message).To(Equal("internal: error getting kubernetes provider test-account: error getting provider"))
+				Expect(ce.Status).To(Equal(http.StatusBadRequest))
+			})
+		})
+
+		When("listing resources returns an error", func() {
+			BeforeEach(func() {
+				fakeKubeClient.ListResourceWithContextReturns(nil, errors.New("error listing resources"))
+			})
+
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
+				Expect(ce.Message).To(Equal("error listing resources"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
+			})
+		})
+
+		When("the provider is namespace-scoped", func() {
+			BeforeEach(func() {
+				namespace := "test-namespace1"
+				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{
+					Name:      "test-account",
+					Host:      "http://localhost",
+					CAData:    "",
+					Namespace: &namespace,
+				}, nil)
+			})
+
+			It("limits the list request to the provider's namespace", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				_, _, lo := fakeKubeClient.ListResourceWithContextArgsForCall(0)
+				Expect(lo.FieldSelector).To(Equal("metadata.namespace=test-namespace1"))
+			})
+		})
+
+		It("succeeds", func() {
+			Expect(res.StatusCode).To(Equal(http.StatusOK))
+			validateResponse(payloadListClustersByName)
+			_, kind, _ := fakeKubeClient.ListResourceWithContextArgsForCall(0)
+			Expect(kind).To(Equal("replicaSet"))
+		})
+	})
+
 	Describe("#ListServerGroups", func() {
 		BeforeEach(func() {
 			setup()

--- a/internal/api/core/payload_test.go
+++ b/internal/api/core/payload_test.go
@@ -2682,6 +2682,76 @@ const payloadListClusters2 = `{
             ]
           }`
 
+const payloadListClustersByName = `{
+          "accountName": "test-account",
+          "application": "test-application",
+          "loadBalancers": [],
+          "moniker": {
+            "app": "test-application",
+            "cluster": "deployment test-deployment"
+          },
+          "name": "deployment test-deployment",
+          "serverGroups": [
+            {
+              "account": "test-account",
+              "apiVersion": "apps/v1",
+              "cloudProvider": "kubernetes",
+              "displayName": "test-rs1",
+              "kind": "ReplicaSet",
+              "labels": {
+                "labelKey1": "labelValue1",
+                "labelKey2": "labelValue2"
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment",
+                "sequence": 19
+              },
+              "name": "replicaSet test-rs1",
+              "namespace": "test-namespace1",
+              "region": "test-namespace1",
+              "serverGroupManagers": [
+                {
+                  "account": "test-account",
+                  "location": "test-namespace1",
+                  "name": "test-deployment"
+                }
+              ],
+              "type": "kubernetes",
+              "zones": []
+            },
+            {
+              "account": "test-account",
+              "apiVersion": "apps/v1",
+              "cloudProvider": "kubernetes",
+              "displayName": "test-rs4",
+              "kind": "ReplicaSet",
+              "labels": {
+                "labelKey1": "labelValue1",
+                "labelKey2": "labelValue2"
+              },
+              "moniker": {
+                "app": "test-application",
+                "cluster": "deployment test-deployment",
+                "sequence": 19
+              },
+              "name": "replicaSet test-rs4",
+              "namespace": "test-namespace1",
+              "region": "test-namespace1",
+              "serverGroupManagers": [
+                {
+                  "account": "test-account",
+                  "location": "test-namespace1",
+                  "name": "test-deployment"
+                }
+              ],
+              "type": "kubernetes",
+              "zones": []
+            }
+          ],
+          "type": "kubernetes"
+        }`
+
 const payloadGetServerGroupManagedLoadBalancersMalformed = `{
               "account": "test-account",
               "accountName": "test-account",

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -93,6 +93,9 @@ func (s *Server) Setup() {
 		// @PostAuthorize("@authorizationSupport.filterForAccounts(returnObject)")
 		api.GET("/applications/:application/clusters", mc.AuthApplication("READ"), c.ListClusters)
 
+		// https://github.com/spinnaker/clouddriver/blob/ed236a6fe946007a4136f6206b311525ea460e65/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/ClusterController.groovy#L140
+		api.GET("/applications/:application/clusters/:account/:clusterName/kubernetes", mc.AuthApplication("READ"), c.ListClustersByName)
+
 		// https://github.com/spinnaker/clouddriver/blob/master/clouddriver-web/src/main/groovy/com/netflix/spinnaker/clouddriver/controllers/JobController.groovy#L35
 		// @PreAuthorize("hasPermission(#application, 'APPLICATION', 'READ') and hasPermission(#account, 'ACCOUNT', 'READ')")
 		// @ApiOperation(value = "Collect a JobStatus", notes = "Collects the output of the job.")


### PR DESCRIPTION
- implements `/applications/{application}/clusters/{account}/{clusterName}/kubernetes` endpoint

This is used when checking cluster size in a *Check Preconditions* stage. Here is an example of an intentionally failed stage:
![image](https://user-images.githubusercontent.com/7597848/144882940-55abd687-c2bc-4f68-89d1-15486bda6a42.png)

Notes:
- This just lists a given kind and filters on application and cluster name. The only logic around changing the kind is if the requested cluster is kind `deployment` in which case we actually list `replicaSets`.
- I decided to ignore much of the response (instances, instance counts, etc) as they did not seem important for the use-case.