### PR TITLE
Fix unexpected task failure

### DIFF
--- a/internal/api/core/core_test.go
+++ b/internal/api/core/core_test.go
@@ -66,6 +66,9 @@ func setup() {
 	fakeSQLClient.ListKubernetesResourcesByTaskIDReturns([]kubernetes.Resource{
 		{
 			AccountName: "test-account-name",
+			Resource:    "test-kind",
+			Name:        "test-name",
+			Namespace:   "test-namespace",
 		},
 	}, nil)
 	fakeSQLClient.ListKubernetesProvidersReturns([]kubernetes.Provider{


### PR DESCRIPTION
After a Kubernetes operation (like deploy/delete/etc), Orca monitors the `/task/:id` endpoint to grab this operation's status. If we do not return a task object then Orca will hit a null pointer exception [here](https://github.com/spinnaker/orca/blob/master/orca-clouddriver/src/main/groovy/com/netflix/spinnaker/orca/clouddriver/tasks/MonitorKatoTask.groovy#L224) since a Clouddriver error does not contain a `$.status` field. This happens very rarely, but it results in a non-descriptive `Unexpected task failure` error in the UI.

This PR fixes this issue by always returning a task, regardless of the failure type. It wraps the errors in descriptive text for the task status. It makes use of the field `retryable` so Orca can know that even though a task failed for certain errors, it can retry.

Here is a list of errors that can happen and the task status that is returned:

1) failed listing resources by task ID
```
task status
--------------------
failed: true
retryable: true
```
2) task ID not found
```
task status
--------------------
failed: true
retryable: false
```
3) error getting provider associated with task ID
```
task status
--------------------
failed: true
retryable: true
```
4) error getting resource associated with task ID
```
task status
--------------------
failed: true
retryable: true
```