### PR TITLE
fix(kubernetes): non-string annotation values cause the annotation map in a manifest's Go representation to be empty 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,12 @@
 name: Build
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
   pull_request:
     branches: [master]
   workflow_call:
-  workflow_dispatch:
     
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: ^1.13
+          go-version: "1.18"
 
       - name: Get dependencies
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,7 @@ on:
   pull_request:
     branches: [master]
   workflow_call:
+  workflow_dispatch:
     
 jobs:
   build:

--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -2,6 +2,7 @@ package kubernetes
 
 import (
 	"fmt"
+	"log"
 	"net/http"
 	"strings"
 
@@ -73,6 +74,8 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 	for _, manifest := range manifests {
 		// Create a copy of the unstructured object since we access by reference.
 		manifest := manifest
+
+		log.Println("before processing ", manifest.GetAnnotations())
 
 		err = provider.ValidateKindStatus(manifest.GetKind())
 		if err != nil {
@@ -159,6 +162,8 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 				return
 			}
 		}
+
+		log.Println("after processing", manifest.GetAnnotations())
 
 		meta := kubernetes.Metadata{}
 		if kubernetes.Replace(manifest) {

--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -75,7 +75,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 		// Create a copy of the unstructured object since we access by reference.
 		manifest := manifest
 
-		log.Println("before processing ", manifest)
+		log.Println("before processing ", manifest, manifest.GetAnnotations())
 
 		err = provider.ValidateKindStatus(manifest.GetKind())
 		if err != nil {
@@ -114,6 +114,8 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			clouddriver.Error(c, http.StatusInternalServerError, err)
 			return
 		}
+
+		log.Println("after spinnaker annotations ", manifest, manifest.GetAnnotations())
 
 		kubernetes.BindArtifacts(&manifest, artifacts, dm.Account)
 
@@ -162,8 +164,6 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 				return
 			}
 		}
-
-		log.Println("after processing", manifest)
 
 		meta := kubernetes.Metadata{}
 		if kubernetes.Replace(manifest) {

--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -75,7 +75,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 		// Create a copy of the unstructured object since we access by reference.
 		manifest := manifest
 
-		log.Println("before processing ", manifest.GetAnnotations())
+		log.Println("before processing ", manifest)
 
 		err = provider.ValidateKindStatus(manifest.GetKind())
 		if err != nil {
@@ -163,7 +163,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			}
 		}
 
-		log.Println("after processing", manifest.GetAnnotations())
+		log.Println("after processing", manifest)
 
 		meta := kubernetes.Metadata{}
 		if kubernetes.Replace(manifest) {

--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -51,6 +51,9 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 		clouddriver.Error(c, http.StatusBadRequest, err)
 		return
 	}
+
+	log.Println("check toUnstructured ", dm.Manifests, manifests)
+
 	// Merge all list element items into the manifest list.
 	manifests, err = mergeManifests(manifests)
 	if err != nil {
@@ -74,8 +77,6 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 	for _, manifest := range manifests {
 		// Create a copy of the unstructured object since we access by reference.
 		manifest := manifest
-
-		log.Println("before processing ", manifest, manifest.GetAnnotations())
 
 		err = provider.ValidateKindStatus(manifest.GetKind())
 		if err != nil {

--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -52,7 +52,11 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 		return
 	}
 
-	log.Println("check toUnstructured ", dm.Manifests, manifests)
+	m, b, e := unstructured.NestedStringMap(manifests[0].Object, "metadata", "annotations")
+
+	log.Println("printing unstructured manifest", manifests[0])
+
+	log.Println("mocking manifest.GetAnnotations()", m, b, e)
 
 	// Merge all list element items into the manifest list.
 	manifests, err = mergeManifests(manifests)

--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -2,7 +2,6 @@ package kubernetes
 
 import (
 	"fmt"
-	"log"
 	"net/http"
 	"strings"
 
@@ -51,12 +50,6 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 		clouddriver.Error(c, http.StatusBadRequest, err)
 		return
 	}
-
-	m, b, e := unstructured.NestedStringMap(manifests[0].Object, "metadata", "annotations")
-
-	log.Println("printing unstructured manifest", manifests[0])
-
-	log.Println("mocking manifest.GetAnnotations()", m, b, e)
 
 	// Merge all list element items into the manifest list.
 	manifests, err = mergeManifests(manifests)
@@ -119,8 +112,6 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			clouddriver.Error(c, http.StatusInternalServerError, err)
 			return
 		}
-
-		log.Println("after spinnaker annotations ", manifest, manifest.GetAnnotations())
 
 		kubernetes.BindArtifacts(&manifest, artifacts, dm.Account)
 

--- a/internal/api/core/kubernetes/deploy_test.go
+++ b/internal/api/core/kubernetes/deploy_test.go
@@ -48,6 +48,31 @@ var _ = Describe("Deploy", func() {
 		})
 	})
 
+	When("the manifest contains a non-string annotation", func() {
+		BeforeEach(func() {
+			deployManifestRequest.Manifests = []map[string]interface{}{
+				{
+					"kind":       "ConfigMap",
+					"apiVersion": "v1",
+					"metadata": map[string]interface{}{
+						"annotations": map[string]interface{}{
+							kubernetes.AnnotationSpinnakerMaxVersionHistory: 10,
+							kubernetes.AnnotationSpinnakerReplaced:          true,
+						},
+						"name": "test",
+					},
+				},
+			}
+		})
+
+		It("suceeds and annotations are set properly", func() {
+			Expect(c.Writer.Status()).To(Equal(http.StatusOK))
+			u := fakeKubeClient.ReplaceArgsForCall(0)
+			Expect(u.GetAnnotations()).To(HaveKeyWithValue(kubernetes.AnnotationSpinnakerMaxVersionHistory, "10"))
+			Expect(u.GetAnnotations()).To(HaveKeyWithValue(kubernetes.AnnotationSpinnakerReplaced, "true"))
+		})
+	})
+
 	Context("the kind is a list", func() {
 		var fakeUnstructured unstructured.Unstructured
 		var manifests []map[string]interface{}

--- a/internal/kubernetes/unstructured.go
+++ b/internal/kubernetes/unstructured.go
@@ -62,6 +62,7 @@ func ToUnstructured(manifest map[string]interface{}) (unstructured.Unstructured,
 
 	// If annotations exist in manifest and are map[string]interface, attempt to convert to map[string]string
 	annotations := make(map[string]string, len(m))
+
 	for k, v := range annotationsMap {
 		if str, ok := v.(string); ok {
 			annotations[k] = str

--- a/internal/kubernetes/unstructured.go
+++ b/internal/kubernetes/unstructured.go
@@ -61,7 +61,7 @@ func ToUnstructured(manifest map[string]interface{}) (unstructured.Unstructured,
 	}
 
 	// If annotations exist in manifest and are map[string]interface, convert to map[string]string
-	annotations := make(map[string]string, len(u.Object))
+	annotations := make(map[string]string, len(annotationsMap))
 
 	for k, v := range annotationsMap {
 		annotations[k] = fmt.Sprintf("%v", v)


### PR DESCRIPTION
Kubernetes expects manifest annotations to be a map with string values. This PR resolves the bug indirectly discovered in [this issue](https://github.com/homedepot/go-clouddriver/issues/168) by forcing all non-string annotations to `string` type when converting to a kubernetes `unstructured.Unstructured` object.


Failure because annotations were getting cleared out, thus `strategy.spinnaker.io/replace` was missing:

<img width="1182" alt="Screenshot 2024-01-09 at 5 04 22 PM" src="https://github.com/homedepot/go-clouddriver/assets/44239562/cfaab50c-398a-4b6e-b657-fa07cded1aea">

Successful deployment after fix:

<img width="1172" alt="Screenshot 2024-01-09 at 5 04 53 PM" src="https://github.com/homedepot/go-clouddriver/assets/44239562/0222919c-049e-41a3-a882-b087f8d449dc">
