### PR TITLE
fix(sql): fix gorm scan error found in smoketests

### DIFF
--- a/internal/api/v1/provider.go
+++ b/internal/api/v1/provider.go
@@ -92,6 +92,7 @@ func (cc *Controller) GetKubernetesProvider(c *gin.Context) {
 			c.JSON(http.StatusNotFound, gin.H{"error": "provider not found"})
 			return
 		}
+
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 
 		return

--- a/internal/api/v1/provider.go
+++ b/internal/api/v1/provider.go
@@ -88,13 +88,12 @@ func (cc *Controller) GetKubernetesProvider(c *gin.Context) {
 
 	p, err := cc.SQLClient.GetKubernetesProviderAndPermissions(name)
 	if err != nil {
+		if err == gorm.ErrRecordNotFound {
+			c.JSON(http.StatusNotFound, gin.H{"error": "provider not found"})
+			return
+		}
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 
-		return
-	}
-
-	if p.Name == "" {
-		c.JSON(http.StatusNotFound, gin.H{"error": "provider not found"})
 		return
 	}
 

--- a/internal/api/v1/provider_test.go
+++ b/internal/api/v1/provider_test.go
@@ -354,7 +354,7 @@ var _ = Describe("Provider", func() {
 
 		When("the record is not found", func() {
 			BeforeEach(func() {
-				fakeSQLClient.GetKubernetesProviderAndPermissionsReturns(kubernetes.Provider{}, nil)
+				fakeSQLClient.GetKubernetesProviderAndPermissionsReturns(kubernetes.Provider{}, gorm.ErrRecordNotFound)
 			})
 
 			It("returns an error", func() {

--- a/internal/sql/client_test.go
+++ b/internal/sql/client_test.go
@@ -386,7 +386,7 @@ var _ = Describe("Sql", func() {
 				sqlRows := sqlmock.NewRows([]string{"name", "host", "ca_data", "bearer_token", "token_provider", "legacy_namespace", "namespace"}).
 					AddRow("test-name", "test-host", "test-ca-data", "test-token", "google", nil, "ns1").
 					AddRow("test-name", "test-host", "test-ca-data", "test-token", "google", nil, "ns2")
-				mock.ExpectQuery("(?i)^SELECT a.host, a.ca_data, a.bearer_token, a.token_provider, a.namespace as legacy_namespace, b.namespace FROM kubernetes_providers a " +
+				mock.ExpectQuery("(?i)^SELECT a.name, a.host, a.ca_data, a.bearer_token, a.token_provider, a.namespace as legacy_namespace, b.namespace FROM kubernetes_providers a " +
 					"LEFT JOIN kubernetes_providers_namespaces b ON a.name = b.account_name " +
 					"WHERE a.name = \\?").
 					WillReturnRows(sqlRows)


### PR DESCRIPTION
- fixes gorm scan error for `sql.Client.GetKubernetesProvider` by ensuring scan arguments and queried columns are equal
- returns `gorm.ErrRecordNotFound` instead of nil error when the provider struct is empty, i.e. does not exist in DB, for `sql.Client.GetKubernetesProvider` and `sql.Client.GetKubernetesProviderAndPermissions`