### PR TITLE
Add ability to list providers for given accounts

### DIFF
--- a/internal/api/core/applications_test.go
+++ b/internal/api/core/applications_test.go
@@ -242,13 +242,17 @@ var _ = Describe("Application", func() {
 			})
 		})
 
-		When("getting the kubernetes provider for an account errors", func() {
+		When("listing the kubernetes providers for accounts errors", func() {
 			BeforeEach(func() {
-				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, errors.New("error getting provider"))
+				fakeSQLClient.ListKubernetesProvidersReturns(nil, errors.New("error listing providers"))
 			})
 
-			It("continues", func() {
-				Expect(res.StatusCode).To(Equal(http.StatusOK))
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
+				Expect(ce.Message).To(Equal("internal: error listing kubernetes providers: error listing providers"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
 		})
 
@@ -625,11 +629,13 @@ var _ = Describe("Application", func() {
 		When("using a namespace-scoped provider", func() {
 			BeforeEach(func() {
 				namespace := "test-namespace"
-				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{
-					Name:      "test-account",
-					Host:      "http://localhost",
-					CAData:    "",
-					Namespace: &namespace,
+				fakeSQLClient.ListKubernetesProvidersReturns([]kubernetes.Provider{
+					{
+						Name:      "account1",
+						Host:      "http://localhost",
+						CAData:    "",
+						Namespace: &namespace,
+					},
 				}, nil)
 			})
 
@@ -1093,13 +1099,17 @@ var _ = Describe("Application", func() {
 			})
 		})
 
-		When("getting the kubernetes provider for an account errors", func() {
+		When("listing the kubernetes providers for accounts errors", func() {
 			BeforeEach(func() {
-				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, errors.New("error getting provider"))
+				fakeSQLClient.ListKubernetesProvidersReturns(nil, errors.New("error listing providers"))
 			})
 
-			It("continues", func() {
-				Expect(res.StatusCode).To(Equal(http.StatusOK))
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
+				Expect(ce.Message).To(Equal("internal: error listing kubernetes providers: error listing providers"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
 		})
 
@@ -1638,11 +1648,13 @@ var _ = Describe("Application", func() {
 		When("using a namespace-scoped provider", func() {
 			BeforeEach(func() {
 				namespace := "test-namespace"
-				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{
-					Name:      "test-account",
-					Host:      "http://localhost",
-					CAData:    "",
-					Namespace: &namespace,
+				fakeSQLClient.ListKubernetesProvidersReturns([]kubernetes.Provider{
+					{
+						Name:      "account1",
+						Host:      "http://localhost",
+						CAData:    "",
+						Namespace: &namespace,
+					},
 				}, nil)
 			})
 
@@ -2526,13 +2538,17 @@ var _ = Describe("Application", func() {
 			})
 		})
 
-		When("getting the kubernetes provider for an account errors", func() {
+		When("listing the kubernetes providers for accounts errors", func() {
 			BeforeEach(func() {
-				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{}, errors.New("error getting provider"))
+				fakeSQLClient.ListKubernetesProvidersReturns(nil, errors.New("error listing providers"))
 			})
 
-			It("continues", func() {
-				Expect(res.StatusCode).To(Equal(http.StatusOK))
+			It("returns an error", func() {
+				Expect(res.StatusCode).To(Equal(http.StatusInternalServerError))
+				ce := getClouddriverError()
+				Expect(ce.Error).To(HavePrefix("Internal Server Error"))
+				Expect(ce.Message).To(Equal("internal: error listing kubernetes providers: error listing providers"))
+				Expect(ce.Status).To(Equal(http.StatusInternalServerError))
 			})
 		})
 
@@ -3190,11 +3206,13 @@ var _ = Describe("Application", func() {
 		When("using a namespace-scoped provider", func() {
 			BeforeEach(func() {
 				namespace := "test-namespace"
-				fakeSQLClient.GetKubernetesProviderReturns(kubernetes.Provider{
-					Name:      "test-account",
-					Host:      "http://localhost",
-					CAData:    "",
-					Namespace: &namespace,
+				fakeSQLClient.ListKubernetesProvidersReturns([]kubernetes.Provider{
+					{
+						Name:      "account1",
+						Host:      "http://localhost",
+						CAData:    "",
+						Namespace: &namespace,
+					},
 				}, nil)
 			})
 

--- a/internal/api/core/core_test.go
+++ b/internal/api/core/core_test.go
@@ -68,6 +68,28 @@ func setup() {
 			AccountName: "test-account-name",
 		},
 	}, nil)
+	fakeSQLClient.ListKubernetesProvidersReturns([]kubernetes.Provider{
+		{
+			Name:   "account1",
+			Host:   "http://localhost",
+			CAData: "",
+		},
+		{
+			Name:   "account2",
+			Host:   "http://localhost",
+			CAData: "",
+		},
+		{
+			Name:   "account3",
+			Host:   "http://localhost",
+			CAData: "",
+		},
+		{
+			Name:   "account4",
+			Host:   "http://localhost",
+			CAData: "",
+		},
+	}, nil)
 
 	fakeKubeClient = &kubernetesfakes.FakeClient{}
 	fakeKubeClient.GetReturns(&unstructured.Unstructured{Object: map[string]interface{}{}}, nil)


### PR DESCRIPTION
For Spinnaker applications that have dozens of accounts associated with them, we're seeing slow concurrent calls to grab each Kubernetes provider needed to populate the Clusters page in Spinnaker. This is because we are making one SQL call to list all account names associated with a given application (from the `kubernetes_resources` table), then making separate SQL calls for each of these accounts in a go routine to the `kubernetes_providers` table to get the provider info. 

This PR solves this problem by:
- provides a new function `KubernetesProvidersForAccountsWithTimeout` that grabs ALL providers and generates a list for the accounts list passed in
- removing the call to `GetKubernetesProvider` in the Application's API and replacing it with a single call to `KubernetesProvidersForAccountsWithTimeout`

Essentially, this PR decreases the number of SQL calls for the Applications API from `1 + n`, where `n` is the number of associated accounts for a given application, to `2`.

