### PR TITLE
Use in memory cache for Kubernetes API discovery and HTTP requests

### DIFF
--- a/cmd/clouddriver/clouddriver.go
+++ b/cmd/clouddriver/clouddriver.go
@@ -84,6 +84,10 @@ func init() {
 		server.WithVerboseRequestLogging()
 	}
 
+	if os.Getenv("KUBERNETES_USE_DISK_CACHE") == "true" {
+		kubernetes.UseDiskCache()
+	}
+
 	server.Setup()
 }
 

--- a/internal/kubernetes/cached/disk/cached_discovery_test.go
+++ b/internal/kubernetes/cached/disk/cached_discovery_test.go
@@ -81,8 +81,8 @@ var _ = Describe("CachedDiscovery", func() {
 
 		When("server groups is called twice", func() {
 			BeforeEach(func() {
-				_, _ = cdc.ServerGroups()
-				_, _ = cdc.ServerGroups()
+				cdc.ServerGroups()
+				cdc.ServerGroups()
 			})
 
 			It("should be fresh", func() {
@@ -93,7 +93,7 @@ var _ = Describe("CachedDiscovery", func() {
 
 		When("resources is called", func() {
 			BeforeEach(func() {
-				_, _ = cdc.ServerResources()
+				cdc.ServerResources()
 			})
 
 			It("should be fresh", func() {
@@ -104,8 +104,8 @@ var _ = Describe("CachedDiscovery", func() {
 
 		When("resources is called twice", func() {
 			BeforeEach(func() {
-				_, _ = cdc.ServerResources()
-				_, _ = cdc.ServerResources()
+				cdc.ServerResources()
+				cdc.ServerResources()
 			})
 
 			It("should be fresh", func() {
@@ -116,14 +116,14 @@ var _ = Describe("CachedDiscovery", func() {
 
 		Context("client is recreated", func() {
 			BeforeEach(func() {
-				_, _ = cdc.ServerGroups()
-				_, _ = cdc.ServerResources()
+				cdc.ServerGroups()
+				cdc.ServerResources()
 				cdc = NewCachedDiscoveryClient(c, d, 60*time.Second)
 			})
 
 			When("server groups is called", func() {
 				BeforeEach(func() {
-					_, _ = cdc.ServerGroups()
+					cdc.ServerGroups()
 				})
 
 				It("should not be fresh", func() {
@@ -134,7 +134,7 @@ var _ = Describe("CachedDiscovery", func() {
 
 			When("resources is called", func() {
 				BeforeEach(func() {
-					_, _ = cdc.ServerResources()
+					cdc.ServerResources()
 				})
 
 				It("should not be fresh", func() {
@@ -200,7 +200,7 @@ var _ = Describe("CachedDiscovery", func() {
 			os.RemoveAll(d)
 			c = &fakeDiscoveryClient{}
 			cdc = NewCachedDiscoveryClient(c, d, 1*time.Nanosecond)
-			_, _ = cdc.ServerGroups()
+			cdc.ServerGroups()
 		})
 
 		JustBeforeEach(func() {

--- a/internal/kubernetes/cached/memory/memcache.go
+++ b/internal/kubernetes/cached/memory/memcache.go
@@ -57,7 +57,7 @@ type memCacheClient struct {
 	ourServerGroups *metav1.APIGroupList
 	ourTTLs         map[string]time.Time
 	invalidated     bool
-	// fresh is true if the cache is not populated
+	// fresh is true if the cache is not populated or all requested entries
 	fresh bool
 }
 

--- a/internal/kubernetes/cached/memory/memcache.go
+++ b/internal/kubernetes/cached/memory/memcache.go
@@ -149,7 +149,7 @@ func (d *memCacheClient) getCachedEntry(key string) (*metav1.APIResourceList, er
 		return nil, errors.New("cache invalidated")
 	}
 
-	if !ourEntry {
+	if len(d.ourEntries) == 0 && !ourEntry {
 		return nil, errors.New("entry not found")
 	}
 

--- a/internal/kubernetes/cached/memory/memcache.go
+++ b/internal/kubernetes/cached/memory/memcache.go
@@ -40,22 +40,15 @@ type cacheEntry struct {
 
 // memCacheClient can Invalidate() to stay up-to-date with discovery
 // information.
-//
-// TODO: Switch to a watch interface. Right now it will poll after each
-// Invalidate() call.
 type memCacheClient struct {
 	delegate discovery.DiscoveryInterface
 
 	// ttl is how long the cache should be considered valid
 	ttl time.Duration
 
-	// lock                   sync.RWMutex
-	mutex sync.Mutex
-	// groupToServerResources map[string]*cacheEntry
+	mutex      sync.Mutex
 	ourEntries map[string]*cacheEntry
 	ourTTLs    map[string]time.Duration
-	// groupList              *metav1.APIGroupList
-	// cacheValid             bool
 	// invalidated is true if all cache files should be ignored that are not ours (e.g. after Invalidate() was called)
 	invalidated bool
 	// fresh is true if all used cache files were ours
@@ -142,6 +135,11 @@ func (d *memCacheClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*meta
 
 func (d *memCacheClient) ServerGroups() (*metav1.APIGroupList, error) {
 	cachedEntry, err := d.getCachedEntry("servergroups")
+	// don't fail on errors, we either don't have an entry or won't be able to run the cached check. Either way we can fallback.
+	if err == nil {
+
+	}
+
 	// d.lock.Lock()
 	// defer d.lock.Unlock()
 

--- a/internal/kubernetes/cached/memory/memcache.go
+++ b/internal/kubernetes/cached/memory/memcache.go
@@ -1,0 +1,282 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"syscall"
+
+	openapi_v2 "github.com/googleapis/gnostic/openapiv2"
+
+	errorsutil "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+	restclient "k8s.io/client-go/rest"
+)
+
+type cacheEntry struct {
+	resourceList *metav1.APIResourceList
+	err          error
+}
+
+// memCacheClient can Invalidate() to stay up-to-date with discovery
+// information.
+//
+// TODO: Switch to a watch interface. Right now it will poll after each
+// Invalidate() call.
+type memCacheClient struct {
+	delegate discovery.DiscoveryInterface
+
+	lock                   sync.RWMutex
+	groupToServerResources map[string]*cacheEntry
+	groupList              *metav1.APIGroupList
+	cacheValid             bool
+}
+
+// Error Constants
+var (
+	ErrCacheNotFound = errors.New("not found")
+)
+
+var _ discovery.CachedDiscoveryInterface = &memCacheClient{}
+
+// isTransientConnectionError checks whether given error is "Connection refused" or
+// "Connection reset" error which usually means that apiserver is temporarily
+// unavailable.
+func isTransientConnectionError(err error) bool {
+	var errno syscall.Errno
+	if errors.As(err, &errno) {
+		return errno == syscall.ECONNREFUSED || errno == syscall.ECONNRESET
+	}
+	return false
+}
+
+func isTransientError(err error) bool {
+	if isTransientConnectionError(err) {
+		return true
+	}
+
+	if t, ok := err.(errorsutil.APIStatus); ok && t.Status().Code >= 500 {
+		return true
+	}
+
+	return errorsutil.IsTooManyRequests(err)
+}
+
+// ServerResourcesForGroupVersion returns the supported resources for a group and version.
+func (d *memCacheClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	// if !d.cacheValid {
+	// 	if err := d.refreshLocked(); err != nil {
+	// 		return nil, err
+	// 	}
+	// }
+
+	cachedVal, ok := d.groupToServerResources[groupVersion]
+	if ok {
+		if cachedVal.err != nil && isTransientError(cachedVal.err) {
+			r, err := d.serverResourcesForGroupVersion(groupVersion)
+			if err != nil {
+				utilruntime.HandleError(fmt.Errorf("couldn't get resource list for %v: %v", groupVersion, err))
+			}
+
+			cachedVal = &cacheEntry{r, err}
+			d.groupToServerResources[groupVersion] = cachedVal
+		}
+
+		return cachedVal.resourceList, cachedVal.err
+	}
+
+	liveResources, err := d.delegate.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		return liveResources, err
+	}
+
+	cachedVal = &cacheEntry{liveResources, err}
+	d.groupToServerResources[groupVersion] = cachedVal
+
+	return cachedVal.resourceList, cachedVal.err
+}
+
+// ServerResources returns the supported resources for all groups and versions.
+// Deprecated: use ServerGroupsAndResources instead.
+func (d *memCacheClient) ServerResources() ([]*metav1.APIResourceList, error) {
+	return discovery.ServerResources(d)
+}
+
+// ServerGroupsAndResources returns the groups and supported resources for all groups and versions.
+func (d *memCacheClient) ServerGroupsAndResources() ([]*metav1.APIGroup, []*metav1.APIResourceList, error) {
+	return discovery.ServerGroupsAndResources(d)
+}
+
+func (d *memCacheClient) ServerGroups() (*metav1.APIGroupList, error) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	// if !d.cacheValid {
+	// 	if err := d.refreshLocked(); err != nil {
+	// 		return nil, err
+	// 	}
+	// }
+
+	if d.groupList != nil {
+		return d.groupList, nil
+	}
+
+	liveGroups, err := d.delegate.ServerGroups()
+	if err != nil {
+		return liveGroups, err
+	}
+
+	if liveGroups == nil || len(liveGroups.Groups) == 0 {
+		return liveGroups, err
+	}
+
+	d.groupList = liveGroups
+
+	// cachedVal, ok := d.groupToServerResources[groupVersion]
+	// if ok {
+	// 	if cachedVal.err != nil && isTransientError(cachedVal.err) {
+	// 		r, err := d.serverResourcesForGroupVersion(groupVersion)
+	// 		if err != nil {
+	// 			utilruntime.HandleError(fmt.Errorf("couldn't get resource list for %v: %v", groupVersion, err))
+	// 		}
+	// 		cachedVal = &cacheEntry{r, err}
+	// 		d.groupToServerResources[groupVersion] = cachedVal
+	// 	}
+	//
+	// 	return cachedVal.resourceList, cachedVal.err
+	// }
+	//
+	// r, err := d.serverResourcesForGroupVersion(groupVersion)
+	// if err != nil {
+	// 	utilruntime.HandleError(fmt.Errorf("couldn't get resource list for %v: %v", groupVersion, err))
+	// }
+	// cachedVal = &cacheEntry{r, err}
+	// d.groupToServerResources[groupVersion] = cachedVal
+	//
+	// return cachedVal.resourceList, cachedVal.err
+
+	return d.groupList, nil
+}
+
+func (d *memCacheClient) RESTClient() restclient.Interface {
+	return d.delegate.RESTClient()
+}
+
+func (d *memCacheClient) ServerPreferredResources() ([]*metav1.APIResourceList, error) {
+	return discovery.ServerPreferredResources(d)
+}
+
+func (d *memCacheClient) ServerPreferredNamespacedResources() ([]*metav1.APIResourceList, error) {
+	return discovery.ServerPreferredNamespacedResources(d)
+}
+
+func (d *memCacheClient) ServerVersion() (*version.Info, error) {
+	return d.delegate.ServerVersion()
+}
+
+func (d *memCacheClient) OpenAPISchema() (*openapi_v2.Document, error) {
+	return d.delegate.OpenAPISchema()
+}
+
+func (d *memCacheClient) Fresh() bool {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+	// Return whether the cache is populated at all. It is still possible that
+	// a single entry is missing due to transient errors and the attempt to read
+	// that entry will trigger retry.
+	return d.cacheValid
+}
+
+// Invalidate enforces that no cached data that is older than the current time
+// is used.
+func (d *memCacheClient) Invalidate() {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+	d.cacheValid = false
+	d.groupToServerResources = nil
+	d.groupList = nil
+}
+
+// refreshLocked refreshes the state of cache. The caller must hold d.lock for
+// writing.
+func (d *memCacheClient) refreshLocked() error {
+	// TODO: Could this multiplicative set of calls be replaced by a single call
+	// to ServerResources? If it's possible for more than one resulting
+	// APIResourceList to have the same GroupVersion, the lists would need merged.
+	gl, err := d.delegate.ServerGroups()
+	if err != nil || len(gl.Groups) == 0 {
+		utilruntime.HandleError(fmt.Errorf("couldn't get current server API group list: %v", err))
+		return err
+	}
+
+	wg := &sync.WaitGroup{}
+	resultLock := &sync.Mutex{}
+	rl := map[string]*cacheEntry{}
+	for _, g := range gl.Groups {
+		for _, v := range g.Versions {
+			gv := v.GroupVersion
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				defer utilruntime.HandleCrash()
+
+				r, err := d.serverResourcesForGroupVersion(gv)
+				if err != nil {
+					utilruntime.HandleError(fmt.Errorf("couldn't get resource list for %v: %v", gv, err))
+				}
+
+				resultLock.Lock()
+				defer resultLock.Unlock()
+				rl[gv] = &cacheEntry{r, err}
+			}()
+		}
+	}
+	wg.Wait()
+
+	d.groupToServerResources, d.groupList = rl, gl
+	d.cacheValid = true
+	return nil
+}
+
+func (d *memCacheClient) serverResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	r, err := d.delegate.ServerResourcesForGroupVersion(groupVersion)
+	if err != nil {
+		return r, err
+	}
+	if len(r.APIResources) == 0 {
+		return r, fmt.Errorf("Got empty response for: %v", groupVersion)
+	}
+	return r, nil
+}
+
+// NewMemCacheClient creates a new CachedDiscoveryInterface which caches
+// discovery information in memory and will stay up-to-date if Invalidate is
+// called with regularity.
+func NewMemCacheClient(delegate discovery.DiscoveryInterface) discovery.CachedDiscoveryInterface {
+	return &memCacheClient{
+		delegate:               delegate,
+		groupToServerResources: map[string]*cacheEntry{},
+	}
+}

--- a/internal/kubernetes/cached/memory/memcache_test.go
+++ b/internal/kubernetes/cached/memory/memcache_test.go
@@ -1,0 +1,389 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"errors"
+	"net/http"
+	"reflect"
+	"sync"
+	"testing"
+
+	errorsutil "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/discovery/fake"
+)
+
+type resourceMapEntry struct {
+	list *metav1.APIResourceList
+	err  error
+}
+
+type fakeDiscovery struct {
+	*fake.FakeDiscovery
+
+	lock         sync.Mutex
+	groupList    *metav1.APIGroupList
+	groupListErr error
+	resourceMap  map[string]*resourceMapEntry
+}
+
+func (c *fakeDiscovery) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if rl, ok := c.resourceMap[groupVersion]; ok {
+		return rl.list, rl.err
+	}
+	return nil, errors.New("doesn't exist")
+}
+
+func (c *fakeDiscovery) ServerGroups() (*metav1.APIGroupList, error) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	if c.groupList == nil {
+		return nil, errors.New("doesn't exist")
+	}
+	return c.groupList, c.groupListErr
+}
+
+func TestClient(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{{
+				Name: "astronomy",
+				Versions: []metav1.GroupVersionForDiscovery{{
+					GroupVersion: "astronomy/v8beta1",
+					Version:      "v8beta1",
+				}},
+			}},
+		},
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	g, err := c.ServerGroups()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if !c.Fresh() {
+		t.Errorf("Expected fresh.")
+	}
+	c.Invalidate()
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+
+	g, err = c.ServerGroups()
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.groupList, g; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	if !c.Fresh() {
+		t.Errorf("Expected fresh.")
+	}
+	r, err := c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+
+	fake.lock.Lock()
+	fake.resourceMap = map[string]*resourceMapEntry{
+		"astronomy/v8beta1": {
+			list: &metav1.APIResourceList{
+				GroupVersion: "astronomy/v8beta1",
+				APIResources: []metav1.APIResource{{
+					Name:         "stars",
+					SingularName: "star",
+					Namespaced:   true,
+					Kind:         "Star",
+					ShortNames:   []string{"s"},
+				}},
+			},
+		},
+	}
+	fake.lock.Unlock()
+
+	c.Invalidate()
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}
+
+func TestServerGroupsFails(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{{
+				Name: "astronomy",
+				Versions: []metav1.GroupVersionForDiscovery{{
+					GroupVersion: "astronomy/v8beta1",
+					Version:      "v8beta1",
+				}},
+			}},
+		},
+		groupListErr: errors.New("some error"),
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	_, err := c.ServerGroups()
+	if err == nil {
+		t.Errorf("Expected error")
+	}
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	fake.lock.Lock()
+	fake.groupListErr = nil
+	fake.lock.Unlock()
+	r, err := c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	if !c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+}
+
+func TestPartialPermanentFailure(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{
+				{
+					Name: "astronomy",
+					Versions: []metav1.GroupVersionForDiscovery{{
+						GroupVersion: "astronomy/v8beta1",
+						Version:      "v8beta1",
+					}},
+				},
+				{
+					Name: "astronomy2",
+					Versions: []metav1.GroupVersionForDiscovery{{
+						GroupVersion: "astronomy2/v8beta1",
+						Version:      "v8beta1",
+					}},
+				},
+			},
+		},
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				err: errors.New("some permanent error"),
+			},
+			"astronomy2/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy2/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	r, err := c.ServerResourcesForGroupVersion("astronomy2/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy2/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	fake.lock.Lock()
+	fake.resourceMap["astronomy/v8beta1"] = &resourceMapEntry{
+		list: &metav1.APIResourceList{
+			GroupVersion: "astronomy/v8beta1",
+			APIResources: []metav1.APIResource{{
+				Name:         "dwarfplanets",
+				SingularName: "dwarfplanet",
+				Namespaced:   true,
+				Kind:         "DwarfPlanet",
+				ShortNames:   []string{"dp"},
+			}},
+		},
+		err: nil,
+	}
+	fake.lock.Unlock()
+	// We don't retry permanent errors, so it should fail.
+	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+	c.Invalidate()
+
+	// After Invalidate, we should retry.
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}
+
+func TestPartialRetryableFailure(t *testing.T) {
+	fake := &fakeDiscovery{
+		groupList: &metav1.APIGroupList{
+			Groups: []metav1.APIGroup{
+				{
+					Name: "astronomy",
+					Versions: []metav1.GroupVersionForDiscovery{{
+						GroupVersion: "astronomy/v8beta1",
+						Version:      "v8beta1",
+					}},
+				},
+				{
+					Name: "astronomy2",
+					Versions: []metav1.GroupVersionForDiscovery{{
+						GroupVersion: "astronomy2/v8beta1",
+						Version:      "v8beta1",
+					}},
+				},
+			},
+		},
+		resourceMap: map[string]*resourceMapEntry{
+			"astronomy/v8beta1": {
+				err: &errorsutil.StatusError{
+					ErrStatus: metav1.Status{
+						Message: "Some retryable error",
+						Code:    int32(http.StatusServiceUnavailable),
+						Reason:  metav1.StatusReasonServiceUnavailable,
+					},
+				},
+			},
+			"astronomy2/v8beta1": {
+				list: &metav1.APIResourceList{
+					GroupVersion: "astronomy2/v8beta1",
+					APIResources: []metav1.APIResource{{
+						Name:         "dwarfplanets",
+						SingularName: "dwarfplanet",
+						Namespaced:   true,
+						Kind:         "DwarfPlanet",
+						ShortNames:   []string{"dp"},
+					}},
+				},
+			},
+		},
+	}
+
+	c := NewMemCacheClient(fake)
+	if c.Fresh() {
+		t.Errorf("Expected not fresh.")
+	}
+	r, err := c.ServerResourcesForGroupVersion("astronomy2/v8beta1")
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy2/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+	_, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err == nil {
+		t.Errorf("Expected error, got nil")
+	}
+
+	fake.lock.Lock()
+	fake.resourceMap["astronomy/v8beta1"] = &resourceMapEntry{
+		list: &metav1.APIResourceList{
+			GroupVersion: "astronomy/v8beta1",
+			APIResources: []metav1.APIResource{{
+				Name:         "dwarfplanets",
+				SingularName: "dwarfplanet",
+				Namespaced:   true,
+				Kind:         "DwarfPlanet",
+				ShortNames:   []string{"dp"},
+			}},
+		},
+		err: nil,
+	}
+	fake.lock.Unlock()
+	// We should retry retryable error even without Invalidate() being called,
+	// so no error is expected.
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+
+	// Check that the last result was cached and we don't retry further.
+	fake.lock.Lock()
+	fake.resourceMap["astronomy/v8beta1"].err = errors.New("some permanent error")
+	fake.lock.Unlock()
+	r, err = c.ServerResourcesForGroupVersion("astronomy/v8beta1")
+	if err != nil {
+		t.Errorf("Expected no error, got %v", err)
+	}
+	if e, a := fake.resourceMap["astronomy/v8beta1"].list, r; !reflect.DeepEqual(e, a) {
+		t.Errorf("Expected %#v, got %#v", e, a)
+	}
+}

--- a/internal/kubernetes/cached/memory/memory_suite_test.go
+++ b/internal/kubernetes/cached/memory/memory_suite_test.go
@@ -1,0 +1,13 @@
+package memory_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestMemory(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Memory Suite")
+}

--- a/internal/kubernetes/cached/memory/round_tripper.go
+++ b/internal/kubernetes/cached/memory/round_tripper.go
@@ -1,0 +1,66 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory
+
+import (
+	"net/http"
+
+	"github.com/gregjones/httpcache"
+	"k8s.io/klog/v2"
+)
+
+//go:generate counterfeiter . CacheRoundTripper
+type MemCacheRoundTripper interface {
+	RoundTrip(req *http.Request) (*http.Response, error)
+	CancelRequest(req *http.Request)
+}
+
+type memCacheRoundTripper struct {
+	rt *httpcache.Transport
+}
+
+func NewMemCacheRoundTripper(rt http.RoundTripper) http.RoundTripper {
+	return newMemCacheRoundTripper(rt)
+}
+
+// newMemCacheRoundTripper creates a roundtripper that reads the ETag on
+// response headers and send the If-None-Match header on subsequent
+// corresponding requests.
+func newMemCacheRoundTripper(rt http.RoundTripper) http.RoundTripper {
+	t := httpcache.NewTransport(httpcache.NewMemoryCache())
+	t.Transport = rt
+
+	return &memCacheRoundTripper{rt: t}
+}
+
+func (rt *memCacheRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	return rt.rt.RoundTrip(req)
+}
+
+func (rt *memCacheRoundTripper) CancelRequest(req *http.Request) {
+	type canceler interface {
+		CancelRequest(*http.Request)
+	}
+
+	if cr, ok := rt.rt.Transport.(canceler); ok {
+		cr.CancelRequest(req)
+	} else {
+		klog.Errorf("CancelRequest not implemented by %T", rt.rt.Transport)
+	}
+}
+
+func (rt *memCacheRoundTripper) WrappedRoundTripper() http.RoundTripper { return rt.rt.Transport }

--- a/internal/kubernetes/cached/memory/round_tripper_test.go
+++ b/internal/kubernetes/cached/memory/round_tripper_test.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2017 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package memory_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	. "github.com/homedepot/go-clouddriver/internal/kubernetes/cached/memory"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+// copied from k8s.io/client-go/transport/round_trippers_test.go
+type testRoundTripper struct {
+	Request  *http.Request
+	Response *http.Response
+	Err      error
+}
+
+func (rt *testRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	rt.Request = req
+	return rt.Response, rt.Err
+}
+
+var _ = Describe("CachedDiscovery", func() {
+	var (
+		rt      *testRoundTripper
+		err     error
+		cache   http.RoundTripper
+		req     *http.Request
+		resp    *http.Response
+		content []byte
+	)
+
+	BeforeEach(func() {
+		rt = &testRoundTripper{}
+		Expect(err).To(BeNil())
+	})
+
+	JustBeforeEach(func() {
+		cache = NewMemCacheRoundTripper(rt)
+	})
+
+	AfterEach(func() {
+		if resp != nil {
+			resp.Body.Close()
+		}
+	})
+
+	Describe("#RoundTrip", func() {
+		BeforeEach(func() {
+			req = &http.Request{
+				Method: http.MethodGet,
+				URL:    &url.URL{Host: "localhost"},
+			}
+		})
+
+		JustBeforeEach(func() {
+			resp, err = cache.RoundTrip(req)
+			Expect(err).To(BeNil())
+			content, err = ioutil.ReadAll(resp.Body)
+			Expect(err).To(BeNil())
+		})
+
+		When("the data is not cached", func() {
+			BeforeEach(func() {
+				rt.Response = &http.Response{
+					Header:     http.Header{"ETag": []string{`"123456"`}},
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte("Content"))),
+					StatusCode: http.StatusOK,
+				}
+			})
+
+			It("succeeds", func() {
+				Expect(string(content)).To(Equal("Content"))
+			})
+		})
+
+		When("the data is cached", func() {
+			BeforeEach(func() {
+				rt.Response = &http.Response{
+					StatusCode: http.StatusNotModified,
+					Body:       ioutil.NopCloser(bytes.NewReader([]byte("Other Content"))),
+				}
+			})
+
+			It("succeeds", func() {
+				Expect(string(content)).To(Equal("Other Content"))
+			})
+		})
+	})
+})

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -62,18 +62,7 @@ func (c *client) Apply(u *unstructured.Unstructured) (Metadata, error) {
 
 	restMapping, err := c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
-		// If we're using memory cache, try invalidating the cache and grabbing
-		// the rest mapping again.
-		if !useDiskCache {
-			c.mapper.Reset()
-
-			restMapping, err = c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
-			if err != nil {
-				return metadata, err
-			}
-		} else {
-			return metadata, err
-		}
+		return metadata, err
 	}
 
 	gvr := restMapping.Resource

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -62,7 +62,18 @@ func (c *client) Apply(u *unstructured.Unstructured) (Metadata, error) {
 
 	restMapping, err := c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
 	if err != nil {
-		return metadata, err
+		// If we're using memory cache, try invalidating the cache and grabbing
+		// the rest mapping again.
+		if !useDiskCache {
+			c.mapper.Reset()
+
+			restMapping, err = c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+			if err != nil {
+				return metadata, err
+			}
+		} else {
+			return metadata, err
+		}
 	}
 
 	gvr := restMapping.Resource

--- a/internal/kubernetes/controller.go
+++ b/internal/kubernetes/controller.go
@@ -4,9 +4,12 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/homedepot/go-clouddriver/internal/kubernetes/cached/disk"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -32,7 +35,7 @@ type controller struct{}
 // disk cache directory of /var/kube/cache. This is where the client
 // stores and references its discovery of the Kubernetes API server.
 func (c *controller) NewClient(config *rest.Config) (Client, error) {
-	return newClientWithDefaultDiskCache(config)
+	return newClientWithMemoryCache(config)
 }
 
 // NewClientset returns a new kubernetes Clientset wrapper.
@@ -53,6 +56,31 @@ const (
 	defaultTimeout = 180 * time.Second
 	ttl            = 10 * time.Minute
 )
+
+func newClientWithMemoryCache(config *rest.Config) (Client, error) {
+	// If the timeout is not set, set it to the default timeout.
+	if config.Timeout == 0 {
+		config.Timeout = defaultTimeout
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	mapper, err := mapperForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	kubeClient := &client{
+		c:      dynamicClient,
+		config: config,
+		mapper: mapper,
+	}
+
+	return kubeClient, nil
+}
 
 func newClientWithDefaultDiskCache(config *rest.Config) (Client, error) {
 	// If the timeout is not set, set it to the default timeout.
@@ -77,7 +105,6 @@ func newClientWithDefaultDiskCache(config *rest.Config) (Client, error) {
 	}
 
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(cdc)
-
 	kubeClient := &client{
 		c:      dynamicClient,
 		config: config,
@@ -85,6 +112,68 @@ func newClientWithDefaultDiskCache(config *rest.Config) (Client, error) {
 	}
 
 	return kubeClient, nil
+}
+
+var (
+	mux           sync.Mutex
+	cachedConfigs = map[string]*rest.Config{}
+	cachedMappers = map[string]*restmapper.DeferredDiscoveryRESTMapper{}
+)
+
+func mapperForConfig(inConfig *rest.Config) (*restmapper.DeferredDiscoveryRESTMapper, error) {
+	config := inConfig
+
+	if _, ok := cachedConfigs[config.Host]; ok {
+		cachedConfig := cachedConfigs[config.Host]
+		if string(cachedConfig.TLSClientConfig.CAData) != string(config.TLSClientConfig.CAData) ||
+			cachedConfig.BearerToken != config.BearerToken {
+			err := setCaches(config)
+			if err != nil {
+				return nil, err
+			}
+		}
+	} else {
+		err := setCaches(config)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return cachedMapper(config), nil
+}
+
+func setCaches(config *rest.Config) error {
+	m, err := newMapperForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	mux.Lock()
+	defer mux.Unlock()
+
+	cachedConfigs[config.Host] = config
+	cachedMappers[config.Host] = m
+
+	return nil
+}
+
+func newMapperForConfig(config *rest.Config) (*restmapper.DeferredDiscoveryRESTMapper, error) {
+	// DiscoveryClient queries API server about the resources
+	dc, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	mapper := restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(dc))
+
+	return mapper, nil
+}
+
+func cachedMapper(config *rest.Config) *restmapper.DeferredDiscoveryRESTMapper {
+	mux.Lock()
+	defer mux.Unlock()
+
+	return cachedMappers[config.Host]
 }
 
 // overlyCautiousIllegalFileCharacters matches characters that *might* not be supported.

--- a/internal/kubernetes/controller.go
+++ b/internal/kubernetes/controller.go
@@ -41,9 +41,10 @@ func UseDiskCache() {
 	useDiskCache = true
 }
 
-// NewClient returns a new dynamic Kubernetes client with a default
-// disk cache directory of /var/kube/cache. This is where the client
-// stores and references its discovery of the Kubernetes API server.
+// NewClient returns a new dynamic Kubernetes client. By default it returns
+// a client that uses in-memory cache store, unless `useDiskCache` is set
+// to true. This is where the client stores and references its discovery of
+// the Kubernetes API server.
 func (c *controller) NewClient(config *rest.Config) (Client, error) {
 	var (
 		client Client
@@ -75,7 +76,7 @@ const (
 	// Default cache directory.
 	cacheDir       = "/var/kube/cache"
 	defaultTimeout = 180 * time.Second
-	ttl            = 2 * time.Minute
+	ttl            = 10 * time.Minute
 )
 
 func newClientWithMemoryCache(config *rest.Config) (Client, error) {

--- a/internal/kubernetes/controller.go
+++ b/internal/kubernetes/controller.go
@@ -94,7 +94,6 @@ func newClientWithMemoryCache(config *rest.Config) (Client, error) {
 	}
 
 	mapper := restmapper.NewDeferredDiscoveryRESTMapper(mc)
-
 	kubeClient := &client{
 		c:      dynamicClient,
 		config: config,

--- a/internal/kubernetes/controller_test.go
+++ b/internal/kubernetes/controller_test.go
@@ -1,0 +1,158 @@
+package kubernetes
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"k8s.io/client-go/rest"
+)
+
+var _ = Describe("Controller", func() {
+	var (
+		client     Client
+		clientset  Clientset
+		config     *rest.Config
+		controller Controller
+		err        error
+	)
+
+	Describe("#NewClient", func() {
+		BeforeEach(func() {
+			config = &rest.Config{
+				Host:        "https://test-host",
+				BearerToken: "some.bearer.token",
+				TLSClientConfig: rest.TLSClientConfig{
+					CAData: []byte("test-ca-data"),
+				},
+			}
+			controller = NewController()
+		})
+
+		JustBeforeEach(func() {
+			client, err = controller.NewClient(config)
+		})
+
+		Context("memory cache", func() {
+			When("generating the dynamic client returns an error", func() {
+				BeforeEach(func() {
+					config = &rest.Config{
+						Host:        ":::badhost;",
+						BearerToken: "some.bearer.token",
+						TLSClientConfig: rest.TLSClientConfig{
+							CAData: []byte("test-ca-data"),
+						},
+					}
+				})
+
+				It("returns an error", func() {
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(Equal("parse \"https://:::badhost;\": invalid port \":badhost;\" after host"))
+				})
+			})
+
+			When("a call is made for a cached client", func() {
+				JustBeforeEach(func() {
+					client, err = controller.NewClient(config)
+				})
+
+				It("returns and cached client", func() {
+					Expect(err).To(BeNil())
+					Expect(client).ToNot(BeNil())
+					Expect(cachedConfigs).To(HaveLen(1))
+					Expect(cachedMemCacheClients).To(HaveLen(1))
+					cachedConfig := cachedConfigs[config.Host]
+					Expect(cachedConfig.Host).To(Equal("https://test-host"))
+					Expect(cachedConfig.BearerToken).To(Equal("some.bearer.token"))
+					Expect(string(cachedConfig.TLSClientConfig.CAData)).To(Equal("test-ca-data"))
+				})
+			})
+
+			When("the bearer token for a client changes", func() {
+				JustBeforeEach(func() {
+					config.BearerToken = "another.bearer.token"
+					client, err = controller.NewClient(config)
+				})
+
+				It("resets the cache and returns the new client", func() {
+					Expect(err).To(BeNil())
+					Expect(client).ToNot(BeNil())
+					Expect(cachedConfigs).To(HaveLen(1))
+					Expect(cachedMemCacheClients).To(HaveLen(1))
+					cachedConfig := cachedConfigs[config.Host]
+					Expect(cachedConfig.Host).To(Equal("https://test-host"))
+					Expect(cachedConfig.BearerToken).To(Equal("another.bearer.token"))
+					Expect(string(cachedConfig.TLSClientConfig.CAData)).To(Equal("test-ca-data"))
+				})
+			})
+
+			When("the CAData for a client changes", func() {
+				JustBeforeEach(func() {
+					config.TLSClientConfig.CAData = []byte("different-ca-data")
+					client, err = controller.NewClient(config)
+				})
+
+				It("resets the cache and returns the new client", func() {
+					Expect(err).To(BeNil())
+					Expect(client).ToNot(BeNil())
+					Expect(cachedConfigs).To(HaveLen(1))
+					Expect(cachedMemCacheClients).To(HaveLen(1))
+					cachedConfig := cachedConfigs[config.Host]
+					Expect(cachedConfig.Host).To(Equal("https://test-host"))
+					Expect(cachedConfig.BearerToken).To(Equal("some.bearer.token"))
+					Expect(string(cachedConfig.TLSClientConfig.CAData)).To(Equal("different-ca-data"))
+				})
+			})
+
+			It("returns and caches client", func() {
+				Expect(err).To(BeNil())
+				Expect(client).ToNot(BeNil())
+				Expect(cachedConfigs).To(HaveLen(1))
+				Expect(cachedMemCacheClients).To(HaveLen(1))
+				cachedConfig := cachedConfigs[config.Host]
+				Expect(cachedConfig.Host).To(Equal("https://test-host"))
+				Expect(cachedConfig.BearerToken).To(Equal("some.bearer.token"))
+				Expect(string(cachedConfig.TLSClientConfig.CAData)).To(Equal("test-ca-data"))
+			})
+		})
+	})
+
+	Describe("#NewClientset", func() {
+		BeforeEach(func() {
+			config = &rest.Config{
+				Host:        "https://test-host",
+				BearerToken: "some.bearer.token",
+				TLSClientConfig: rest.TLSClientConfig{
+					CAData: []byte("test-ca-data"),
+				},
+			}
+			controller = NewController()
+		})
+
+		JustBeforeEach(func() {
+			clientset, err = controller.NewClientset(config)
+		})
+
+		Context("memory cache", func() {
+			When("generating the clientset returns an error", func() {
+				BeforeEach(func() {
+					config = &rest.Config{
+						Host:        ":::badhost;",
+						BearerToken: "some.bearer.token",
+						TLSClientConfig: rest.TLSClientConfig{
+							CAData: []byte("test-ca-data"),
+						},
+					}
+				})
+
+				It("returns an error", func() {
+					Expect(err).ToNot(BeNil())
+					Expect(err.Error()).To(Equal("parse \"https://:::badhost;\": invalid port \":badhost;\" after host"))
+				})
+			})
+
+			It("returns the clientset", func() {
+				Expect(err).To(BeNil())
+				Expect(clientset).ToNot(BeNil())
+			})
+		})
+	})
+})

--- a/internal/kubernetes/controller_test.go
+++ b/internal/kubernetes/controller_test.go
@@ -63,13 +63,21 @@ var _ = Describe("Controller", func() {
 					Expect(cachedConfig.Host).To(Equal("https://test-host"))
 					Expect(cachedConfig.BearerToken).To(Equal("some.bearer.token"))
 					Expect(string(cachedConfig.TLSClientConfig.CAData)).To(Equal("test-ca-data"))
+					cachedClient := cachedMemCacheClients[config.Host]
+					Expect(cachedClient.Fresh()).To(BeTrue())
 				})
 			})
 
 			When("the bearer token for a client changes", func() {
 				JustBeforeEach(func() {
-					config.BearerToken = "another.bearer.token"
-					client, err = controller.NewClient(config)
+					newConfig := &rest.Config{
+						Host:        "https://test-host",
+						BearerToken: "another.bearer.token",
+						TLSClientConfig: rest.TLSClientConfig{
+							CAData: []byte("test-ca-data"),
+						},
+					}
+					client, err = controller.NewClient(newConfig)
 				})
 
 				It("resets the cache and returns the new client", func() {
@@ -81,13 +89,21 @@ var _ = Describe("Controller", func() {
 					Expect(cachedConfig.Host).To(Equal("https://test-host"))
 					Expect(cachedConfig.BearerToken).To(Equal("another.bearer.token"))
 					Expect(string(cachedConfig.TLSClientConfig.CAData)).To(Equal("test-ca-data"))
+					cachedClient := cachedMemCacheClients[config.Host]
+					Expect(cachedClient.Fresh()).To(BeTrue())
 				})
 			})
 
 			When("the CAData for a client changes", func() {
 				JustBeforeEach(func() {
-					config.TLSClientConfig.CAData = []byte("different-ca-data")
-					client, err = controller.NewClient(config)
+					newConfig := &rest.Config{
+						Host:        "https://test-host",
+						BearerToken: "some.bearer.token",
+						TLSClientConfig: rest.TLSClientConfig{
+							CAData: []byte("different-ca-data"),
+						},
+					}
+					client, err = controller.NewClient(newConfig)
 				})
 
 				It("resets the cache and returns the new client", func() {
@@ -99,6 +115,8 @@ var _ = Describe("Controller", func() {
 					Expect(cachedConfig.Host).To(Equal("https://test-host"))
 					Expect(cachedConfig.BearerToken).To(Equal("some.bearer.token"))
 					Expect(string(cachedConfig.TLSClientConfig.CAData)).To(Equal("different-ca-data"))
+					cachedClient := cachedMemCacheClients[config.Host]
+					Expect(cachedClient.Fresh()).To(BeTrue())
 				})
 			})
 
@@ -111,6 +129,8 @@ var _ = Describe("Controller", func() {
 				Expect(cachedConfig.Host).To(Equal("https://test-host"))
 				Expect(cachedConfig.BearerToken).To(Equal("some.bearer.token"))
 				Expect(string(cachedConfig.TLSClientConfig.CAData)).To(Equal("test-ca-data"))
+				cachedClient := cachedMemCacheClients[config.Host]
+				Expect(cachedClient.Fresh()).To(BeTrue())
 			})
 		})
 	})


### PR DESCRIPTION
*Note: I am currently just looking for feedback on implementation and features while this is being tested in our sandbox*.

This PR converts Go Clouddriver to use an in-memory cache store *by default* for both its Kubernetes API discovery and HTTP response caching. It is configurable by setting the environment variable `KUBERNETES_USE_DISK_CACHE` to `true`.

I rewrote the [memory/memcache.go](https://github.com/kubernetes/client-go/blob/master/discovery/cached/memory/memcache.go) to be logically similar to [disk/cached_discovery.go](https://github.com/kubernetes/client-go/blob/master/discovery/cached/disk/cached_discovery.go).

I added a roundtripper that uses `github.com/gregjones/httpcache` for its in-memory HTTP request caching. The disk caching implementation uses a directory to store these cached requests (https://github.com/kubernetes/client-go/blob/master/discovery/cached/disk/round_tripper.go).

Additionally we are now caching Kubernetes rest configs and their corresponding in-memory cache discovery clients (Cache All The Stuff!). The purpose of this is because generating these discovery clients is dependent on some config. Parts of the config can change (for example the `CAData` or `BearerToken`), so it's necessary to hold this information in memory and check if it's changed to know if we need to generate a new memory store for API discovery. Currently, we only check if the `CAData` or `BearerToken` have changed and then update the clients as needed.

I decided to put the mutex locks at the beginning of any function that makes live calls for discovery in the `memcache.go` file. This is very helpful since Go Clouddriver is often making concurrent calls to the cluster, which can result in multiple API discovery transactions taking place at once. Since we're no longer dealing with the overhead of writing and reading files this seemed logical and has the added benefit of a client only making a single API discovery transaction regardless of how many concurrent requests are made to the cluster.

Feedback or comments are welcome. Specifically:
- Should I add tests for the `internal/kubernetes/controller.go` file now that there's more logic in there?
- How do we feel about the name for the environment variable to use disk cache?
- Can we think of a better way to handle storing configs and caching clients in memory?