### PR TITLE
Revert "fix versioning broken when deploying to multiple clusters with same artifact"

### DIFF
--- a/internal/api/core/kubernetes/deploy.go
+++ b/internal/api/core/kubernetes/deploy.go
@@ -113,7 +113,7 @@ func (cc *Controller) Deploy(c *gin.Context, dm DeployManifestRequest) {
 			return
 		}
 
-		kubernetes.BindArtifacts(&manifest, artifacts, dm.Account)
+		kubernetes.BindArtifacts(&manifest, artifacts)
 
 		if kubernetes.IsVersioned(manifest) {
 			err := handleVersionedManifest(provider.Client, &manifest, application)

--- a/internal/api/core/kubernetes/patch.go
+++ b/internal/api/core/kubernetes/patch.go
@@ -72,7 +72,7 @@ func (cc *Controller) Patch(c *gin.Context, pm PatchManifestRequest) {
 		u := unstructured.Unstructured{
 			Object: m,
 		}
-		kubernetes.BindArtifacts(&u, pm.AllArtifacts, pm.Account)
+		kubernetes.BindArtifacts(&u, pm.AllArtifacts)
 
 		b, err = json.Marshal(&u.Object)
 		if err != nil {

--- a/internal/api/core/kubernetes/patch_test.go
+++ b/internal/api/core/kubernetes/patch_test.go
@@ -40,7 +40,6 @@ var _ = Describe("Patch", func() {
 					Reference: "gcr.io/test-project/test-container-image:v1.0.0",
 					Name:      "gcr.io/test-project/test-container-image",
 					Type:      artifact.TypeDockerImage,
-					Metadata:  clouddriver.ArtifactMetadata{Account: patchManifestRequest.Account},
 				},
 			}
 		})

--- a/internal/api/core/kubernetes/runjob.go
+++ b/internal/api/core/kubernetes/runjob.go
@@ -62,7 +62,7 @@ func (cc *Controller) RunJob(c *gin.Context, rj RunJobRequest) {
 		u.SetName(generateName + rand.String(randNameNumber))
 	}
 
-	kubernetes.BindArtifacts(&u, append(rj.RequiredArtifacts, rj.OptionalArtifacts...), rj.Account)
+	kubernetes.BindArtifacts(&u, append(rj.RequiredArtifacts, rj.OptionalArtifacts...))
 
 	meta := kubernetes.Metadata{}
 	if kubernetes.Replace(u) {

--- a/internal/api/core/kubernetes/runjob_test.go
+++ b/internal/api/core/kubernetes/runjob_test.go
@@ -71,7 +71,6 @@ var _ = Describe("RunJob", func() {
 					Reference: "gcr.io/test-project/test-container-image:v1.0.0",
 					Name:      "gcr.io/test-project/test-container-image",
 					Type:      artifact.TypeDockerImage,
-					Metadata:  clouddriver.ArtifactMetadata{Account: runJobRequest.Account},
 				},
 			}
 		})

--- a/internal/kubernetes/artifact.go
+++ b/internal/kubernetes/artifact.go
@@ -53,31 +53,27 @@ var (
 // apiVersion: v1
 // kind: Pod
 // metadata:
-//
-//	name: dapi-test-pod
-//
+//   name: dapi-test-pod
 // spec:
-//
-//	containers:
-//	  - name: test-container
-//	    image: k8s.gcr.io/busybox
-//	    volumeMounts:
-//	    - name: my-volume
-//	      mountPath: /etc/config
-//	volumes:
-//	  - name: my-volume
-//	    configMap:
-//	      # Provide the name of the ConfigMap containing the files you want
-//	      # to add to the container
-//	      name: replace-me
-//	restartPolicy: Never
+//   containers:
+//     - name: test-container
+//       image: k8s.gcr.io/busybox
+//       volumeMounts:
+//       - name: my-volume
+//         mountPath: /etc/config
+//   volumes:
+//     - name: my-volume
+//       configMap:
+//         # Provide the name of the ConfigMap containing the files you want
+//         # to add to the container
+//         name: replace-me
+//   restartPolicy: Never
 //
 // Now let's say we pass in the following Clouddriver Artifact:
-//
-//	{
-//	  "name": "replace-me",
-//	  "reference": "my-config-map-v000"
-//	}
+// {
+//   "name": "replace-me",
+//   "reference": "my-config-map-v000"
+// }
 //
 // This would result in the JSON path '.spec.volumes[0].configMap.name' changing from
 // 'replace-me' to 'my-config-map-v000'.
@@ -85,12 +81,8 @@ var (
 // The source code for these Replacers can be found here:
 // https://github.com/spinnaker/clouddriver/blob/4d4e01084ac5259792020e419b1af7686ab38019/clouddriver-kubernetes/src/main/java/com/netflix/spinnaker/clouddriver/kubernetes/artifact/Replacer.java#L150
 func BindArtifacts(u *unstructured.Unstructured,
-	artifacts []clouddriver.Artifact, account string) {
+	artifacts []clouddriver.Artifact) {
 	for _, a := range artifacts {
-		if !isBindable(a, account) {
-			continue
-		}
-
 		switch a.Type {
 		case artifact.TypeDockerImage:
 			bindArtifact(u.Object, a, iterables(jsonPathDockerImageContainers)...)
@@ -155,11 +147,9 @@ func BindArtifacts(u *unstructured.Unstructured,
 //
 // Take for example the following variadic arguments for paths passed into the function:
 // [
-//
-//	'.spec.containers',
-//	'.env',
-//	'.field.name'
-//
+//   '.spec.containers',
+//   '.env',
+//   '.field.name'
 // ]
 //
 // In this case the first two args ('.spec.containers' and '.env') are of type []interface{}.
@@ -189,10 +179,6 @@ func bindArtifact(obj map[string]interface{}, a clouddriver.Artifact, paths ...s
 	if found && a.Name == name {
 		_ = unstructured.SetNestedField(obj, a.Reference, fields(paths[0])...)
 	}
-}
-
-func isBindable(artifact clouddriver.Artifact, account string) bool {
-	return artifact.Metadata.Account == account
 }
 
 // FindArtifacts lists all artifacts found in a given manifest.

--- a/internal/kubernetes/artifact_test.go
+++ b/internal/kubernetes/artifact_test.go
@@ -16,117 +16,50 @@ var _ = Describe("Artifact", func() {
 		var (
 			resource  *unstructured.Unstructured
 			artifacts []clouddriver.Artifact
-			account   string
 		)
 
 		BeforeEach(func() {
-			account = "my-test-acct"
 			artifacts = []clouddriver.Artifact{
 				{
 					Name:      "gcr.io/test-project/test-container-image",
 					Type:      artifact.TypeDockerImage,
 					Reference: "gcr.io/test-project/test-container-image:v1.0.0",
-					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-config-map",
 					Type:      artifact.TypeKubernetesConfigMap,
 					Reference: "my-config-map-v000",
-					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-config-map2",
 					Type:      artifact.TypeKubernetesConfigMap,
 					Reference: "my-config-map2-v000",
-					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-secret",
 					Type:      artifact.TypeKubernetesSecret,
 					Reference: "my-secret-v000",
-					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-secret2",
 					Type:      artifact.TypeKubernetesSecret,
 					Reference: "my-secret2-v000",
-					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-deployment",
 					Type:      artifact.TypeKubernetesDeployment,
 					Reference: "my-deployment-v000",
-					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 				{
 					Name:      "my-replicaSet",
 					Type:      artifact.TypeKubernetesReplicaSet,
 					Reference: "my-replicaSet-v000",
-					Metadata:  clouddriver.ArtifactMetadata{Account: account},
 				},
 			}
 		})
 
 		JustBeforeEach(func() {
-			BindArtifacts(resource, artifacts, account)
-		})
-
-		When("an artifact that does not exist in the target cluster is present in the execution context", func() {
-			BeforeEach(func() {
-				account = "my-test-acct"
-				artifacts = []clouddriver.Artifact{
-					{
-						Name:      "my-config-map",
-						Type:      artifact.TypeKubernetesConfigMap,
-						Reference: "my-config-map-v001",
-						Metadata:  clouddriver.ArtifactMetadata{Account: "my-test-acct-2"},
-					},
-					{
-						Name:      "my-config-map",
-						Type:      artifact.TypeKubernetesConfigMap,
-						Reference: "my-config-map-v000",
-						Metadata:  clouddriver.ArtifactMetadata{Account: account},
-					},
-					{
-						Name:      "my-config-map2",
-						Type:      artifact.TypeKubernetesConfigMap,
-						Reference: "my-config-map2-v000",
-						Metadata:  clouddriver.ArtifactMetadata{Account: account},
-					},
-				}
-				resource = &unstructured.Unstructured{
-					Object: map[string]interface{}{
-						"kind":       "Deployment",
-						"apiVersion": "apps/v1",
-						"spec": map[string]interface{}{
-							"template": map[string]interface{}{
-								"spec": map[string]interface{}{
-									"volumes": []interface{}{
-										map[string]interface{}{
-											"configMap": map[string]interface{}{
-												"name": "not-my-config-map",
-											},
-										},
-										map[string]interface{}{
-											"configMap": map[string]interface{}{
-												"name": "my-config-map",
-											},
-										},
-									},
-								},
-							},
-						},
-					},
-				}
-			})
-
-			It("ignores the artifact corresponding to the wrong target cluster", func() {
-				o := NewDeployment(resource.Object)
-				volumes := o.Object().Spec.Template.Spec.Volumes
-				Expect(volumes).To(HaveLen(2))
-				Expect(volumes[0].VolumeSource.ConfigMap.Name).To(Equal("not-my-config-map"))
-				Expect(volumes[1].VolumeSource.ConfigMap.Name).To(Equal("my-config-map-v000"))
-			})
+			BindArtifacts(resource, artifacts)
 		})
 
 		When("the iterable path is not of type []interface{}", func() {


### PR DESCRIPTION
Reverts homedepot/go-clouddriver#169

This change was made under the assumption that clouddriver artifacts contain some metadata about the account provider, something like this, as described [here](https://github.com/homedepot/go-clouddriver/issues/158#issuecomment-1636216552):

```json
{
  "reference": "test-config-v001",
  "metadata": {
    "account": "cluster-a"
  },
  "name": "test-config"
}
```

After testing in sandbox because of the recent support threads with complaints of artifacts not being bound correctly, I found that this metadata is actually empty in practice. So comparing the contents of the metadata with the spinnaker account set in the Deploy stage will always return false, which is what was causing people's deployments to fail. This means we still don't have a fix for [issue 158](https://github.com/homedepot/go-clouddriver/issues/158) though.