### PR TITLE
Fix replace for non-versioned resources

### DIFF
--- a/internal/kubernetes/client.go
+++ b/internal/kubernetes/client.go
@@ -176,7 +176,7 @@ func (c *client) Replace(u *unstructured.Unstructured) (Metadata, error) {
 
 	exists := true
 	// Determine if the resource currently exists.
-	if err := info.Get(); err != nil {
+	if _, err := helper.Get(info.Namespace, info.Name); err != nil {
 		if !errors.IsNotFound(err) {
 			return metadata, err
 		}


### PR DESCRIPTION
Fix for [Issue 157](https://github.com/homedepot/go-clouddriver/issues/157).  

Using info.Get() checks if the resource exists and if it does exist then it updates the info.Object() field to that existing resource.  This causes the existing resource to be used instead of the new object.  Using helper.Get() just returns the object if it exists or an IsNotFound error if it does not exist allowing the new object in info.Object() to be used to replace the existing object.


Initial config map to be deployed:
<img width="551" alt="Screenshot 2023-07-11 at 1 39 20 PM" src="https://github.com/homedepot/go-clouddriver/assets/76484282/0b1b2b77-9d8f-4137-961c-99ea4618f333">

Deployed config map:
<img width="708" alt="Screenshot 2023-07-11 at 1 39 45 PM" src="https://github.com/homedepot/go-clouddriver/assets/76484282/7a4e33f1-aaad-4ef3-a430-b8a854934c19">

Updated config map with replace set to true and versioned set to false:
<img width="593" alt="Screenshot 2023-07-11 at 1 40 29 PM" src="https://github.com/homedepot/go-clouddriver/assets/76484282/b97d71e6-d9de-4ea2-8755-e8dd2c4b9ee9">

New deployed config map with updates:
<img width="721" alt="Screenshot 2023-07-11 at 1 41 28 PM" src="https://github.com/homedepot/go-clouddriver/assets/76484282/6c23cad2-4fb8-476a-9bec-0c8c98106492">
