### PR TITLE
Error on delete manifest requests where there are no kinds

### DIFF
--- a/internal/api/core/kubernetes/delete.go
+++ b/internal/api/core/kubernetes/delete.go
@@ -108,23 +108,8 @@ func (cc *Controller) Delete(c *gin.Context, dm DeleteManifestRequest) {
 			return
 		}
 
-		// Spinnaker OSS does not fail when no kinds are selected,
-		// so create a 'no op' resource and return.
 		if len(dm.Kinds) == 0 {
-			kr := kubernetes.Resource{
-				AccountName: dm.Account,
-				ID:          uuid.New().String(),
-				TaskID:      taskID,
-				TaskType:    clouddriver.TaskTypeNoOp,
-				Timestamp:   internal.CurrentTimeUTC(),
-			}
-
-			err = cc.SQLClient.CreateKubernetesResource(kr)
-			if err != nil {
-				clouddriver.Error(c, http.StatusInternalServerError, err)
-				return
-			}
-
+			clouddriver.Error(c, http.StatusBadRequest, fmt.Errorf("requested to delete manifests by label, but no kinds were selected"))
 			return
 		}
 

--- a/internal/api/core/kubernetes/delete_test.go
+++ b/internal/api/core/kubernetes/delete_test.go
@@ -194,6 +194,19 @@ var _ = Describe("Delete", func() {
 			})
 		})
 
+		When("there are no kinds selected", func() {
+			BeforeEach(func() {
+				deleteManifestRequest.Kinds = []string{}
+			})
+
+			It("gracefully succeeds w/o deleting", func() {
+				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+				Expect(fakeKubeClient.DeleteResourceByKindAndNameAndNamespaceCallCount()).To(Equal(0))
+				kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
+				Expect(kr.TaskType).To(Equal(clouddriver.TaskTypeNoOp))
+			})
+		})
+
 		When("getting the gvr returns an error", func() {
 			BeforeEach(func() {
 				fakeKubeClient.GVRForKindReturns(schema.GroupVersionResource{}, errors.New("error getting gvr"))

--- a/internal/api/core/kubernetes/delete_test.go
+++ b/internal/api/core/kubernetes/delete_test.go
@@ -199,11 +199,9 @@ var _ = Describe("Delete", func() {
 				deleteManifestRequest.Kinds = []string{}
 			})
 
-			It("gracefully succeeds w/o deleting", func() {
-				Expect(c.Writer.Status()).To(Equal(http.StatusOK))
-				Expect(fakeKubeClient.DeleteResourceByKindAndNameAndNamespaceCallCount()).To(Equal(0))
-				kr := fakeSQLClient.CreateKubernetesResourceArgsForCall(0)
-				Expect(kr.TaskType).To(Equal(clouddriver.TaskTypeNoOp))
+			It("returns an error", func() {
+				Expect(c.Writer.Status()).To(Equal(http.StatusBadRequest))
+				Expect(c.Errors.Last().Error()).To(Equal("requested to delete manifests by label, but no kinds were selected"))
 			})
 		})
 


### PR DESCRIPTION
This is the expected result in OSS Clouddriver - to return a status OK when no kinds are selects.