### PR TITLE
fix versioning broken when deploying to multiple clusters with same artifact

### DIFF
--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -100,7 +100,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			return
 		}
 
-		kubernetes.BindArtifacts(&manifest, artifacts)
+		kubernetes.BindArtifacts(&manifest, artifacts, dm.Account)
 
 		if kubernetes.IsVersioned(manifest) {
 			err := handleVersionedManifest(provider.Client, &manifest, application)

--- a/internal/api/core/kubernetes/patch.go
+++ b/internal/api/core/kubernetes/patch.go
@@ -65,7 +65,7 @@ func (cc *Controller) Patch(c *gin.Context, pm PatchManifestRequest) {
 		u := unstructured.Unstructured{
 			Object: m,
 		}
-		kubernetes.BindArtifacts(&u, pm.AllArtifacts)
+		kubernetes.BindArtifacts(&u, pm.AllArtifacts, pm.Account)
 
 		b, err = json.Marshal(&u.Object)
 		if err != nil {

--- a/internal/api/core/kubernetes/patch_test.go
+++ b/internal/api/core/kubernetes/patch_test.go
@@ -40,6 +40,7 @@ var _ = Describe("Patch", func() {
 					Reference: "gcr.io/test-project/test-container-image:v1.0.0",
 					Name:      "gcr.io/test-project/test-container-image",
 					Type:      artifact.TypeDockerImage,
+					Metadata:  clouddriver.ArtifactMetadata{Account: patchManifestRequest.Account},
 				},
 			}
 		})

--- a/internal/api/core/kubernetes/runjob.go
+++ b/internal/api/core/kubernetes/runjob.go
@@ -54,7 +54,7 @@ func (cc *Controller) RunJob(c *gin.Context, rj RunJobRequest) {
 		u.SetName(generateName + rand.String(randNameNumber))
 	}
 
-	kubernetes.BindArtifacts(&u, append(rj.RequiredArtifacts, rj.OptionalArtifacts...))
+	kubernetes.BindArtifacts(&u, append(rj.RequiredArtifacts, rj.OptionalArtifacts...), rj.Account)
 
 	meta := kubernetes.Metadata{}
 	if kubernetes.Replace(u) {

--- a/internal/api/core/kubernetes/runjob_test.go
+++ b/internal/api/core/kubernetes/runjob_test.go
@@ -71,6 +71,7 @@ var _ = Describe("RunJob", func() {
 					Reference: "gcr.io/test-project/test-container-image:v1.0.0",
 					Name:      "gcr.io/test-project/test-container-image",
 					Type:      artifact.TypeDockerImage,
+					Metadata:  clouddriver.ArtifactMetadata{Account: runJobRequest.Account},
 				},
 			}
 		})

--- a/internal/kubernetes/artifact.go
+++ b/internal/kubernetes/artifact.go
@@ -53,27 +53,31 @@ var (
 // apiVersion: v1
 // kind: Pod
 // metadata:
-//   name: dapi-test-pod
+//
+//	name: dapi-test-pod
+//
 // spec:
-//   containers:
-//     - name: test-container
-//       image: k8s.gcr.io/busybox
-//       volumeMounts:
-//       - name: my-volume
-//         mountPath: /etc/config
-//   volumes:
-//     - name: my-volume
-//       configMap:
-//         # Provide the name of the ConfigMap containing the files you want
-//         # to add to the container
-//         name: replace-me
-//   restartPolicy: Never
+//
+//	containers:
+//	  - name: test-container
+//	    image: k8s.gcr.io/busybox
+//	    volumeMounts:
+//	    - name: my-volume
+//	      mountPath: /etc/config
+//	volumes:
+//	  - name: my-volume
+//	    configMap:
+//	      # Provide the name of the ConfigMap containing the files you want
+//	      # to add to the container
+//	      name: replace-me
+//	restartPolicy: Never
 //
 // Now let's say we pass in the following Clouddriver Artifact:
-// {
-//   "name": "replace-me",
-//   "reference": "my-config-map-v000"
-// }
+//
+//	{
+//	  "name": "replace-me",
+//	  "reference": "my-config-map-v000"
+//	}
 //
 // This would result in the JSON path '.spec.volumes[0].configMap.name' changing from
 // 'replace-me' to 'my-config-map-v000'.
@@ -81,8 +85,11 @@ var (
 // The source code for these Replacers can be found here:
 // https://github.com/spinnaker/clouddriver/blob/4d4e01084ac5259792020e419b1af7686ab38019/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/Replacer.java#L150
 func BindArtifacts(u *unstructured.Unstructured,
-	artifacts []clouddriver.Artifact) {
+	artifacts []clouddriver.Artifact, account string) {
 	for _, a := range artifacts {
+		if !isBindable(a, account) {
+			continue
+		}
 		switch a.Type {
 		case artifact.TypeDockerImage:
 			bindArtifact(u.Object, a, iterables(jsonPathDockerImageContainers)...)
@@ -147,9 +154,11 @@ func BindArtifacts(u *unstructured.Unstructured,
 //
 // Take for example the following variadic arguments for paths passed into the function:
 // [
-//   '.spec.containers',
-//   '.env',
-//   '.field.name'
+//
+//	'.spec.containers',
+//	'.env',
+//	'.field.name'
+//
 // ]
 //
 // In this case the first two args ('.spec.containers' and '.env') are of type []interface{}.
@@ -179,6 +188,13 @@ func bindArtifact(obj map[string]interface{}, a clouddriver.Artifact, paths ...s
 	if found && a.Name == name {
 		_ = unstructured.SetNestedField(obj, a.Reference, fields(paths[0])...)
 	}
+}
+
+func isBindable(artifact clouddriver.Artifact, account string) bool {
+	if artifact.Metadata.Account == account {
+		return true
+	}
+	return false
 }
 
 // FindArtifacts lists all artifacts found in a given manifest.

--- a/internal/kubernetes/artifact.go
+++ b/internal/kubernetes/artifact.go
@@ -90,6 +90,7 @@ func BindArtifacts(u *unstructured.Unstructured,
 		if !isBindable(a, account) {
 			continue
 		}
+
 		switch a.Type {
 		case artifact.TypeDockerImage:
 			bindArtifact(u.Object, a, iterables(jsonPathDockerImageContainers)...)
@@ -191,10 +192,7 @@ func bindArtifact(obj map[string]interface{}, a clouddriver.Artifact, paths ...s
 }
 
 func isBindable(artifact clouddriver.Artifact, account string) bool {
-	if artifact.Metadata.Account == account {
-		return true
-	}
-	return false
+	return artifact.Metadata.Account == account
 }
 
 // FindArtifacts lists all artifacts found in a given manifest.

--- a/internal/kubernetes/artifact_test.go
+++ b/internal/kubernetes/artifact_test.go
@@ -16,50 +16,59 @@ var _ = Describe("Artifact", func() {
 		var (
 			resource  *unstructured.Unstructured
 			artifacts []clouddriver.Artifact
+			account   string
 		)
 
 		BeforeEach(func() {
+			account = "my-test-acct"
 			artifacts = []clouddriver.Artifact{
 				{
 					Name:      "gcr.io/test-project/test-container-image",
 					Type:      artifact.TypeDockerImage,
 					Reference: "gcr.io/test-project/test-container-image:v1.0.0",
+					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-config-map",
 					Type:      artifact.TypeKubernetesConfigMap,
 					Reference: "my-config-map-v000",
+					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-config-map2",
 					Type:      artifact.TypeKubernetesConfigMap,
 					Reference: "my-config-map2-v000",
+					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-secret",
 					Type:      artifact.TypeKubernetesSecret,
 					Reference: "my-secret-v000",
+					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-secret2",
 					Type:      artifact.TypeKubernetesSecret,
 					Reference: "my-secret2-v000",
+					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-deployment",
 					Type:      artifact.TypeKubernetesDeployment,
 					Reference: "my-deployment-v000",
+					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-replicaSet",
 					Type:      artifact.TypeKubernetesReplicaSet,
 					Reference: "my-replicaSet-v000",
+					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 			}
 		})
 
 		JustBeforeEach(func() {
-			BindArtifacts(resource, artifacts)
+			BindArtifacts(resource, artifacts, account)
 		})
 
 		When("the iterable path is not of type []interface{}", func() {


### PR DESCRIPTION
This change adds a function `isBindable` which validates that an artifact's provider account is the same as the account passed in with the deployment request. The `BindArtifacts` function uses this to exclude artifacts that don't exist in the target cluster, thus preventing the behavior detailed in [this issue](https://github.com/homedepot/go-clouddriver/issues/158) which was causing certain deployments to fail.

I also updated the unit tests to verify the expected behavior.

Tests without the bug fix: 

<img width="1310" alt="Screenshot 2023-08-15 at 1 20 15 PM" src="https://github.com/homedepot/go-clouddriver/assets/44239562/94a7ca7f-069c-4e38-92f8-d001eef7f594">

Tests with the bug fix:

<img width="902" alt="Screenshot 2023-08-15 at 1 21 05 PM" src="https://github.com/homedepot/go-clouddriver/assets/44239562/2a06c21c-1bd3-4462-a64c-92932231322c">
