### PR TITLE
increase tokenprovider length

### DIFF
--- a/internal/kubernetes/provider.go
+++ b/internal/kubernetes/provider.go
@@ -25,7 +25,7 @@ type Provider struct {
 	Host          string              `json:"host"`
 	CAData        string              `json:"caData" gorm:"type:text"`
 	BearerToken   string              `json:"bearerToken,omitempty" gorm:"size:2048"`
-	TokenProvider string              `json:"tokenProvider,omitempty" gorm:"size:32;not null;default:'google'"`
+	TokenProvider string              `json:"tokenProvider,omitempty" gorm:"size:128;not null;default:'google'"`
 	Namespace     *string             `json:"namespace,omitempty" gorm:"size:253"`
 	Permissions   ProviderPermissions `json:"permissions" gorm:"-"`
 	// Providers can hold instances of clients.

--- a/internal/sql/client_test.go
+++ b/internal/sql/client_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Sql", func() {
 			"`host` varchar\\(256\\)," +
 			"`ca_data` text," +
 			"`bearer_token` varchar\\(2048\\)," +
-			"`token_provider` varchar\\(32\\) NOT NULL DEFAULT 'google'," +
+			"`token_provider` varchar\\(128\\) NOT NULL DEFAULT 'google'," +
 			"`namespace` varchar\\(253\\)," +
 			"PRIMARY KEY \\(`name`\\)" +
 			"\\)$").


### PR DESCRIPTION
32 was a bit too short for the "provider-context" trick of using "providerName.context" as the provider in g-clouddriver.

In our use case, we have a single provider (Conjur) which provides many credentials for many clusters, so the specific cluster an account is associated with needs to be provided as well.  The "trick" here was to provide a context as part of the provider name, using "conjur.context" or similar.  In our case, we would also like to have more than one provider of that type, but we will address that in Arcade later.   For now, just making the string here longer is sufficient.

I chose 128 as a "probably long enough" length, but I'd be tempted to ask why it should not be "text" -- and indeed, why any of the fields need lengths at all here.