### PR TITLE
Ignore search types

### DIFF
--- a/internal/api/core/search.go
+++ b/internal/api/core/search.go
@@ -41,6 +41,14 @@ type PageResult struct {
 	Cluster        string `json:"cluster,omitempty"`
 }
 
+var unsupportedKinds = []string{
+	"applications",
+	"instances",
+	"loadBalancers",
+	"projects",
+	"securityGroups",
+}
+
 // Search is the generic search endpoint. It ignores the `pageSize` query parameter
 // and lists resources for a kind and namespace across all accounts the user
 // has access to concurrently.
@@ -59,19 +67,8 @@ func (cc *Controller) Search(c *gin.Context) {
 	}
 
 	results := []PageResult{}
-	// Ignore requests for 'securityGroups' as this is a bogus Kubernetes kind and always
-	// returns the following JSON:
-	// [
-	//   {
-	//     "pageNumber": 1,
-	//     "pageSize": 500,
-	//     "platform": "aws",
-	//     "query": "namespace",
-	//     "results": [],
-	//     "totalMatches": 0
-	//   }
-	// ]
-	if strings.EqualFold(kind, "securityGroups") {
+	// Ignore requests for unsupported kinds
+	if containsIgnoreCase(unsupportedKinds, kind) {
 		sr := SearchResponse{}
 		page := Page{
 			PageNumber:   1,

--- a/internal/api/core/search_test.go
+++ b/internal/api/core/search_test.go
@@ -47,15 +47,65 @@ var _ = Describe("Search", func() {
 			})
 		})
 
-		When("kind is securityGroups", func() {
-			BeforeEach(func() {
-				uri = svr.URL + "/search?pageSize=500&q=default&type=securityGroups"
+		Context("unsupported kinds", func() {
+			When("kind is applications", func() {
+				BeforeEach(func() {
+					uri = svr.URL + "/search?pageSize=500&q=default&type=applications"
+				})
+
+				It("returns the default response", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					validateResponse(payloadSearchDefault)
+					Expect(fakeKubeClient.ListResourcesByKindAndNamespaceWithContextCallCount()).To(BeZero())
+				})
 			})
 
-			It("returns the default response", func() {
-				Expect(res.StatusCode).To(Equal(http.StatusOK))
-				validateResponse(payloadSearchDefault)
-				Expect(fakeKubeClient.ListResourcesByKindAndNamespaceWithContextCallCount()).To(BeZero())
+			When("kind is instances", func() {
+				BeforeEach(func() {
+					uri = svr.URL + "/search?pageSize=500&q=default&type=instances"
+				})
+
+				It("returns the default response", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					validateResponse(payloadSearchDefault)
+					Expect(fakeKubeClient.ListResourcesByKindAndNamespaceWithContextCallCount()).To(BeZero())
+				})
+			})
+
+			When("kind is loadBalancers", func() {
+				BeforeEach(func() {
+					uri = svr.URL + "/search?pageSize=500&q=default&type=loadBalancers"
+				})
+
+				It("returns the default response", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					validateResponse(payloadSearchDefault)
+					Expect(fakeKubeClient.ListResourcesByKindAndNamespaceWithContextCallCount()).To(BeZero())
+				})
+			})
+
+			When("kind is projects", func() {
+				BeforeEach(func() {
+					uri = svr.URL + "/search?pageSize=500&q=default&type=projects"
+				})
+
+				It("returns the default response", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					validateResponse(payloadSearchDefault)
+					Expect(fakeKubeClient.ListResourcesByKindAndNamespaceWithContextCallCount()).To(BeZero())
+				})
+			})
+
+			When("kind is securityGroups", func() {
+				BeforeEach(func() {
+					uri = svr.URL + "/search?pageSize=500&q=default&type=securityGroups"
+				})
+
+				It("returns the default response", func() {
+					Expect(res.StatusCode).To(Equal(http.StatusOK))
+					validateResponse(payloadSearchDefault)
+					Expect(fakeKubeClient.ListResourcesByKindAndNamespaceWithContextCallCount()).To(BeZero())
+				})
 			})
 		})
 


### PR DESCRIPTION
Ignores searching for kinds "applications", "instances", "loadBalancers", "projects", and "securityGroups" to make the search page faster.