### PR TITLE
Implements replace strategy

### DIFF
--- a/internal/api/core/kubernetes/runjob.go
+++ b/internal/api/core/kubernetes/runjob.go
@@ -56,7 +56,13 @@ func (cc *Controller) RunJob(c *gin.Context, rj RunJobRequest) {
 
 	kubernetes.BindArtifacts(&u, append(rj.RequiredArtifacts, rj.OptionalArtifacts...))
 
-	meta, err := provider.Client.Apply(&u)
+	meta := kubernetes.Metadata{}
+	if kubernetes.Replace(u) {
+		meta, err = provider.Client.Replace(&u)
+	} else {
+		meta, err = provider.Client.Apply(&u)
+	}
+
 	if err != nil {
 		clouddriver.Error(c, http.StatusInternalServerError, err)
 		return

--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -174,8 +174,8 @@ func (c *client) Replace(u *unstructured.Unstructured) (Metadata, error) {
 		return metadata, err
 	}
 
-	// Determine if the resource currently exists.
 	exists := true
+	// Determine if the resource currently exists.
 	if err := info.Get(); err != nil {
 		if !errors.IsNotFound(err) {
 			return metadata, err

--- a/internal/kubernetes/kubernetesfakes/fake_client.go
+++ b/internal/kubernetes/kubernetesfakes/fake_client.go
@@ -204,6 +204,19 @@ type FakeClient struct {
 		result2 *unstructured.Unstructured
 		result3 error
 	}
+	ReplaceStub        func(*unstructured.Unstructured) (kubernetes.Metadata, error)
+	replaceMutex       sync.RWMutex
+	replaceArgsForCall []struct {
+		arg1 *unstructured.Unstructured
+	}
+	replaceReturns struct {
+		result1 kubernetes.Metadata
+		result2 error
+	}
+	replaceReturnsOnCall map[int]struct {
+		result1 kubernetes.Metadata
+		result2 error
+	}
 	invocations      map[string][][]interface{}
 	invocationsMutex sync.RWMutex
 }
@@ -1065,6 +1078,70 @@ func (fake *FakeClient) PatchUsingStrategyReturnsOnCall(i int, result1 kubernete
 	}{result1, result2, result3}
 }
 
+func (fake *FakeClient) Replace(arg1 *unstructured.Unstructured) (kubernetes.Metadata, error) {
+	fake.replaceMutex.Lock()
+	ret, specificReturn := fake.replaceReturnsOnCall[len(fake.replaceArgsForCall)]
+	fake.replaceArgsForCall = append(fake.replaceArgsForCall, struct {
+		arg1 *unstructured.Unstructured
+	}{arg1})
+	stub := fake.ReplaceStub
+	fakeReturns := fake.replaceReturns
+	fake.recordInvocation("Replace", []interface{}{arg1})
+	fake.replaceMutex.Unlock()
+	if stub != nil {
+		return stub(arg1)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2
+	}
+	return fakeReturns.result1, fakeReturns.result2
+}
+
+func (fake *FakeClient) ReplaceCallCount() int {
+	fake.replaceMutex.RLock()
+	defer fake.replaceMutex.RUnlock()
+	return len(fake.replaceArgsForCall)
+}
+
+func (fake *FakeClient) ReplaceCalls(stub func(*unstructured.Unstructured) (kubernetes.Metadata, error)) {
+	fake.replaceMutex.Lock()
+	defer fake.replaceMutex.Unlock()
+	fake.ReplaceStub = stub
+}
+
+func (fake *FakeClient) ReplaceArgsForCall(i int) *unstructured.Unstructured {
+	fake.replaceMutex.RLock()
+	defer fake.replaceMutex.RUnlock()
+	argsForCall := fake.replaceArgsForCall[i]
+	return argsForCall.arg1
+}
+
+func (fake *FakeClient) ReplaceReturns(result1 kubernetes.Metadata, result2 error) {
+	fake.replaceMutex.Lock()
+	defer fake.replaceMutex.Unlock()
+	fake.ReplaceStub = nil
+	fake.replaceReturns = struct {
+		result1 kubernetes.Metadata
+		result2 error
+	}{result1, result2}
+}
+
+func (fake *FakeClient) ReplaceReturnsOnCall(i int, result1 kubernetes.Metadata, result2 error) {
+	fake.replaceMutex.Lock()
+	defer fake.replaceMutex.Unlock()
+	fake.ReplaceStub = nil
+	if fake.replaceReturnsOnCall == nil {
+		fake.replaceReturnsOnCall = make(map[int]struct {
+			result1 kubernetes.Metadata
+			result2 error
+		})
+	}
+	fake.replaceReturnsOnCall[i] = struct {
+		result1 kubernetes.Metadata
+		result2 error
+	}{result1, result2}
+}
+
 func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	fake.invocationsMutex.RLock()
 	defer fake.invocationsMutex.RUnlock()
@@ -1094,6 +1171,8 @@ func (fake *FakeClient) Invocations() map[string][][]interface{} {
 	defer fake.patchMutex.RUnlock()
 	fake.patchUsingStrategyMutex.RLock()
 	defer fake.patchUsingStrategyMutex.RUnlock()
+	fake.replaceMutex.RLock()
+	defer fake.replaceMutex.RUnlock()
 	copiedInvocations := map[string][][]interface{}{}
 	for key, value := range fake.invocations {
 		copiedInvocations[key] = value


### PR DESCRIPTION
Implements the [replace strategy](https://spinnaker.io/docs/reference/providers/kubernetes-v2/#strategy)
> As of Spinnaker 1.14, you can force Spinnaker to use replace instead of of apply while deploying a Kubernetes resource. This may be useful for resources such as ConfigMap which may exceed the annotation size limit of 262144 characters.
>
> When set to 'true' for a versioned resource, this will update your resources using replace.


This only implements replace in `deploy.go`, there are other places that apply is being called - should they be changed as well?
- restart.go
- rollback.go
- runjob.go
- scale.go
