### PR TITLE
[CN-3941]: Improve loading of custom kinds config file

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -5,7 +5,7 @@ This document contains a list of maintainers of this repo.  For information on c
 |------|--------|
 | James Guido | [@guido9j](https://github.com/guido9j) <img src="https://avatars.githubusercontent.com/guido9j" width="20"> |
 | Parag Patel | [@iteaguy](https://github.com/iteaguy) <img src="https://avatars.githubusercontent.com/iteaguy" width="20"> |
-| Abe Garcia | [@abe21412](https://github.com/abe21412) <img src="https://avatars.githubusercontent.com/abe21412" width="20"> |
+| Alice Garcia | [@alice485](https://github.com/alice485) <img src="https://avatars.githubusercontent.com/alice485" width="20"> |
 | Don Benjamin | [@theassyrian](https://github.com/theassyrian) <img src="https://avatars.githubusercontent.com/theassyrian" width="20"> |
 | Patrick Berry | [@pjberry16](https://github.com/pjberry16) <img src="https://avatars.githubusercontent.com/pjberry16" width="20"> |
 | Ryan Johnson | [@ryanjohnsontv](https://github.com/ryanjohnsontv) <img src="https://avatars.githubusercontent.com/ryanjohnsontv" width="20"> |

--- a/internal/kubernetes/custom_kind.go
+++ b/internal/kubernetes/custom_kind.go
@@ -3,7 +3,6 @@ package kubernetes
 import (
 	"encoding/json"
 	"fmt"
-	"log"
 	"os"
 	"strings"
 	"sync"
@@ -102,8 +101,6 @@ func getCustomKindConfig(kind string) CustomKindConfig {
 
 	if configFile == nil {
 		once.Do(func() {
-			log.Println("config file is nil, reading from file")
-
 			allConfigs := make(map[string]CustomKindConfig)
 			configBytes, err := os.ReadFile(customKindsConfigPath)
 
@@ -118,9 +115,6 @@ func getCustomKindConfig(kind string) CustomKindConfig {
 
 			configFile = allConfigs
 		})
-	} else {
-		log.Println("config file not nil")
-		log.Println(configFile)
 	}
 
 	config, ok := configFile[kind]

--- a/internal/kubernetes/custom_kind.go
+++ b/internal/kubernetes/custom_kind.go
@@ -103,8 +103,10 @@ func getCustomKindConfig(kind string) CustomKindConfig {
 	if configFile == nil {
 		once.Do(func() {
 			log.Println("config file is nil, reading from file")
+
 			allConfigs := make(map[string]CustomKindConfig)
 			configBytes, err := os.ReadFile(customKindsConfigPath)
+
 			if err != nil {
 				clouddriver.Log(fmt.Errorf("error reading custom kinds config file at %s: %v",
 					customKindsConfigPath, err))
@@ -113,6 +115,7 @@ func getCustomKindConfig(kind string) CustomKindConfig {
 			if err := json.Unmarshal(configBytes, &allConfigs); err != nil {
 				clouddriver.Log(fmt.Errorf("error setting up custom kinds config: %v", err))
 			}
+
 			configFile = allConfigs
 		})
 	} else {


### PR DESCRIPTION
- Adds code to load custom kinds config from file only on the first invocation of `getCustomKindConfig()`; future calls will retrieve the value from memory

The debugging logs below show that on the first call, the config data is nil and so it reads the JSON file from disk, but on subsequent calls, it skips that block and uses the in-memory non-nil config data.

<img width="565" alt="Screenshot 2025-03-17 at 3 39 12 PM" src="https://github.com/user-attachments/assets/b20acc40-2238-43c7-8afa-d57363f68430" />
