### PR TITLE
avoid goproc for explicit namespaces

### DIFF
--- a/internal/api/core/credentials.go
+++ b/internal/api/core/credentials.go
@@ -88,6 +88,9 @@ func (cc *Controller) ListCredentials(c *gin.Context) {
 
 		if expand == "true" {
 			sca.SpinnakerKindMap = spinnakerKindMap
+			if provider.Namespace != nil && *provider.Namespace != "" {
+				sca.Namespaces = []string{*provider.Namespace}
+			}
 		}
 
 		credentials = append(credentials, sca)
@@ -101,11 +104,14 @@ func (cc *Controller) ListCredentials(c *gin.Context) {
 	if expand == "true" {
 		wg := &sync.WaitGroup{}
 		accountNamespacesCh := make(chan AccountNamespaces, len(providers))
-		wg.Add(len(providers))
 
 		// Get all namespaces of allowed accounts asynchronously.
 		for _, provider := range providers {
-			go cc.listNamespaces(provider, wg, accountNamespacesCh)
+			if provider.Namespace == nil || *provider.Namespace == "" {
+				wg.Add(1)
+
+				go cc.listNamespaces(provider, wg, accountNamespacesCh)
+			}
 		}
 
 		wg.Wait()


### PR DESCRIPTION
This is covered by existing tests.

With many providers, `/credentials?expand=true` can be a pretty expensive operation even when explicit namespaces are configured in the provider.  This change avoids using a goproc and a channel just to return a static string, and the associated repeated linear search to add the found namespaces.

In my testing, with an extreme of 10,000 providers, this reduces the time to respond from 2 seconds to around 250 ms when all have namespaces.

I suspect some amount of cache would be useful here for the k8x queries, since those are unlikely to rapidly change and likely expensive.