### PR TITLE
Always grab involved object kind field selector by correct casing

### DIFF
--- a/internal/kubernetes/clientset.go
+++ b/internal/kubernetes/clientset.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"unicode"
 
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -58,7 +59,7 @@ func (c *clientset) PodLogs(name, namespace, container string) (string, error) {
 // Events returns events for a given kind, name, and namespace.
 func (c *clientset) Events(ctx context.Context, kind, name, namespace string) ([]v1.Event, error) {
 	lo := metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("involvedObject.kind=%s,involvedObject.name=%s", kind, name),
+		FieldSelector: fmt.Sprintf("involvedObject.kind=%s,involvedObject.name=%s", uppercaseFirst(kind), name),
 	}
 
 	events, err := c.clientset.CoreV1().Events(namespace).List(ctx, lo)
@@ -67,4 +68,13 @@ func (c *clientset) Events(ctx context.Context, kind, name, namespace string) ([
 	}
 
 	return events.Items, nil
+}
+
+// uppercaseFirst uppercases the first letter of a string.
+func uppercaseFirst(str string) string {
+	for i, v := range str {
+		return string(unicode.ToUpper(v)) + str[i+1:]
+	}
+
+	return ""
 }


### PR DESCRIPTION
When using the field selector `involvedObject.kind=SomeKind` to grab events, the kind is always expected to start with a capital letter. Grabbing events from a pipeline stage were working fine as the request to grab a manifest would send something like `Deployment my-deployment`, but getting events in the clusters page was failing because `deployment` was lowercased. This fixes that problem.
![Screen Shot 2021-12-20 at 3 27 41 PM](https://user-images.githubusercontent.com/7597848/146830588-a589c3f6-49ac-4588-acb4-14321ca3d691.png)

