### PR TITLE
chore(kubernetes): use initialized map to validate cluster-scoped kinds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 clouddriver.db
 .idea/
 .DS_Store
+coverprofile.out

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/go-playground/universal-translator v0.17.0 // indirect
 	github.com/go-playground/validator/v10 v10.2.0 // indirect
 	github.com/go-sql-driver/mysql v1.6.0 // indirect
+	github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 // indirect
 	github.com/gogo/protobuf v1.3.1 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -61,6 +62,7 @@ require (
 	github.com/google/go-cmp v0.5.6 // indirect
 	github.com/google/go-querystring v1.0.0 // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.0 // indirect
 	github.com/gorilla/handlers v1.5.1 // indirect
 	github.com/gorilla/mux v1.8.0 // indirect
@@ -93,6 +95,7 @@ require (
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211 // indirect
 	golang.org/x/text v0.3.7 // indirect
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	golang.org/x/tools v0.1.10 // indirect
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/genproto v0.0.0-20210921142501-181ce0d877f6 // indirect
 	google.golang.org/grpc v1.40.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -179,6 +179,8 @@ github.com/go-playground/validator/v10 v10.2.0/go.mod h1:uOYAAleCW8F/7oMFd6aG0GO
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0 h1:p104kn46Q8WdvHunIJ9dAyjPVtrBPhSr3KT2yUst43I=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
@@ -262,6 +264,7 @@ github.com/google/pprof v0.0.0-20210122040257-d980be63207e/go.mod h1:kpwsk12EmLe
 github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210601050228-01bbb1931b22/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/pprof v0.0.0-20210609004039-a478d1d731e9/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
+github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 h1:K6RDEckDVWvDI9JAJYCmNdQXq6neHJOYx3V6jnqNEec=
 github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1/go.mod h1:kpwsk12EmLew5upagYY7GY0pfYCcupk39gWOCRROcvE=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -715,6 +718,8 @@ golang.org/x/tools v0.1.2/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.3/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.4/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
 golang.org/x/tools v0.1.5/go.mod h1:o0xws9oXOQQZyjljx8fwUC0k7L1pTE6eaCbjGeHmOkk=
+golang.org/x/tools v0.1.10 h1:QjFRCZxdOhBJ/UNgnBZLbNV13DlbnK0quyivTnXJM20=
+golang.org/x/tools v0.1.10/go.mod h1:Uh6Zz+xoGYZom868N8YTex3t7RhtHDBrE8Gzo9bV56E=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/internal/api/core/kubernetes/cleanup_test.go
+++ b/internal/api/core/kubernetes/cleanup_test.go
@@ -2,6 +2,8 @@ package kubernetes_test
 
 import (
 	"errors"
+	"io/ioutil"
+	"log"
 	"net/http"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -15,6 +17,7 @@ import (
 
 var _ = Describe("CleanupArtifacts", func() {
 	BeforeEach(func() {
+		log.SetOutput(ioutil.Discard)
 		setup()
 	})
 

--- a/internal/kubernetes/namespace.go
+++ b/internal/kubernetes/namespace.go
@@ -55,6 +55,6 @@ func setNamespaceIfScoped(namespace string, u *unstructured.Unstructured) {
 // See https://github.com/spinnaker/clouddriver/blob/58ab154b0ec0d62772201b5b319af349498a4e3f/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKindProperties.java#L31
 // for clouddriver OSS namespace-scoped kinds.
 func isNamespaceScoped(kind string) bool {
-	_, v := clusterScopedKinds[strings.ToLower(kind)]
-	return !v
+	_, clusterScoped := clusterScopedKinds[strings.ToLower(kind)]
+	return !clusterScoped
 }

--- a/internal/kubernetes/namespace.go
+++ b/internal/kubernetes/namespace.go
@@ -55,15 +55,6 @@ func setNamespaceIfScoped(namespace string, u *unstructured.Unstructured) {
 // See https://github.com/spinnaker/clouddriver/blob/58ab154b0ec0d62772201b5b319af349498a4e3f/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/description/manifest/KubernetesKindProperties.java#L31
 // for clouddriver OSS namespace-scoped kinds.
 func isNamespaceScoped(kind string) bool {
-	namespaceScoped := true
-
-	for _, value := range clusterScopedKinds {
-		if strings.EqualFold(value, kind) {
-			namespaceScoped = false
-
-			break
-		}
-	}
-
-	return namespaceScoped
+	_, v := clusterScopedKinds[strings.ToLower(kind)]
+	return !v
 }

--- a/internal/kubernetes/provider.go
+++ b/internal/kubernetes/provider.go
@@ -8,17 +8,17 @@ import (
 )
 
 var (
-	clusterScopedKinds = []string{
-		"apiService",
-		"clusterRole",
-		"clusterRoleBinding",
-		"customResourceDefinition",
-		"mutatingWebhookConfiguration",
-		"namespace",
-		"persistentVolume",
-		"podSecurityPolicy",
-		"storageClass",
-		"validatingWebhookConfiguration",
+	clusterScopedKinds = map[string]struct{}{
+		"apiservice":                     struct{}{},
+		"clusterrole":                    struct{}{},
+		"clusterrolebinding":             struct{}{},
+		"customresourcedefinition":       struct{}{},
+		"mutatingwebhookconfiguration":   struct{}{},
+		"namespace":                      struct{}{},
+		"persistentvolume":               struct{}{},
+		"podsecuritypolicy":              struct{}{},
+		"storageclass":                   struct{}{},
+		"validatingwebhookconfiguration": struct{}{},
 	}
 )
 
@@ -78,10 +78,8 @@ func (p *Provider) ValidateKindStatus(kind string) error {
 		return nil
 	}
 
-	for _, value := range clusterScopedKinds {
-		if strings.EqualFold(value, kind) {
-			return fmt.Errorf("namespace-scoped account not allowed to access cluster-scoped kind: '%s'", kind)
-		}
+	if _, v := clusterScopedKinds[strings.ToLower(kind)]; v {
+		return fmt.Errorf("namespace-scoped account not allowed to access cluster-scoped kind: '%s'", kind)
 	}
 
 	return nil

--- a/internal/kubernetes/provider_test.go
+++ b/internal/kubernetes/provider_test.go
@@ -1,16 +1,17 @@
 package kubernetes_test
 
 import (
-	. "github.com/homedepot/go-clouddriver/internal/kubernetes"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+
+	. "github.com/homedepot/go-clouddriver/internal/kubernetes"
 )
 
 var _ = Describe("Provider", func() {
 	var (
 		provider  Provider
 		kind      string
-		namespace string = "test-namespace"
+		namespace = "test-namespace"
 	)
 
 	Context("#ValidateKindStatus", func() {
@@ -24,20 +25,35 @@ var _ = Describe("Provider", func() {
 		})
 
 		When("Provider is namespace-scoped", func() {
+			clusterScopedKinds := []string{
+				"apiService",
+				"clusterRole",
+				"clusterRoleBinding",
+				"customResourceDefinition",
+				"mutatingWebhookConfiguration",
+				"namespace",
+				"persistentVolume",
+				"podSecurityPolicy",
+				"storageClass",
+				"validatingWebhookConfiguration",
+			}
+
 			BeforeEach(func() {
 				provider.Namespaces = []string{namespace}
 			})
 
-			When("kind is not allowed", func() {
-				BeforeEach(func() {
-					kind = "Namespace"
-				})
+			for _, k := range clusterScopedKinds {
+				When("kind "+k+" is not allowed", func() {
+					BeforeEach(func() {
+						kind = k
+					})
 
-				It("errors", func() {
-					Expect(err).ToNot(BeNil())
-					Expect(err.Error()).To(Equal("namespace-scoped account not allowed to access cluster-scoped kind: 'Namespace'"))
+					It("errors", func() {
+						Expect(err).ToNot(BeNil())
+						Expect(err.Error()).To(Equal("namespace-scoped account not allowed to access cluster-scoped kind: '" + kind + "'"))
+					})
 				})
-			})
+			}
 
 			When("kind is allowed", func() {
 				It("succeeds", func() {


### PR DESCRIPTION
Use an initialized `map[string]struct{}` to validate cluster-scoped kinds to decrease complexity.