### PR TITLE
Fix memcache concurrency issues and list all providers before searching

### DIFF
--- a/internal/api/core/search.go
+++ b/internal/api/core/search.go
@@ -91,7 +91,6 @@ func (cc *Controller) Search(c *gin.Context) {
 	wg := &sync.WaitGroup{}
 	ac := make(chan accountName, internal.DefaultChanSize)
 
-	// Grab the kube provider for the given account.
 	providers, err := cc.AllKubernetesProvidersWithTimeout(time.Second * internal.DefaultListTimeoutSeconds)
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)

--- a/internal/api/core/search.go
+++ b/internal/api/core/search.go
@@ -174,7 +174,7 @@ func (cc *Controller) search(wg *sync.WaitGroup, provider *kubernetes.Provider,
 	// Declare a context with timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*internal.DefaultListTimeoutSeconds)
 	defer cancel()
-	// lo := metav1.ListOptions{}
+
 	// List resources with the context.
 	ul, err := provider.Client.ListResourcesByKindAndNamespaceWithContext(ctx, kind, namespace, metav1.ListOptions{})
 	if err != nil {

--- a/internal/api/core/search.go
+++ b/internal/api/core/search.go
@@ -178,7 +178,6 @@ func (cc *Controller) search(wg *sync.WaitGroup, provider *kubernetes.Provider,
 	// List resources with the context.
 	ul, err := provider.Client.ListResourcesByKindAndNamespaceWithContext(ctx, kind, namespace, metav1.ListOptions{})
 	if err != nil {
-		clouddriver.Log(fmt.Errorf("error searching for account %s: %v", provider.Name, err))
 		return
 	}
 

--- a/internal/api/core/search.go
+++ b/internal/api/core/search.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/homedepot/go-clouddriver/internal"
+	"github.com/homedepot/go-clouddriver/internal/kubernetes"
 	clouddriver "github.com/homedepot/go-clouddriver/pkg"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -90,10 +91,19 @@ func (cc *Controller) Search(c *gin.Context) {
 	wg := &sync.WaitGroup{}
 	ac := make(chan accountName, internal.DefaultChanSize)
 
-	wg.Add(len(accounts))
+	// Grab the kube provider for the given account.
+	providers, err := cc.AllKubernetesProvidersWithTimeout(time.Second * internal.DefaultListTimeoutSeconds)
+	if err != nil {
+		clouddriver.Error(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	providers = filterProviders(providers, accounts)
+
+	wg.Add(len(providers))
 	// List the requested resource across accounts concurrently.
-	for _, account := range accounts {
-		go cc.search(wg, account, kind, namespace, ac)
+	for _, provider := range providers {
+		go cc.search(wg, provider, kind, namespace, ac)
 	}
 
 	// Wait for all concurrent calls to finish.
@@ -147,14 +157,11 @@ type accountName struct {
 
 // search lists a requested resource by account and kind and namespace
 // then writes to a channel of accountName.
-func (cc *Controller) search(wg *sync.WaitGroup, account, kind, namespace string, ac chan accountName) {
+func (cc *Controller) search(wg *sync.WaitGroup, provider *kubernetes.Provider,
+	kind, namespace string, ac chan accountName) {
 	// Increment the wait group counter when we're done here.
 	defer wg.Done()
-	// Grab the kube provider for the given account.
-	provider, err := cc.KubernetesProviderWithTimeout(account, time.Second*internal.DefaultListTimeoutSeconds)
-	if err != nil {
-		return
-	}
+
 	// If namespace-scoped account and we are attempting to list kinds in a forbidden namespace,
 	// just return.
 	if provider.Namespace != nil && *provider.Namespace != namespace {
@@ -167,17 +174,37 @@ func (cc *Controller) search(wg *sync.WaitGroup, account, kind, namespace string
 	// Declare a context with timeout.
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second*internal.DefaultListTimeoutSeconds)
 	defer cancel()
+	// lo := metav1.ListOptions{}
 	// List resources with the context.
 	ul, err := provider.Client.ListResourcesByKindAndNamespaceWithContext(ctx, kind, namespace, metav1.ListOptions{})
 	if err != nil {
+		clouddriver.Log(fmt.Errorf("error searching for account %s: %v", provider.Name, err))
 		return
 	}
 
 	for _, u := range ul.Items {
 		an := accountName{
-			account: account,
+			account: provider.Name,
 			name:    u.GetName(),
 		}
 		ac <- an
 	}
+}
+
+// filterProviders returs a list of providers filtered by the allowe account names passed in.
+func filterProviders(providers []*kubernetes.Provider, allowedAccounts []string) []*kubernetes.Provider {
+	ps := []*kubernetes.Provider{}
+	m := map[string]bool{}
+
+	for _, allowedAccount := range allowedAccounts {
+		m[allowedAccount] = true
+	}
+
+	for _, provider := range providers {
+		if m[provider.Name] {
+			ps = append(ps, provider)
+		}
+	}
+
+	return ps
 }

--- a/internal/controller_test.go
+++ b/internal/controller_test.go
@@ -2,6 +2,8 @@ package internal_test
 
 import (
 	"errors"
+	"io/ioutil"
+	"log"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -28,6 +30,7 @@ var _ = Describe("Controller", func() {
 		fakeKubernetesClient     *kubernetesfakes.FakeClient
 		fakeKubernetesClientset  *kubernetesfakes.FakeClientset
 		provider                 *kubernetes.Provider
+		providers                []*kubernetes.Provider
 		err                      error
 	)
 
@@ -44,6 +47,20 @@ var _ = Describe("Controller", func() {
 			CAData:        "12341234",
 			TokenProvider: "test-token-provider",
 		}, nil)
+		fakeSQLClient.ListKubernetesProvidersReturns([]kubernetes.Provider{
+			{
+				Name:          "test-name1",
+				Host:          "test-host1",
+				CAData:        "12341234",
+				TokenProvider: "test-token-provider1",
+			},
+			{
+				Name:          "test-name2",
+				Host:          "test-host2",
+				CAData:        "56785678",
+				TokenProvider: "test-token-provider2",
+			},
+		}, nil)
 
 		fakeKubernetesController.NewClientReturns(fakeKubernetesClient, nil)
 		fakeKubernetesController.NewClientsetReturns(fakeKubernetesClientset, nil)
@@ -53,6 +70,7 @@ var _ = Describe("Controller", func() {
 			KubernetesController: fakeKubernetesController,
 			SQLClient:            fakeSQLClient,
 		}
+		log.SetOutput(ioutil.Discard)
 	})
 
 	Describe("#KubernetesProvider", func() {
@@ -146,6 +164,95 @@ var _ = Describe("Controller", func() {
 			Expect(provider.Client).ToNot(BeNil())
 			Expect(provider.Clientset).ToNot(BeNil())
 			config := fakeKubernetesController.NewClientArgsForCall(0)
+			Expect(config.Timeout).To(Equal(time.Second * 1))
+		})
+	})
+
+	Describe("#AllKubernetesProvidersWithTimeout", func() {
+		JustBeforeEach(func() {
+			providers, err = c.AllKubernetesProvidersWithTimeout(time.Second * 1)
+		})
+
+		When("listing the providers from sql returns an error", func() {
+			BeforeEach(func() {
+				fakeSQLClient.ListKubernetesProvidersReturns([]kubernetes.Provider{}, errors.New("error listing providers"))
+			})
+
+			It("returns an error", func() {
+				Expect(err).ToNot(BeNil())
+				Expect(err.Error()).To(Equal("internal: error listing kubernetes providers: error listing providers"))
+			})
+		})
+
+		When("the ca data is bad", func() {
+			BeforeEach(func() {
+				fakeSQLClient.ListKubernetesProvidersReturns([]kubernetes.Provider{
+					{
+						CAData: "{}",
+					},
+				}, nil)
+			})
+
+			It("continues and returns an empty list", func() {
+				Expect(err).To(BeNil())
+				Expect(providers).To(HaveLen(0))
+			})
+		})
+
+		When("getting the arcade token returns an error", func() {
+			BeforeEach(func() {
+				fakeArcadeClient.TokenReturns("", errors.New("error getting token"))
+			})
+
+			It("continues and returns an empty list", func() {
+				Expect(err).To(BeNil())
+				Expect(providers).To(HaveLen(0))
+			})
+		})
+
+		When("generating a new client returns an error", func() {
+			BeforeEach(func() {
+				fakeKubernetesController.NewClientReturns(nil, errors.New("error generating client"))
+			})
+
+			It("continues and returns an empty list", func() {
+				Expect(err).To(BeNil())
+				Expect(providers).To(HaveLen(0))
+			})
+		})
+
+		When("generating a new clientset returns an error", func() {
+			BeforeEach(func() {
+				fakeKubernetesController.NewClientsetReturns(nil, errors.New("error generating clientset"))
+			})
+
+			It("continues and returns an empty list", func() {
+				Expect(err).To(BeNil())
+				Expect(providers).To(HaveLen(0))
+			})
+		})
+
+		It("succeeds", func() {
+			Expect(err).To(BeNil())
+			Expect(providers).ToNot(BeNil())
+			Expect(providers).To(HaveLen(2))
+			Expect(providers[0]).ToNot(BeNil())
+			Expect(providers[1]).ToNot(BeNil())
+			Expect(providers[0].Name).To(Equal("test-name1"))
+			Expect(providers[0].Host).To(Equal("test-host1"))
+			Expect(providers[0].CAData).To(Equal("12341234"))
+			Expect(providers[0].TokenProvider).To(Equal("test-token-provider1"))
+			Expect(providers[0].Client).ToNot(BeNil())
+			Expect(providers[0].Clientset).ToNot(BeNil())
+			Expect(providers[1].Name).To(Equal("test-name2"))
+			Expect(providers[1].Host).To(Equal("test-host2"))
+			Expect(providers[1].CAData).To(Equal("56785678"))
+			Expect(providers[1].TokenProvider).To(Equal("test-token-provider2"))
+			Expect(providers[1].Client).ToNot(BeNil())
+			Expect(providers[1].Clientset).ToNot(BeNil())
+			config := fakeKubernetesController.NewClientArgsForCall(0)
+			Expect(config.Timeout).To(Equal(time.Second * 1))
+			config = fakeKubernetesController.NewClientArgsForCall(1)
 			Expect(config.Timeout).To(Equal(time.Second * 1))
 		})
 	})

--- a/internal/kubernetes/cached/memory/memcache.go
+++ b/internal/kubernetes/cached/memory/memcache.go
@@ -76,7 +76,6 @@ var _ discovery.CachedDiscoveryInterface = &memCacheClient{}
 
 // ServerResourcesForGroupVersion returns the supported resources for a group and version.
 func (d *memCacheClient) ServerResourcesForGroupVersion(groupVersion string) (*metav1.APIResourceList, error) {
-
 	cachedEntry, err := d.getCachedEntry(groupVersion)
 	if err == nil && cachedEntry != nil {
 		b, err := json.Marshal(cachedEntry)


### PR DESCRIPTION
- no longer concurrently make calls to SQL to grab accounts on the search endpoint. Instead we list all providers and filter out any the user does not have access to.
- change how we handle mutex locks on the mem cache client so we don't block concurrent listing of server groups and resources (this is bad for clusters that we timeout reaching)
- store cached configs and clients with unique keys based on their config host name and timeout - this prevents us using a config with the wrong timeout for specific operations